### PR TITLE
feat(m3): WASM Plugin System

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +39,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -82,6 +97,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +148,7 @@ dependencies = [
  "barbacane-router",
  "barbacane-spec-parser",
  "barbacane-validator",
+ "barbacane-wasm",
  "bytes",
  "clap",
  "http",
@@ -109,8 +157,9 @@ dependencies = [
  "hyper-util",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -125,7 +174,7 @@ dependencies = [
  "sha2",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -137,7 +186,7 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -159,7 +208,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -172,7 +221,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -184,8 +233,35 @@ dependencies = [
  "jsonschema",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "barbacane-wasm"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "barbacane-plugin-sdk",
+ "dashmap",
+ "hex",
+ "jsonschema",
+ "regex-lite",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+ "wasmtime",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -234,12 +310,21 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -254,6 +339,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -304,6 +391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,12 +422,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.115.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c1d02b72b6c411c0a2e92b25ed791ad5d071184193c08a34aa0fdcdf000b72"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.115.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720b93bd86ebbb23ebfb2db1ed44d54b2ecbdbb2d034d485bc64aa605ee787ab"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.115.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed3d2d9914d30b460eedd7fd507720203023997bef71452ce84873f9c93537c"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.115.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "888c188d32263ec9e048873ff0b68c700933600d553f4412417916828be25f8e"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.115.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddd5f4114d04ce7e073dd74e2ad16541fc61970726fcc8b2d5644a154ee4127"
+
+[[package]]
+name = "cranelift-control"
+version = "0.115.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92cc4c98d6a4256a1600d93ccd3536f3e77da9b4ca2c279de786ac22876e67d6"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.115.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760af4b5e051b5f82097a27274b917e3751736369fa73660513488248d27f23d"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.115.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf77ec0f470621655ec7539860b5c620d4f91326654ab21b075b83900f8831"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.115.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b665d0a6932c421620be184f9fc7f7adaf1b0bc2fa77bb7ac5177c49abf645b"
+
+[[package]]
+name = "cranelift-native"
+version = "0.115.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2e75d1bd43dfec10924798f15e6474f1dbf63b0024506551aa19394dbe72ab"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -344,6 +556,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +591,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +621,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -375,6 +656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +669,18 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -407,6 +706,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fancy-regex"
@@ -468,6 +773,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -554,6 +865,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+dependencies = [
+ "bitflags",
+ "debugid",
+ "fxhash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +920,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +951,25 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -616,6 +979,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -723,7 +1092,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -825,6 +1194,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,7 +1227,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -878,10 +1255,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -900,7 +1316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26a960f0c34d5423581d858ce94815cc11f0171b09939409097969ed269ede1b"
 dependencies = [
  "ahash",
- "base64",
+ "base64 0.22.1",
  "bytecount",
  "email_address",
  "fancy-regex",
@@ -925,10 +1341,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -940,6 +1374,12 @@ dependencies = [
  "libc",
  "redox_syscall 0.7.0",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -969,10 +1409,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.3",
+]
 
 [[package]]
 name = "mime"
@@ -1098,6 +1556,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1692,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,6 +1722,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa96cb91275ed31d6da3e983447320c4eb219ac180fa1679a0889ff32861e2d"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8324e531de91a3c25021a30fb7862d39cc516b61fbb801176acb5ff279ea887b"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "sptr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1756,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1255,6 +1793,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1291,6 +1840,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1863,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
 
 [[package]]
 name = "regex-syntax"
@@ -1313,7 +1882,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -1364,6 +1933,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,7 +1966,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1460,6 +2054,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +2104,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1571,6 +2184,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1581,6 +2197,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1664,6 +2286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,8 +2300,26 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1682,7 +2328,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1768,6 +2425,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,7 +2517,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1848,6 +2558,18 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2008,6 +2730,326 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc8444fe4920de80a4fe5ab564fff2ae58b6b73166b89751f8c6c93509da32e5"
+dependencies = [
+ "leb128",
+ "wasmparser 0.221.3",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7343c42a97f2926c7819ff81b64012092ae954c5d83ddd30c9fcdefd97d0b283"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.221.3",
+]
+
+[[package]]
+name = "wasmtime"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd30973c65eceb0f37dfcc430d83abd5eb24015fdfcab6912f52949287e04f0"
+dependencies = [
+ "addr2line",
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "fxprof-processed-profile",
+ "gimli",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "ittapi",
+ "libc",
+ "libm",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.36.7",
+ "once_cell",
+ "paste",
+ "postcard",
+ "psm",
+ "pulley-interpreter",
+ "rayon",
+ "rustix 0.38.44",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "sptr",
+ "target-lexicon",
+ "wasm-encoder 0.221.3",
+ "wasmparser 0.221.3",
+ "wasmtime-asm-macros",
+ "wasmtime-cache",
+ "wasmtime-component-macro",
+ "wasmtime-component-util",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit-debug",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-slab",
+ "wasmtime-versioned-export-macros",
+ "wasmtime-winch",
+ "wat",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c21dd30d1f3f93ee390ac1a7ec304ecdbfdab6390e1add41a1f52727b0992b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabd563cfbfe75c5bf514081f624ca8d18391a37520d8c794abce702474e688c"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix 0.38.44",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml",
+ "windows-sys 0.59.0",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f948a6ef3119d52c9f12936970de28ddf3f9bea04bc65571f4a92d2e5ab38f4"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9275aa01ceaaa2fa6c0ecaa5267518d80b9d6e9ae7c7ea42f4c6e073e6a69ef"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0701a44a323267aae4499672dae422b266cee3135a23b640972ec8c0e10a44a2"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools",
+ "log",
+ "object 0.36.7",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 1.0.69",
+ "wasmparser 0.221.3",
+ "wasmtime-environ",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "264c968c1b81d340355ece2be0bc31a10f567ccb6ce08512c3b7d10e26f3cbe5"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap",
+ "log",
+ "object 0.36.7",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.221.3",
+ "wasmparser 0.221.3",
+ "wasmprinter",
+ "wasmtime-component-util",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78505221fd5bd7b07b4e1fa2804edea49dc231e626ad6861adc8f531812973e6"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "rustix 0.38.44",
+ "wasmtime-asm-macros",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cec0a8e5620ae71bfcaaec78e3076be5b6ebf869f4e6191925d73242224a915"
+dependencies = [
+ "object 0.36.7",
+ "rustix 0.38.44",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bedb677ca1b549d98f95e9e1f9251b460090d99a2c196a0614228c064bf2e59"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-slab"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "564905638c132c275d365c1fa074f0b499790568f43148d29de84ccecfb5cb31"
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91092e6cf77390eeccee273846a9327f3e8f91c3c6280f60f37809f0e62d29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmtime-winch"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b111d909dc604c741bd8ac2f4af373eaa5c68c34b5717271bcb687688212cef8"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "object 0.36.7",
+ "target-lexicon",
+ "wasmparser 0.221.3",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f38f7a5eb2f06f53fe943e7fb8bf4197f7cf279f1bc52c0ce56e9d3ffd750a4"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "wit-parser",
+]
+
+[[package]]
+name = "wast"
+version = "244.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e7b9f9e23311275920e3d6b56d64137c160cf8af4f84a7283b36cfecbf4acb"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.244.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf35b87ed352f9ab6cd0732abde5a67dd6153dfd02c493e61459218b19456fa"
+dependencies = [
+ "wast",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,6 +3057,54 @@ checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "28.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6232f40a795be2ce10fc761ed3b403825126a60d12491ac556ea104a932fd18a"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser 0.221.3",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
 ]
 
 [[package]]
@@ -2057,6 +3147,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2209,10 +3308,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "wit-parser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "896112579ed56b4a538b07a3d16e562d101ff6265c46b515ce0c701eef16b2ac"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.221.3",
+]
 
 [[package]]
 name = "writeable"
@@ -2227,7 +3353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.3",
 ]
 
 [[package]]
@@ -2338,3 +3464,31 @@ name = "zmij"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,9 +190,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "barbacane-plugin-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "barbacane-plugin-sdk"
 version = "0.1.0"
 dependencies = [
+ "barbacane-plugin-macros",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/barbacane-router",
     "crates/barbacane-validator",
     "crates/barbacane-plugin-sdk",
+    "crates/barbacane-wasm",
     "crates/barbacane-test",
 ]
 resolver = "2"
@@ -37,9 +38,11 @@ clap = { version = "4", features = ["derive"] }
 
 # Error handling
 thiserror = "2"
+anyhow = "1"
 
 # Crypto
 sha2 = "0.10"
+hex = "0.4"
 
 # Archive
 flate2 = "1"
@@ -51,10 +54,25 @@ reqwest = { version = "0.12", features = ["json"] }
 # JSON Schema validation
 jsonschema = "0.26"
 
+# WASM runtime
+wasmtime = { version = "28", features = ["async", "cranelift", "pooling-allocator"] }
+
+# Plugin manifest
+toml = "0.8"
+semver = "1"
+regex-lite = "0.1"
+
+# Concurrency
+dashmap = "6"
+
+# Logging
+tracing = "0.1"
+
 # Workspace crates
 barbacane-spec-parser = { path = "crates/barbacane-spec-parser" }
 barbacane-compiler = { path = "crates/barbacane-compiler" }
 barbacane-router = { path = "crates/barbacane-router" }
 barbacane-validator = { path = "crates/barbacane-validator" }
 barbacane-plugin-sdk = { path = "crates/barbacane-plugin-sdk" }
+barbacane-wasm = { path = "crates/barbacane-wasm" }
 barbacane-test = { path = "crates/barbacane-test" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/barbacane-router",
     "crates/barbacane-validator",
     "crates/barbacane-plugin-sdk",
+    "crates/barbacane-plugin-macros",
     "crates/barbacane-wasm",
     "crates/barbacane-test",
 ]
@@ -68,11 +69,17 @@ dashmap = "6"
 # Logging
 tracing = "0.1"
 
+# Proc macros
+syn = { version = "2", features = ["full", "parsing"] }
+quote = "1"
+proc-macro2 = "1"
+
 # Workspace crates
 barbacane-spec-parser = { path = "crates/barbacane-spec-parser" }
 barbacane-compiler = { path = "crates/barbacane-compiler" }
 barbacane-router = { path = "crates/barbacane-router" }
 barbacane-validator = { path = "crates/barbacane-validator" }
 barbacane-plugin-sdk = { path = "crates/barbacane-plugin-sdk" }
+barbacane-plugin-macros = { path = "crates/barbacane-plugin-macros" }
 barbacane-wasm = { path = "crates/barbacane-wasm" }
 barbacane-test = { path = "crates/barbacane-test" }

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -49,31 +49,40 @@ The gateway enforces the spec. Requests that don't conform are rejected before r
 
 ---
 
-## M3 — WASM Plugin System
+## M3 — WASM Plugin System (In Progress)
 
 The extensibility layer. Plugins are loaded as WASM modules with sandboxed execution, host functions, and context passing.
 
 **Specs:** SPEC-003
 
-- [ ] wasmtime integration — load `.wasm` modules, AOT compile, instance pooling
-- [ ] Plugin manifest — parse `plugin.toml` (name, version, type, capabilities, wasm path)
-- [ ] Plugin config schema — load `config-schema.json`, validate spec config blocks against it (E1023)
-- [ ] WASM export contract — `init`, `on_request`, `on_response` for middlewares
-- [ ] WASM export contract — `dispatch` for dispatchers
-- [ ] Host function: `host_set_output` — plugin writes results to host buffer
-- [ ] Host function: `host_log` — structured logging from plugins
-- [ ] Host function: `host_context_get` / `host_context_set` — per-request context map
-- [ ] Host function: `host_clock_now` — monotonic clock
-- [ ] Capability enforcement — reject imports not declared in `plugin.toml`
-- [ ] Middleware chain execution — ordered `on_request` calls, reverse `on_response` calls
-- [ ] Short-circuit support — middleware returns 1, chain stops, response returned
-- [ ] Per-operation chain resolution — global chain + per-route overrides (replace, not merge)
-- [ ] Plugin instance model — separate instance per (name, config) pair
-- [ ] Memory limits — 16 MB linear memory, 100ms execution timeout, 1 MB stack
-- [ ] Error handling — traps produce 500, response-phase traps are fault-tolerant
-- [ ] `barbacane-plugin-sdk` crate — `Request`, `Response`, `Action` types, serde glue
+### Runtime Core (`barbacane-wasm` crate)
+- [x] wasmtime integration — load `.wasm` modules, AOT compile, instance pooling
+- [x] Plugin manifest — parse `plugin.toml` (name, version, type, capabilities, wasm path)
+- [x] Plugin config schema — load `config-schema.json`, validate spec config blocks against it (E1023)
+- [x] WASM export contract — `init`, `on_request`, `on_response` for middlewares
+- [x] WASM export contract — `dispatch` for dispatchers
+- [x] Plugin instance model — separate instance per (name, config) pair
+- [x] Memory limits — 16 MB linear memory, 100ms execution timeout, 1 MB stack
+- [x] Error handling — traps produce 500, response-phase traps are fault-tolerant
+
+### Host Functions
+- [x] Host function: `host_set_output` — plugin writes results to host buffer
+- [x] Host function: `host_log` — structured logging from plugins
+- [x] Host function: `host_context_get` / `host_context_set` — per-request context map
+- [x] Host function: `host_clock_now` — monotonic clock
+- [x] Capability enforcement — reject imports not declared in `plugin.toml`
+
+### Middleware Chain
+- [x] Middleware chain execution — ordered `on_request` calls, reverse `on_response` calls
+- [x] Short-circuit support — middleware returns 1, chain stops, response returned
+- [x] Per-operation chain resolution — global chain + per-route overrides (replace, not merge)
+
+### Plugin SDK
+- [x] `barbacane-plugin-sdk` crate — `Request`, `Response`, `Action` types, serde glue
 - [ ] `#[barbacane_middleware]` macro — generates init/on_request/on_response exports
 - [ ] `#[barbacane_dispatcher]` macro — generates init/dispatch exports
+
+### CLI & Bundling
 - [ ] `barbacane-control plugin register` CLI — validate and store plugin in registry
 - [ ] Plugin version resolution — `name`, `name@1.0.0`, `name@^1.0.0`
 - [ ] Compiler: plugin resolution — E1020–E1024 checks

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -49,7 +49,7 @@ The gateway enforces the spec. Requests that don't conform are rejected before r
 
 ---
 
-## M3 — WASM Plugin System (In Progress)
+## M3 — WASM Plugin System ✅
 
 The extensibility layer. Plugins are loaded as WASM modules with sandboxed execution, host functions, and context passing.
 
@@ -77,17 +77,17 @@ The extensibility layer. Plugins are loaded as WASM modules with sandboxed execu
 - [x] Short-circuit support — middleware returns 1, chain stops, response returned
 - [x] Per-operation chain resolution — global chain + per-route overrides (replace, not merge)
 
-### Plugin SDK
+### Plugin SDK (`barbacane-plugin-macros` crate)
 - [x] `barbacane-plugin-sdk` crate — `Request`, `Response`, `Action` types, serde glue
-- [ ] `#[barbacane_middleware]` macro — generates init/on_request/on_response exports
-- [ ] `#[barbacane_dispatcher]` macro — generates init/dispatch exports
+- [x] `#[barbacane_middleware]` macro — generates init/on_request/on_response exports
+- [x] `#[barbacane_dispatcher]` macro — generates init/dispatch exports
 
 ### CLI & Bundling
-- [ ] `barbacane-control plugin register` CLI — validate and store plugin in registry
-- [ ] Plugin version resolution — `name`, `name@1.0.0`, `name@^1.0.0`
-- [ ] Compiler: plugin resolution — E1020–E1024 checks
-- [ ] Artifact bundling — copy `.wasm` files into `plugins/` directory of `.bca`
-- [ ] Integration tests — middleware chain, short-circuit, context passing, plugin crash handling
+- [x] Plugin version resolution — `name`, `name@1.0.0`, `name@^1.0.0`
+- [x] Artifact bundling — copy `.wasm` files into `plugins/` directory of `.bca`
+- [ ] `barbacane-control plugin register` CLI — validate and store plugin in registry (deferred to M8)
+- [ ] Compiler: plugin resolution — E1020–E1024 checks (deferred to M8)
+- [ ] Integration tests — middleware chain with real WASM plugins (requires M4 for http-upstream)
 
 ---
 

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -30,6 +30,24 @@ pub struct Manifest {
     pub source_specs: Vec<SourceSpec>,
     pub routes_count: usize,
     pub checksums: HashMap<String, String>,
+    /// Bundled plugins (empty if no plugins bundled).
+    #[serde(default)]
+    pub plugins: Vec<BundledPlugin>,
+}
+
+/// Metadata about a bundled plugin.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BundledPlugin {
+    /// Plugin name.
+    pub name: String,
+    /// Plugin version.
+    pub version: String,
+    /// Plugin type (middleware or dispatcher).
+    pub plugin_type: String,
+    /// Path within the artifact (e.g., "plugins/rate-limit.wasm").
+    pub wasm_path: String,
+    /// SHA-256 hash of the WASM file.
+    pub sha256: String,
 }
 
 /// Metadata about a source spec included in the artifact.
@@ -153,6 +171,7 @@ pub fn compile(spec_paths: &[&Path], output: &Path) -> Result<Manifest, CompileE
         source_specs,
         routes_count: routes.operations.len(),
         checksums,
+        plugins: Vec::new(), // No plugins bundled in basic compile
     };
 
     let manifest_json = serde_json::to_string_pretty(&manifest)?;
@@ -260,10 +279,208 @@ pub fn load_specs(artifact_path: &Path) -> Result<HashMap<String, String>, Compi
     Ok(specs)
 }
 
+/// Load all bundled plugins from a .bca artifact.
+/// Returns a map of plugin name -> (version, WASM bytes).
+pub fn load_plugins(artifact_path: &Path) -> Result<HashMap<String, (String, Vec<u8>)>, CompileError> {
+    // First load manifest to get plugin metadata
+    let manifest = load_manifest(artifact_path)?;
+
+    let file = File::open(artifact_path)?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+
+    let mut plugins = HashMap::new();
+
+    // Build a map of wasm_path -> (name, version) from manifest
+    let plugin_info: HashMap<String, (String, String)> = manifest
+        .plugins
+        .iter()
+        .map(|p| (p.wasm_path.clone(), (p.name.clone(), p.version.clone())))
+        .collect();
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path_str = entry.path()?.to_string_lossy().into_owned();
+
+        if let Some((name, version)) = plugin_info.get(&path_str) {
+            let mut wasm_bytes = Vec::new();
+            entry.read_to_end(&mut wasm_bytes)?;
+            plugins.insert(name.clone(), (version.clone(), wasm_bytes));
+        }
+    }
+
+    Ok(plugins)
+}
+
+/// A plugin to be bundled into an artifact.
+pub struct PluginBundle {
+    /// Plugin name.
+    pub name: String,
+    /// Plugin version.
+    pub version: String,
+    /// Plugin type ("middleware" or "dispatcher").
+    pub plugin_type: String,
+    /// WASM binary content.
+    pub wasm_bytes: Vec<u8>,
+}
+
+/// Compile specs with bundled plugins into a .bca artifact.
+pub fn compile_with_plugins(
+    spec_paths: &[&Path],
+    plugins: &[PluginBundle],
+    output: &Path,
+) -> Result<Manifest, CompileError> {
+    // Parse all specs
+    let mut specs: Vec<(ApiSpec, String, String)> = Vec::new();
+
+    for path in spec_paths {
+        let content = std::fs::read_to_string(path)?;
+        let sha256 = compute_sha256(&content);
+        let spec = parse_spec_file(path)?;
+        specs.push((spec, content, sha256));
+    }
+
+    // Validate and collect operations
+    let mut operations: Vec<CompiledOperation> = Vec::new();
+    let mut seen_routes: HashMap<(String, String), String> = HashMap::new();
+
+    for (spec, _, _) in &specs {
+        let spec_file = spec.filename.as_deref().unwrap_or("unknown");
+
+        for op in &spec.operations {
+            let key = (op.path.clone(), op.method.clone());
+            if let Some(other_spec) = seen_routes.get(&key) {
+                return Err(CompileError::RoutingConflict(format!(
+                    "{} {} declared in both '{}' and '{}'",
+                    op.method, op.path, other_spec, spec_file
+                )));
+            }
+            seen_routes.insert(key, spec_file.to_string());
+
+            let dispatch = op.dispatch.clone().ok_or_else(|| {
+                CompileError::MissingDispatch(format!(
+                    "{} {} in '{}'",
+                    op.method, op.path, spec_file
+                ))
+            })?;
+
+            let middlewares = op
+                .middlewares
+                .clone()
+                .unwrap_or_else(|| spec.global_middlewares.clone());
+
+            operations.push(CompiledOperation {
+                index: operations.len(),
+                path: op.path.clone(),
+                method: op.method.clone(),
+                operation_id: op.operation_id.clone(),
+                parameters: op.parameters.clone(),
+                request_body: op.request_body.clone(),
+                dispatch,
+                middlewares,
+            });
+        }
+    }
+
+    // Build routes.json
+    let routes = CompiledRoutes { operations };
+    let routes_json = serde_json::to_string_pretty(&routes)?;
+    let routes_sha256 = compute_sha256(&routes_json);
+
+    // Build plugin metadata
+    let mut bundled_plugins = Vec::new();
+    let mut checksums = HashMap::new();
+    checksums.insert("routes.json".to_string(), format!("sha256:{}", routes_sha256));
+
+    for plugin in plugins {
+        let wasm_path = format!("plugins/{}.wasm", plugin.name);
+        let sha256 = compute_sha256_bytes(&plugin.wasm_bytes);
+
+        checksums.insert(wasm_path.clone(), format!("sha256:{}", sha256));
+
+        bundled_plugins.push(BundledPlugin {
+            name: plugin.name.clone(),
+            version: plugin.version.clone(),
+            plugin_type: plugin.plugin_type.clone(),
+            wasm_path,
+            sha256,
+        });
+    }
+
+    // Build manifest
+    let source_specs: Vec<SourceSpec> = specs
+        .iter()
+        .map(|(spec, _, sha256)| SourceSpec {
+            file: spec.filename.clone().unwrap_or_else(|| "unknown".to_string()),
+            sha256: sha256.clone(),
+            spec_type: match spec.format {
+                SpecFormat::OpenApi => "openapi".to_string(),
+                SpecFormat::AsyncApi => "asyncapi".to_string(),
+            },
+            version: spec.version.clone(),
+        })
+        .collect();
+
+    let manifest = Manifest {
+        barbacane_artifact_version: ARTIFACT_VERSION,
+        compiled_at: chrono_lite_now(),
+        compiler_version: COMPILER_VERSION.to_string(),
+        source_specs,
+        routes_count: routes.operations.len(),
+        checksums,
+        plugins: bundled_plugins,
+    };
+
+    let manifest_json = serde_json::to_string_pretty(&manifest)?;
+
+    // Create the .bca archive
+    let file = File::create(output)?;
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut archive = Builder::new(encoder);
+
+    // Add manifest.json
+    add_file_to_tar(&mut archive, "manifest.json", manifest_json.as_bytes())?;
+
+    // Add routes.json
+    add_file_to_tar(&mut archive, "routes.json", routes_json.as_bytes())?;
+
+    // Add source specs
+    for (spec, content, _) in &specs {
+        let filename = spec
+            .filename
+            .as_deref()
+            .and_then(|p| Path::new(p).file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("spec.yaml");
+        let archive_path = format!("specs/{}", filename);
+        add_file_to_tar(&mut archive, &archive_path, content.as_bytes())?;
+    }
+
+    // Add plugins
+    for plugin in plugins {
+        let wasm_path = format!("plugins/{}.wasm", plugin.name);
+        add_file_to_tar(&mut archive, &wasm_path, &plugin.wasm_bytes)?;
+    }
+
+    // Finish the archive
+    let encoder = archive.into_inner()?;
+    encoder.finish()?;
+
+    Ok(manifest)
+}
+
 /// Compute SHA-256 hash of a string.
 fn compute_sha256(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
+    let result = hasher.finalize();
+    hex::encode(result)
+}
+
+/// Compute SHA-256 hash of bytes.
+fn compute_sha256_bytes(content: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content);
     let result = hasher.finalize();
     hex::encode(result)
 }
@@ -508,5 +725,52 @@ paths:
 
         let routes = load_routes(&output_path).unwrap();
         assert_eq!(routes.operations.len(), 2);
+    }
+
+    #[test]
+    fn compile_with_bundled_plugins() {
+        let temp = TempDir::new().unwrap();
+
+        let spec_content = r#"
+openapi: "3.1.0"
+info:
+  title: Test API
+  version: "1.0.0"
+paths:
+  /health:
+    get:
+      x-barbacane-dispatch:
+        name: mock
+"#;
+        let spec_path = create_test_spec(temp.path(), "test.yaml", spec_content);
+        let output_path = temp.path().join("artifact.bca");
+
+        // Create a fake plugin (minimal valid WASM)
+        let fake_wasm = vec![
+            0x00, 0x61, 0x73, 0x6d, // magic
+            0x01, 0x00, 0x00, 0x00, // version
+        ];
+
+        let plugins = vec![PluginBundle {
+            name: "test-plugin".to_string(),
+            version: "1.0.0".to_string(),
+            plugin_type: "middleware".to_string(),
+            wasm_bytes: fake_wasm.clone(),
+        }];
+
+        let manifest = compile_with_plugins(&[spec_path.as_path()], &plugins, &output_path).unwrap();
+
+        assert_eq!(manifest.plugins.len(), 1);
+        assert_eq!(manifest.plugins[0].name, "test-plugin");
+        assert_eq!(manifest.plugins[0].version, "1.0.0");
+        assert_eq!(manifest.plugins[0].plugin_type, "middleware");
+        assert_eq!(manifest.plugins[0].wasm_path, "plugins/test-plugin.wasm");
+
+        // Load plugins back
+        let loaded = load_plugins(&output_path).unwrap();
+        assert_eq!(loaded.len(), 1);
+        let (version, wasm_bytes) = loaded.get("test-plugin").unwrap();
+        assert_eq!(version, "1.0.0");
+        assert_eq!(wasm_bytes, &fake_wasm);
     }
 }

--- a/crates/barbacane-compiler/src/lib.rs
+++ b/crates/barbacane-compiler/src/lib.rs
@@ -7,8 +7,9 @@ pub mod artifact;
 pub mod error;
 
 pub use artifact::{
-    compile, load_manifest, load_routes, load_specs, CompiledOperation, CompiledRoutes, Manifest,
-    SourceSpec, ARTIFACT_VERSION, COMPILER_VERSION,
+    compile, compile_with_plugins, load_manifest, load_plugins, load_routes, load_specs,
+    BundledPlugin, CompiledOperation, CompiledRoutes, Manifest, PluginBundle, SourceSpec,
+    ARTIFACT_VERSION, COMPILER_VERSION,
 };
 pub use error::CompileError;
 // Re-export validation types from spec-parser

--- a/crates/barbacane-compiler/src/lib.rs
+++ b/crates/barbacane-compiler/src/lib.rs
@@ -12,4 +12,4 @@ pub use artifact::{
 };
 pub use error::CompileError;
 // Re-export validation types from spec-parser
-pub use barbacane_spec_parser::{ContentSchema, Parameter, RequestBody};
+pub use barbacane_spec_parser::{ContentSchema, MiddlewareConfig, Parameter, RequestBody};

--- a/crates/barbacane-plugin-macros/Cargo.toml
+++ b/crates/barbacane-plugin-macros/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "barbacane-plugin-macros"
+description = "Proc macros for building Barbacane WASM plugins"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full", "parsing"] }
+quote = "1"
+proc-macro2 = "1"

--- a/crates/barbacane-plugin-macros/src/lib.rs
+++ b/crates/barbacane-plugin-macros/src/lib.rs
@@ -1,0 +1,256 @@
+//! Proc macros for building Barbacane WASM plugins.
+//!
+//! This crate provides the `#[barbacane_middleware]` and `#[barbacane_dispatcher]`
+//! attribute macros that generate the necessary WASM exports for plugin entry points.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use barbacane_plugin_sdk::prelude::*;
+//!
+//! #[barbacane_middleware]
+//! struct RateLimiter {
+//!     quota: u32,
+//!     window: u32,
+//! }
+//!
+//! impl RateLimiter {
+//!     fn on_request(&mut self, req: Request) -> Action<Request> {
+//!         // Rate limiting logic
+//!         Action::Continue(req)
+//!     }
+//!
+//!     fn on_response(&mut self, resp: Response) -> Response {
+//!         resp
+//!     }
+//! }
+//! ```
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemStruct};
+
+/// Generates WASM exports for a middleware plugin.
+///
+/// The annotated struct must implement:
+/// - `fn on_request(&mut self, req: Request) -> Action<Request>`
+/// - `fn on_response(&mut self, resp: Response) -> Response`
+///
+/// The macro generates:
+/// - `init(ptr, len) -> i32` - Initialize with JSON config
+/// - `on_request(ptr, len) -> i32` - Process request (0=continue, 1=short-circuit)
+/// - `on_response(ptr, len) -> i32` - Process response
+///
+/// The plugin must call `host_set_output` to return data to the host.
+#[proc_macro_attribute]
+pub fn barbacane_middleware(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as ItemStruct);
+    let struct_name = &input.ident;
+
+    let expanded = quote! {
+        #input
+
+        // Global state for the plugin instance
+        static mut PLUGIN_INSTANCE: Option<#struct_name> = None;
+
+        /// Initialize the plugin with JSON config.
+        #[no_mangle]
+        pub extern "C" fn init(ptr: i32, len: i32) -> i32 {
+            let config_bytes = unsafe {
+                core::slice::from_raw_parts(ptr as *const u8, len as usize)
+            };
+
+            match serde_json::from_slice::<#struct_name>(config_bytes) {
+                Ok(instance) => {
+                    unsafe { PLUGIN_INSTANCE = Some(instance); }
+                    0 // Success
+                }
+                Err(_) => 1 // Failed to parse config
+            }
+        }
+
+        /// Process an incoming request.
+        /// Returns 0 to continue, 1 to short-circuit with response.
+        #[no_mangle]
+        pub extern "C" fn on_request(ptr: i32, len: i32) -> i32 {
+            let request_bytes = unsafe {
+                core::slice::from_raw_parts(ptr as *const u8, len as usize)
+            };
+
+            let request: barbacane_plugin_sdk::prelude::Request = match serde_json::from_slice(request_bytes) {
+                Ok(r) => r,
+                Err(_) => return 1, // Parse error, short-circuit
+            };
+
+            let instance = unsafe {
+                match PLUGIN_INSTANCE.as_mut() {
+                    Some(i) => i,
+                    None => return 1, // Not initialized
+                }
+            };
+
+            match instance.on_request(request) {
+                barbacane_plugin_sdk::prelude::Action::Continue(req) => {
+                    // Serialize the request and set output
+                    if let Ok(output) = serde_json::to_vec(&serde_json::json!({
+                        "action": 0,
+                        "data": req
+                    })) {
+                        set_output(&output);
+                    }
+                    0 // Continue
+                }
+                barbacane_plugin_sdk::prelude::Action::ShortCircuit(resp) => {
+                    // Serialize the response and set output
+                    if let Ok(output) = serde_json::to_vec(&serde_json::json!({
+                        "action": 1,
+                        "data": resp
+                    })) {
+                        set_output(&output);
+                    }
+                    1 // Short-circuit
+                }
+            }
+        }
+
+        /// Process an outgoing response.
+        #[no_mangle]
+        pub extern "C" fn on_response(ptr: i32, len: i32) -> i32 {
+            let response_bytes = unsafe {
+                core::slice::from_raw_parts(ptr as *const u8, len as usize)
+            };
+
+            let response: barbacane_plugin_sdk::prelude::Response = match serde_json::from_slice(response_bytes) {
+                Ok(r) => r,
+                Err(_) => return 1,
+            };
+
+            let instance = unsafe {
+                match PLUGIN_INSTANCE.as_mut() {
+                    Some(i) => i,
+                    None => return 1,
+                }
+            };
+
+            let result = instance.on_response(response);
+
+            if let Ok(output) = serde_json::to_vec(&result) {
+                set_output(&output);
+            }
+
+            0
+        }
+
+        /// Helper to set output via host function.
+        fn set_output(data: &[u8]) {
+            extern "C" {
+                fn host_set_output(ptr: i32, len: i32);
+            }
+            unsafe {
+                host_set_output(data.as_ptr() as i32, data.len() as i32);
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+/// Generates WASM exports for a dispatcher plugin.
+///
+/// The annotated struct must implement:
+/// - `fn dispatch(&mut self, req: Request) -> Response`
+///
+/// The macro generates:
+/// - `init(ptr, len) -> i32` - Initialize with JSON config
+/// - `dispatch(ptr, len) -> i32` - Handle request and return response
+///
+/// The plugin must call `host_set_output` to return the response to the host.
+#[proc_macro_attribute]
+pub fn barbacane_dispatcher(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as ItemStruct);
+    let struct_name = &input.ident;
+
+    let expanded = quote! {
+        #input
+
+        // Global state for the plugin instance
+        static mut PLUGIN_INSTANCE: Option<#struct_name> = None;
+
+        /// Initialize the plugin with JSON config.
+        #[no_mangle]
+        pub extern "C" fn init(ptr: i32, len: i32) -> i32 {
+            let config_bytes = unsafe {
+                core::slice::from_raw_parts(ptr as *const u8, len as usize)
+            };
+
+            match serde_json::from_slice::<#struct_name>(config_bytes) {
+                Ok(instance) => {
+                    unsafe { PLUGIN_INSTANCE = Some(instance); }
+                    0 // Success
+                }
+                Err(_) => 1 // Failed to parse config
+            }
+        }
+
+        /// Dispatch a request and return a response.
+        #[no_mangle]
+        pub extern "C" fn dispatch(ptr: i32, len: i32) -> i32 {
+            let request_bytes = unsafe {
+                core::slice::from_raw_parts(ptr as *const u8, len as usize)
+            };
+
+            let request: barbacane_plugin_sdk::prelude::Request = match serde_json::from_slice(request_bytes) {
+                Ok(r) => r,
+                Err(_) => {
+                    // Return error response
+                    let error_resp = barbacane_plugin_sdk::prelude::Response {
+                        status: 500,
+                        headers: std::collections::HashMap::new(),
+                        body: Some(r#"{"error":"failed to parse request"}"#.to_string()),
+                    };
+                    if let Ok(output) = serde_json::to_vec(&error_resp) {
+                        set_output(&output);
+                    }
+                    return 1;
+                }
+            };
+
+            let instance = unsafe {
+                match PLUGIN_INSTANCE.as_mut() {
+                    Some(i) => i,
+                    None => {
+                        let error_resp = barbacane_plugin_sdk::prelude::Response {
+                            status: 500,
+                            headers: std::collections::HashMap::new(),
+                            body: Some(r#"{"error":"plugin not initialized"}"#.to_string()),
+                        };
+                        if let Ok(output) = serde_json::to_vec(&error_resp) {
+                            set_output(&output);
+                        }
+                        return 1;
+                    }
+                }
+            };
+
+            let response = instance.dispatch(request);
+
+            if let Ok(output) = serde_json::to_vec(&response) {
+                set_output(&output);
+            }
+
+            0
+        }
+
+        /// Helper to set output via host function.
+        fn set_output(data: &[u8]) {
+            extern "C" {
+                fn host_set_output(ptr: i32, len: i32);
+            }
+            unsafe {
+                host_set_output(data.as_ptr() as i32, data.len() as i32);
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/crates/barbacane-plugin-sdk/Cargo.toml
+++ b/crates/barbacane-plugin-sdk/Cargo.toml
@@ -8,3 +8,4 @@ license.workspace = true
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+barbacane-plugin-macros = { workspace = true }

--- a/crates/barbacane-plugin-sdk/src/lib.rs
+++ b/crates/barbacane-plugin-sdk/src/lib.rs
@@ -4,10 +4,35 @@
 //! `#[barbacane_middleware]` and `#[barbacane_dispatcher]` macros
 //! that generate the required WASM export glue.
 //!
-//! This crate is a stub until M3 (WASM Plugin System).
+//! # Example
+//!
+//! ```ignore
+//! use barbacane_plugin_sdk::prelude::*;
+//!
+//! #[barbacane_middleware]
+//! #[derive(serde::Deserialize)]
+//! struct RateLimiter {
+//!     quota: u32,
+//!     window: u32,
+//! }
+//!
+//! impl RateLimiter {
+//!     fn on_request(&mut self, req: Request) -> Action<Request> {
+//!         Action::Continue(req)
+//!     }
+//!
+//!     fn on_response(&mut self, resp: Response) -> Response {
+//!         resp
+//!     }
+//! }
+//! ```
 
 pub mod types;
 
+/// Re-export proc macros for plugin development.
+pub use barbacane_plugin_macros::{barbacane_dispatcher, barbacane_middleware};
+
 pub mod prelude {
     pub use crate::types::*;
+    pub use crate::{barbacane_dispatcher, barbacane_middleware};
 }

--- a/crates/barbacane-wasm/Cargo.toml
+++ b/crates/barbacane-wasm/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "barbacane-wasm"
+description = "WASM plugin runtime for Barbacane API gateway"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+# WASM runtime
+wasmtime.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Plugin manifest
+toml.workspace = true
+semver.workspace = true
+regex-lite.workspace = true
+
+# Concurrency
+dashmap.workspace = true
+
+# Async
+tokio.workspace = true
+
+# Error handling
+thiserror.workspace = true
+anyhow.workspace = true
+
+# Logging
+tracing.workspace = true
+
+# JSON Schema validation (for config schemas)
+jsonschema.workspace = true
+
+# Hashing (for config deduplication)
+sha2.workspace = true
+hex.workspace = true
+
+# Workspace crates
+barbacane-plugin-sdk.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/barbacane-wasm/src/chain.rs
+++ b/crates/barbacane-wasm/src/chain.rs
@@ -1,0 +1,364 @@
+//! Middleware chain execution.
+//!
+//! Per SPEC-003 section 5, middlewares execute in order for on_request,
+//! and reverse order for on_response. A middleware returning 1 from
+//! on_request short-circuits the chain with an immediate response.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::WasmError;
+use crate::instance::{PluginInstance, RequestContext};
+use crate::trap::{TrapContext, TrapResult};
+
+/// The result of executing on_request on a single middleware.
+#[derive(Debug)]
+pub enum OnRequestResult {
+    /// Continue to the next middleware with possibly modified request.
+    Continue(Vec<u8>),
+    /// Short-circuit with an immediate response.
+    ShortCircuit(Vec<u8>),
+}
+
+/// Output format from middleware on_request.
+///
+/// The plugin sets output as JSON with this structure.
+#[derive(Debug, Serialize, Deserialize)]
+struct MiddlewareOutput {
+    /// 0 = continue, 1 = short-circuit
+    action: i32,
+    /// The request (if continue) or response (if short-circuit)
+    data: serde_json::Value,
+}
+
+/// A configured middleware in the chain.
+#[derive(Debug, Clone)]
+pub struct MiddlewareConfig {
+    /// Plugin name.
+    pub name: String,
+    /// Plugin config as JSON.
+    pub config: serde_json::Value,
+}
+
+impl MiddlewareConfig {
+    /// Create a new middleware config.
+    pub fn new(name: impl Into<String>, config: serde_json::Value) -> Self {
+        Self {
+            name: name.into(),
+            config,
+        }
+    }
+}
+
+/// A middleware chain that executes multiple middlewares in sequence.
+pub struct MiddlewareChain {
+    /// Middleware configs in order of execution.
+    configs: Vec<MiddlewareConfig>,
+}
+
+impl MiddlewareChain {
+    /// Create a new empty middleware chain.
+    pub fn new() -> Self {
+        Self {
+            configs: Vec::new(),
+        }
+    }
+
+    /// Create a chain from a list of middleware configs.
+    pub fn from_configs(configs: Vec<MiddlewareConfig>) -> Self {
+        Self { configs }
+    }
+
+    /// Add a middleware to the chain.
+    pub fn push(&mut self, config: MiddlewareConfig) {
+        self.configs.push(config);
+    }
+
+    /// Get the number of middlewares in the chain.
+    pub fn len(&self) -> usize {
+        self.configs.len()
+    }
+
+    /// Check if the chain is empty.
+    pub fn is_empty(&self) -> bool {
+        self.configs.is_empty()
+    }
+
+    /// Get the middleware configs.
+    pub fn configs(&self) -> &[MiddlewareConfig] {
+        &self.configs
+    }
+}
+
+impl Default for MiddlewareChain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Result of executing the full request chain.
+#[derive(Debug)]
+pub enum ChainResult {
+    /// Chain completed, continue to dispatch.
+    Continue {
+        /// The final request after all middlewares.
+        request: Vec<u8>,
+        /// Context to pass to on_response chain.
+        context: RequestContext,
+    },
+    /// Chain short-circuited with a response.
+    ShortCircuit {
+        /// The response from the short-circuiting middleware.
+        response: Vec<u8>,
+        /// Index of the middleware that short-circuited.
+        middleware_index: usize,
+        /// Context for response chain (partial).
+        context: RequestContext,
+    },
+    /// Chain failed with an error.
+    Error {
+        /// The error that occurred.
+        error: WasmError,
+        /// The trap result for error handling.
+        trap_result: TrapResult,
+    },
+}
+
+/// Execute the on_request chain.
+///
+/// Processes middlewares in order. If any middleware returns 1 (short-circuit),
+/// stops and returns the response. If all middlewares return 0 (continue),
+/// returns the final request for dispatch.
+pub fn execute_on_request(
+    instances: &mut [PluginInstance],
+    initial_request: &[u8],
+    context: RequestContext,
+) -> ChainResult {
+    let mut current_request = initial_request.to_vec();
+    let current_context = context;
+
+    for (index, instance) in instances.iter_mut().enumerate() {
+        // Set context for this middleware
+        instance.set_context(current_context.clone());
+
+        // Call on_request
+        match instance.on_request(&current_request) {
+            Ok(result_code) => {
+                let output = instance.take_output();
+
+                // Parse the output to determine action
+                match parse_middleware_output(&output, result_code) {
+                    Ok(OnRequestResult::Continue(new_request)) => {
+                        current_request = new_request;
+                        // Preserve any context modifications from the middleware
+                        // (context is updated via host functions during execution)
+                    }
+                    Ok(OnRequestResult::ShortCircuit(response)) => {
+                        return ChainResult::ShortCircuit {
+                            response,
+                            middleware_index: index,
+                            context: current_context,
+                        };
+                    }
+                    Err(e) => {
+                        return ChainResult::Error {
+                            trap_result: TrapResult::from_error(&e, TrapContext::OnRequest),
+                            error: e,
+                        };
+                    }
+                }
+            }
+            Err(e) => {
+                return ChainResult::Error {
+                    trap_result: TrapResult::from_error(&e, TrapContext::OnRequest),
+                    error: e,
+                };
+            }
+        }
+    }
+
+    ChainResult::Continue {
+        request: current_request,
+        context: current_context,
+    }
+}
+
+/// Execute the on_response chain.
+///
+/// Processes middlewares in reverse order. If any middleware fails,
+/// logs the error and continues with the original response (fault-tolerant).
+pub fn execute_on_response(
+    instances: &mut [PluginInstance],
+    initial_response: &[u8],
+    context: RequestContext,
+) -> Vec<u8> {
+    let mut current_response = initial_response.to_vec();
+
+    // Process in reverse order
+    for instance in instances.iter_mut().rev() {
+        instance.set_context(context.clone());
+
+        match instance.on_response(&current_response) {
+            Ok(_result_code) => {
+                let output = instance.take_output();
+                if !output.is_empty() {
+                    current_response = output;
+                }
+            }
+            Err(e) => {
+                // Fault-tolerant: log and continue with current response
+                let trap_result = TrapResult::from_error(&e, TrapContext::OnResponse);
+                tracing::warn!(
+                    error = %trap_result.message(),
+                    "Middleware on_response failed, continuing with original response"
+                );
+            }
+        }
+    }
+
+    current_response
+}
+
+/// Execute on_response for a partial chain (after short-circuit).
+///
+/// Only processes middlewares up to (but not including) the short-circuiting one.
+pub fn execute_on_response_partial(
+    instances: &mut [PluginInstance],
+    response: &[u8],
+    short_circuit_index: usize,
+    context: RequestContext,
+) -> Vec<u8> {
+    if short_circuit_index == 0 {
+        return response.to_vec();
+    }
+
+    let partial_instances = &mut instances[..short_circuit_index];
+    execute_on_response(partial_instances, response, context)
+}
+
+/// Parse middleware output to determine the action.
+fn parse_middleware_output(output: &[u8], result_code: i32) -> Result<OnRequestResult, WasmError> {
+    // If no output, use result code as simple continue/short-circuit
+    if output.is_empty() {
+        return if result_code == 0 {
+            Ok(OnRequestResult::Continue(Vec::new()))
+        } else {
+            Err(WasmError::InitFailed(
+                "middleware returned short-circuit without output".into(),
+            ))
+        };
+    }
+
+    // Try to parse as MiddlewareOutput JSON
+    match serde_json::from_slice::<MiddlewareOutput>(output) {
+        Ok(parsed) => {
+            let data = serde_json::to_vec(&parsed.data)
+                .map_err(|e| WasmError::InitFailed(format!("failed to serialize output: {}", e)))?;
+
+            if parsed.action == 0 || result_code == 0 {
+                Ok(OnRequestResult::Continue(data))
+            } else {
+                Ok(OnRequestResult::ShortCircuit(data))
+            }
+        }
+        Err(_) => {
+            // If not structured output, use raw output with result code
+            if result_code == 0 {
+                Ok(OnRequestResult::Continue(output.to_vec()))
+            } else {
+                Ok(OnRequestResult::ShortCircuit(output.to_vec()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn middleware_config_new() {
+        let config = MiddlewareConfig::new("rate-limit", json!({"quota": 100}));
+        assert_eq!(config.name, "rate-limit");
+        assert_eq!(config.config["quota"], 100);
+    }
+
+    #[test]
+    fn chain_new_is_empty() {
+        let chain = MiddlewareChain::new();
+        assert!(chain.is_empty());
+        assert_eq!(chain.len(), 0);
+    }
+
+    #[test]
+    fn chain_push() {
+        let mut chain = MiddlewareChain::new();
+        chain.push(MiddlewareConfig::new("auth", json!({})));
+        chain.push(MiddlewareConfig::new("rate-limit", json!({})));
+
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain.configs()[0].name, "auth");
+        assert_eq!(chain.configs()[1].name, "rate-limit");
+    }
+
+    #[test]
+    fn chain_from_configs() {
+        let configs = vec![
+            MiddlewareConfig::new("auth", json!({})),
+            MiddlewareConfig::new("cors", json!({})),
+        ];
+        let chain = MiddlewareChain::from_configs(configs);
+
+        assert_eq!(chain.len(), 2);
+    }
+
+    #[test]
+    fn parse_continue_output() {
+        let output = serde_json::to_vec(&json!({
+            "action": 0,
+            "data": {"method": "GET", "path": "/api"}
+        }))
+        .unwrap();
+
+        let result = parse_middleware_output(&output, 0).unwrap();
+        assert!(matches!(result, OnRequestResult::Continue(_)));
+    }
+
+    #[test]
+    fn parse_short_circuit_output() {
+        let output = serde_json::to_vec(&json!({
+            "action": 1,
+            "data": {"status": 401, "body": "Unauthorized"}
+        }))
+        .unwrap();
+
+        let result = parse_middleware_output(&output, 1).unwrap();
+        assert!(matches!(result, OnRequestResult::ShortCircuit(_)));
+    }
+
+    #[test]
+    fn parse_raw_output_continue() {
+        let output = b"raw request data";
+        let result = parse_middleware_output(output, 0).unwrap();
+        assert!(matches!(result, OnRequestResult::Continue(_)));
+    }
+
+    #[test]
+    fn parse_raw_output_short_circuit() {
+        let output = b"error response";
+        let result = parse_middleware_output(output, 1).unwrap();
+        assert!(matches!(result, OnRequestResult::ShortCircuit(_)));
+    }
+
+    #[test]
+    fn parse_empty_continue() {
+        let result = parse_middleware_output(&[], 0).unwrap();
+        assert!(matches!(result, OnRequestResult::Continue(data) if data.is_empty()));
+    }
+
+    #[test]
+    fn parse_empty_short_circuit_fails() {
+        let result = parse_middleware_output(&[], 1);
+        assert!(result.is_err());
+    }
+}

--- a/crates/barbacane-wasm/src/engine.rs
+++ b/crates/barbacane-wasm/src/engine.rs
@@ -1,0 +1,168 @@
+//! WASM engine configuration and AOT compilation.
+//!
+//! This module provides the core wasmtime engine with settings optimized
+//! for the Barbacane plugin runtime.
+
+use wasmtime::{Config, Engine, Module, OptLevel};
+
+use crate::error::WasmError;
+use crate::limits::PluginLimits;
+
+/// A compiled WASM module ready for instantiation.
+#[derive(Clone)]
+pub struct CompiledModule {
+    module: Module,
+    /// The plugin name this module belongs to.
+    pub name: String,
+    /// The plugin version.
+    pub version: String,
+}
+
+impl CompiledModule {
+    /// Get a reference to the underlying wasmtime module.
+    pub fn module(&self) -> &Module {
+        &self.module
+    }
+}
+
+/// The WASM engine that compiles and manages plugin modules.
+pub struct WasmEngine {
+    engine: Engine,
+    limits: PluginLimits,
+}
+
+impl WasmEngine {
+    /// Create a new WASM engine with default configuration.
+    pub fn new() -> Result<Self, WasmError> {
+        Self::with_limits(PluginLimits::default())
+    }
+
+    /// Create a new WASM engine with custom resource limits.
+    pub fn with_limits(limits: PluginLimits) -> Result<Self, WasmError> {
+        let mut config = Config::new();
+
+        // Enable async support for async host functions
+        config.async_support(true);
+
+        // Use Cranelift for AOT compilation with speed optimization
+        config.cranelift_opt_level(OptLevel::Speed);
+
+        // Enable fuel consumption for execution time limiting
+        config.consume_fuel(true);
+
+        // Configure memory settings
+        config.max_wasm_stack(limits.max_stack_bytes);
+
+        // Enable reference types (for modern WASM features)
+        config.wasm_reference_types(true);
+
+        // Enable bulk memory operations
+        config.wasm_bulk_memory(true);
+
+        // Enable multi-value returns
+        config.wasm_multi_value(true);
+
+        // Disable WASM features we don't need
+        config.wasm_threads(false);
+
+        let engine = Engine::new(&config).map_err(|e| WasmError::EngineCreation(e.to_string()))?;
+
+        Ok(Self { engine, limits })
+    }
+
+    /// Get a reference to the underlying wasmtime engine.
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    /// Get the configured resource limits.
+    pub fn limits(&self) -> &PluginLimits {
+        &self.limits
+    }
+
+    /// AOT-compile a WASM module from bytes.
+    ///
+    /// The compiled module can be instantiated multiple times efficiently.
+    pub fn compile(
+        &self,
+        wasm_bytes: &[u8],
+        name: String,
+        version: String,
+    ) -> Result<CompiledModule, WasmError> {
+        let module =
+            Module::new(&self.engine, wasm_bytes).map_err(|e| WasmError::Compilation(e.to_string()))?;
+
+        Ok(CompiledModule {
+            module,
+            name,
+            version,
+        })
+    }
+
+    /// Validate a WASM module without fully compiling it.
+    ///
+    /// This is faster than full compilation and useful for quick validation.
+    pub fn validate(&self, wasm_bytes: &[u8]) -> Result<(), WasmError> {
+        Module::validate(&self.engine, wasm_bytes).map_err(|e| WasmError::Compilation(e.to_string()))
+    }
+}
+
+impl Default for WasmEngine {
+    fn default() -> Self {
+        Self::new().expect("failed to create default WASM engine")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Minimal valid WASM module (empty module)
+    const MINIMAL_WASM: &[u8] = &[
+        0x00, 0x61, 0x73, 0x6d, // magic number
+        0x01, 0x00, 0x00, 0x00, // version
+    ];
+
+    #[test]
+    fn create_engine() {
+        let engine = WasmEngine::new();
+        assert!(engine.is_ok());
+    }
+
+    #[test]
+    fn create_engine_with_limits() {
+        let limits = PluginLimits::default().with_memory(32 * 1024 * 1024);
+        let engine = WasmEngine::with_limits(limits);
+        assert!(engine.is_ok());
+    }
+
+    #[test]
+    fn validate_minimal_wasm() {
+        let engine = WasmEngine::new().unwrap();
+        assert!(engine.validate(MINIMAL_WASM).is_ok());
+    }
+
+    #[test]
+    fn validate_invalid_wasm() {
+        let engine = WasmEngine::new().unwrap();
+        let invalid = &[0x00, 0x00, 0x00, 0x00];
+        assert!(engine.validate(invalid).is_err());
+    }
+
+    #[test]
+    fn compile_minimal_wasm() {
+        let engine = WasmEngine::new().unwrap();
+        let result = engine.compile(MINIMAL_WASM, "test".into(), "1.0.0".into());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn compiled_module_has_metadata() {
+        let engine = WasmEngine::new().unwrap();
+        let module = engine
+            .compile(MINIMAL_WASM, "my-plugin".into(), "2.1.0".into())
+            .unwrap();
+        assert_eq!(module.name, "my-plugin");
+        assert_eq!(module.version, "2.1.0");
+    }
+}

--- a/crates/barbacane-wasm/src/error.rs
+++ b/crates/barbacane-wasm/src/error.rs
@@ -1,0 +1,101 @@
+//! Error types for the WASM runtime.
+
+use thiserror::Error;
+
+/// Errors that can occur in the WASM runtime.
+#[derive(Debug, Error)]
+pub enum WasmError {
+    /// Failed to create the WASM engine.
+    #[error("failed to create WASM engine: {0}")]
+    EngineCreation(String),
+
+    /// Failed to compile a WASM module.
+    #[error("failed to compile WASM module: {0}")]
+    Compilation(String),
+
+    /// Failed to instantiate a WASM module.
+    #[error("failed to instantiate WASM module: {0}")]
+    Instantiation(String),
+
+    /// WASM execution trapped.
+    #[error("WASM execution trapped: {0}")]
+    Trap(String),
+
+    /// WASM execution timed out.
+    #[error("WASM execution timed out after {0}ms")]
+    Timeout(u64),
+
+    /// WASM memory limit exceeded.
+    #[error("WASM memory limit exceeded: requested {requested} bytes, limit {limit} bytes")]
+    MemoryLimitExceeded { requested: usize, limit: usize },
+
+    /// Missing required export.
+    #[error("missing required WASM export: {0}")]
+    MissingExport(String),
+
+    /// Invalid export signature.
+    #[error("invalid export signature for '{name}': expected {expected}, got {actual}")]
+    InvalidExportSignature {
+        name: String,
+        expected: String,
+        actual: String,
+    },
+
+    /// Undeclared host function import.
+    #[error("plugin imports undeclared host function: {0}")]
+    UndeclaredImport(String),
+
+    /// Unknown capability.
+    #[error("unknown capability: {0}")]
+    UnknownCapability(String),
+
+    /// Plugin manifest parsing failed.
+    #[error("failed to parse plugin manifest: {0}")]
+    ManifestParse(String),
+
+    /// Plugin manifest validation failed.
+    #[error("invalid plugin manifest: {0}")]
+    ManifestValidation(String),
+
+    /// Config schema parsing failed.
+    #[error("failed to parse config schema: {0}")]
+    SchemaParse(String),
+
+    /// Config validation failed.
+    #[error("config validation failed: {0}")]
+    ConfigValidation(String),
+
+    /// Plugin initialization failed.
+    #[error("plugin initialization failed: {0}")]
+    InitFailed(String),
+
+    /// Invalid return code from plugin.
+    #[error("invalid return code from plugin: {0}")]
+    InvalidReturnCode(i32),
+
+    /// Failed to serialize/deserialize data.
+    #[error("serialization error: {0}")]
+    Serialization(String),
+
+    /// I/O error.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl From<wasmtime::Error> for WasmError {
+    fn from(err: wasmtime::Error) -> Self {
+        WasmError::Compilation(err.to_string())
+    }
+}
+
+impl From<serde_json::Error> for WasmError {
+    fn from(err: serde_json::Error) -> Self {
+        WasmError::Serialization(err.to_string())
+    }
+}
+
+impl From<toml::de::Error> for WasmError {
+    fn from(err: toml::de::Error) -> Self {
+        WasmError::ManifestParse(err.to_string())
+    }
+}

--- a/crates/barbacane-wasm/src/host/mod.rs
+++ b/crates/barbacane-wasm/src/host/mod.rs
@@ -1,0 +1,173 @@
+//! Host functions exposed to WASM plugins.
+//!
+//! Per SPEC-003 section 4, plugins import host functions from the
+//! `barbacane` namespace. Each function is only available if declared
+//! in the plugin's capabilities.
+//!
+//! Note: The actual host function implementations are in the instance
+//! module where they're registered with the wasmtime linker. This module
+//! provides documentation and helper types.
+
+/// Host function for writing output.
+///
+/// ```text
+/// host_set_output(ptr: i32, len: i32)
+/// ```
+///
+/// This function is always available (not a capability).
+pub mod output {
+    /// The capability name (none - always available).
+    pub const CAPABILITY: Option<&str> = None;
+
+    /// The function name in the barbacane namespace.
+    pub const FUNCTION_NAME: &str = "host_set_output";
+}
+
+/// Host function for logging.
+///
+/// ```text
+/// host_log(level: i32, msg_ptr: i32, msg_len: i32)
+/// ```
+///
+/// Level values:
+/// - 0 = error
+/// - 1 = warn
+/// - 2 = info
+/// - 3 = debug
+pub mod log {
+    /// The capability name.
+    pub const CAPABILITY: &str = "log";
+
+    /// The function name in the barbacane namespace.
+    pub const FUNCTION_NAME: &str = "host_log";
+
+    /// Log level values.
+    pub mod level {
+        pub const ERROR: i32 = 0;
+        pub const WARN: i32 = 1;
+        pub const INFO: i32 = 2;
+        pub const DEBUG: i32 = 3;
+    }
+}
+
+/// Host functions for request context.
+///
+/// ```text
+/// host_context_get(key_ptr: i32, key_len: i32) -> i32
+/// host_context_read_result(buf_ptr: i32, buf_len: i32) -> i32
+/// host_context_set(key_ptr: i32, key_len: i32, val_ptr: i32, val_len: i32)
+/// ```
+pub mod context {
+    /// The capability name for reading context.
+    pub const GET_CAPABILITY: &str = "context_get";
+
+    /// The capability name for writing context.
+    pub const SET_CAPABILITY: &str = "context_set";
+
+    /// The function names.
+    pub const GET_FUNCTION: &str = "host_context_get";
+    pub const READ_RESULT_FUNCTION: &str = "host_context_read_result";
+    pub const SET_FUNCTION: &str = "host_context_set";
+}
+
+/// Host function for monotonic clock.
+///
+/// ```text
+/// host_clock_now() -> i64
+/// ```
+///
+/// Returns milliseconds since an arbitrary reference point.
+pub mod clock {
+    /// The capability name.
+    pub const CAPABILITY: &str = "clock_now";
+
+    /// The function name.
+    pub const FUNCTION_NAME: &str = "host_clock_now";
+}
+
+/// Host functions for secrets.
+///
+/// ```text
+/// host_get_secret(ref_ptr: i32, ref_len: i32) -> i32
+/// host_secret_read_result(buf_ptr: i32, buf_len: i32) -> i32
+/// ```
+///
+/// Not yet implemented (M5 milestone).
+pub mod secrets {
+    /// The capability name.
+    pub const CAPABILITY: &str = "get_secret";
+
+    /// The function names.
+    pub const GET_FUNCTION: &str = "host_get_secret";
+    pub const READ_RESULT_FUNCTION: &str = "host_secret_read_result";
+}
+
+/// Host functions for HTTP calls.
+///
+/// ```text
+/// host_http_call(req_ptr: i32, req_len: i32) -> i32
+/// host_http_read_result(buf_ptr: i32, buf_len: i32) -> i32
+/// ```
+///
+/// Not yet implemented (M4 milestone).
+pub mod http {
+    /// The capability name.
+    pub const CAPABILITY: &str = "http_call";
+
+    /// The function names.
+    pub const CALL_FUNCTION: &str = "host_http_call";
+    pub const READ_RESULT_FUNCTION: &str = "host_http_read_result";
+}
+
+/// Host functions for Kafka publishing.
+///
+/// ```text
+/// host_kafka_publish(msg_ptr: i32, msg_len: i32) -> i32
+/// ```
+///
+/// Not yet implemented (M9 milestone).
+pub mod kafka {
+    /// The capability name.
+    pub const CAPABILITY: &str = "kafka_publish";
+
+    /// The function name.
+    pub const FUNCTION_NAME: &str = "host_kafka_publish";
+}
+
+/// Host functions for NATS publishing.
+///
+/// ```text
+/// host_nats_publish(msg_ptr: i32, msg_len: i32) -> i32
+/// ```
+///
+/// Not yet implemented (M9 milestone).
+pub mod nats {
+    /// The capability name.
+    pub const CAPABILITY: &str = "nats_publish";
+
+    /// The function name.
+    pub const FUNCTION_NAME: &str = "host_nats_publish";
+}
+
+/// Host functions for telemetry.
+///
+/// ```text
+/// host_metric_counter_inc(name_ptr, name_len, labels_ptr, labels_len, value: f64)
+/// host_metric_histogram_observe(name_ptr, name_len, labels_ptr, labels_len, value: f64)
+/// host_span_start(name_ptr: i32, name_len: i32)
+/// host_span_end()
+/// host_span_set_attribute(key_ptr, key_len, val_ptr, val_len)
+/// ```
+///
+/// Not yet implemented (M7 milestone).
+pub mod telemetry {
+    /// The capability name.
+    pub const CAPABILITY: &str = "telemetry";
+
+    /// The function names.
+    pub const COUNTER_INC: &str = "host_metric_counter_inc";
+    pub const HISTOGRAM_OBSERVE: &str = "host_metric_histogram_observe";
+    pub const SPAN_START: &str = "host_span_start";
+    pub const SPAN_END: &str = "host_span_end";
+    pub const SPAN_SET_ATTRIBUTE: &str = "host_span_set_attribute";
+}

--- a/crates/barbacane-wasm/src/instance.rs
+++ b/crates/barbacane-wasm/src/instance.rs
@@ -1,0 +1,484 @@
+//! WASM plugin instance management.
+//!
+//! Each plugin instance wraps a wasmtime Store and Instance with the
+//! plugin state required for host function calls.
+
+use std::collections::HashMap;
+
+use wasmtime::{Caller, Engine, Instance, Linker, Memory, Store, TypedFunc};
+
+use crate::engine::CompiledModule;
+use crate::error::WasmError;
+use crate::limits::PluginLimits;
+
+/// Per-request context passed to plugins.
+#[derive(Debug, Clone, Default)]
+pub struct RequestContext {
+    /// Key-value store for inter-middleware communication.
+    pub values: HashMap<String, String>,
+
+    /// Result buffer for host_context_get.
+    pub last_get_result: Option<String>,
+
+    /// Trace ID for distributed tracing.
+    pub trace_id: String,
+
+    /// Request ID.
+    pub request_id: String,
+}
+
+impl RequestContext {
+    /// Create a new request context.
+    pub fn new(trace_id: String, request_id: String) -> Self {
+        Self {
+            values: HashMap::new(),
+            last_get_result: None,
+            trace_id,
+            request_id,
+        }
+    }
+}
+
+/// State attached to each WASM store.
+pub struct PluginState {
+    /// Plugin name for logging.
+    pub plugin_name: String,
+
+    /// Output buffer for plugin results.
+    pub output_buffer: Vec<u8>,
+
+    /// Per-request context.
+    pub context: RequestContext,
+
+    /// Maximum memory in bytes.
+    pub max_memory: usize,
+}
+
+impl PluginState {
+    /// Create new plugin state.
+    pub fn new(plugin_name: String, limits: &PluginLimits) -> Self {
+        Self {
+            plugin_name,
+            output_buffer: Vec::new(),
+            context: RequestContext::default(),
+            max_memory: limits.max_memory_bytes,
+        }
+    }
+
+    /// Get the output buffer contents.
+    pub fn take_output(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.output_buffer)
+    }
+
+    /// Set the request context for this call.
+    pub fn set_context(&mut self, context: RequestContext) {
+        self.context = context;
+    }
+}
+
+impl wasmtime::ResourceLimiter for PluginState {
+    fn memory_growing(
+        &mut self,
+        _current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> anyhow::Result<bool> {
+        Ok(desired <= self.max_memory)
+    }
+
+    fn table_growing(
+        &mut self,
+        _current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> anyhow::Result<bool> {
+        // Allow reasonable table growth
+        Ok(desired <= 10_000)
+    }
+}
+
+/// A WASM plugin instance ready for execution.
+pub struct PluginInstance {
+    store: Store<PluginState>,
+    #[allow(dead_code)]
+    instance: Instance,
+    limits: PluginLimits,
+
+    // Cached function references
+    init_func: Option<TypedFunc<(i32, i32), i32>>,
+    on_request_func: Option<TypedFunc<(i32, i32), i32>>,
+    on_response_func: Option<TypedFunc<(i32, i32), i32>>,
+    dispatch_func: Option<TypedFunc<(i32, i32), i32>>,
+    memory: Memory,
+}
+
+impl PluginInstance {
+    /// Create a new plugin instance from a compiled module.
+    pub fn new(
+        engine: &Engine,
+        module: &CompiledModule,
+        limits: PluginLimits,
+    ) -> Result<Self, WasmError> {
+        let state = PluginState::new(module.name.clone(), &limits);
+        let mut store = Store::new(engine, state);
+
+        // Set fuel for execution limiting
+        store
+            .set_fuel(limits.max_fuel)
+            .map_err(|e| WasmError::Instantiation(format!("failed to set fuel: {}", e)))?;
+
+        // Enable resource limiting
+        store.limiter(|state| state);
+
+        // Create linker and add host functions
+        let mut linker = Linker::new(engine);
+        add_host_functions(&mut linker)?;
+
+        // Instantiate the module
+        let instance = linker
+            .instantiate(&mut store, module.module())
+            .map_err(|e| WasmError::Instantiation(e.to_string()))?;
+
+        // Get memory
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| WasmError::MissingExport("memory".into()))?;
+
+        // Cache function references
+        let init_func = instance
+            .get_typed_func::<(i32, i32), i32>(&mut store, "init")
+            .ok();
+        let on_request_func = instance
+            .get_typed_func::<(i32, i32), i32>(&mut store, "on_request")
+            .ok();
+        let on_response_func = instance
+            .get_typed_func::<(i32, i32), i32>(&mut store, "on_response")
+            .ok();
+        let dispatch_func = instance
+            .get_typed_func::<(i32, i32), i32>(&mut store, "dispatch")
+            .ok();
+
+        Ok(Self {
+            store,
+            instance,
+            limits,
+            init_func,
+            on_request_func,
+            on_response_func,
+            dispatch_func,
+            memory,
+        })
+    }
+
+    /// Write data to the plugin's memory and return the pointer.
+    pub fn write_to_memory(&mut self, data: &[u8]) -> Result<i32, WasmError> {
+        let mem_size = self.memory.data_size(&self.store);
+
+        // Find space in memory (simple bump allocator from end of memory)
+        // In a real implementation, we'd use the plugin's allocator
+        if data.len() > mem_size {
+            return Err(WasmError::MemoryLimitExceeded {
+                requested: data.len(),
+                limit: mem_size,
+            });
+        }
+
+        let ptr = (mem_size - data.len()) as i32;
+        if ptr < 0 {
+            return Err(WasmError::MemoryLimitExceeded {
+                requested: data.len(),
+                limit: mem_size,
+            });
+        }
+
+        self.memory
+            .write(&mut self.store, ptr as usize, data)
+            .map_err(|e| WasmError::Trap(format!("memory write failed: {}", e)))?;
+
+        Ok(ptr)
+    }
+
+    /// Call the init function with the given config.
+    pub fn init(&mut self, config_json: &[u8]) -> Result<i32, WasmError> {
+        let init_func = self
+            .init_func
+            .clone()
+            .ok_or_else(|| WasmError::MissingExport("init".into()))?;
+
+        // Write config to memory
+        let ptr = self.write_to_memory(config_json)?;
+        let len = config_json.len() as i32;
+
+        // Reset fuel for this call
+        self.store.set_fuel(self.limits.max_fuel).ok();
+
+        // Call init
+        let result = init_func
+            .call(&mut self.store, (ptr, len))
+            .map_err(|e| WasmError::Trap(e.to_string()))?;
+
+        Ok(result)
+    }
+
+    /// Call on_request with the given request data.
+    pub fn on_request(&mut self, request_json: &[u8]) -> Result<i32, WasmError> {
+        let func = self
+            .on_request_func
+            .clone()
+            .ok_or_else(|| WasmError::MissingExport("on_request".into()))?;
+
+        self.call_handler(func, request_json)
+    }
+
+    /// Call on_response with the given response data.
+    pub fn on_response(&mut self, response_json: &[u8]) -> Result<i32, WasmError> {
+        let func = self
+            .on_response_func
+            .clone()
+            .ok_or_else(|| WasmError::MissingExport("on_response".into()))?;
+
+        self.call_handler(func, response_json)
+    }
+
+    /// Call dispatch with the given request data.
+    pub fn dispatch(&mut self, request_json: &[u8]) -> Result<i32, WasmError> {
+        let func = self
+            .dispatch_func
+            .clone()
+            .ok_or_else(|| WasmError::MissingExport("dispatch".into()))?;
+
+        self.call_handler(func, request_json)
+    }
+
+    /// Call a handler function with data.
+    fn call_handler(
+        &mut self,
+        func: TypedFunc<(i32, i32), i32>,
+        data: &[u8],
+    ) -> Result<i32, WasmError> {
+        // Clear output buffer
+        self.store.data_mut().output_buffer.clear();
+
+        // Write data to memory
+        let ptr = self.write_to_memory(data)?;
+        let len = data.len() as i32;
+
+        // Reset fuel
+        self.store.set_fuel(self.limits.max_fuel).ok();
+
+        // Call function
+        let result = func
+            .call(&mut self.store, (ptr, len))
+            .map_err(|e| WasmError::Trap(e.to_string()))?;
+
+        Ok(result)
+    }
+
+    /// Get the output buffer contents.
+    pub fn take_output(&mut self) -> Vec<u8> {
+        self.store.data_mut().take_output()
+    }
+
+    /// Set the request context for the next call.
+    pub fn set_context(&mut self, context: RequestContext) {
+        self.store.data_mut().set_context(context);
+    }
+}
+
+/// Add host functions to the linker.
+fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError> {
+    // host_set_output - always available
+    linker
+        .func_wrap(
+            "barbacane",
+            "host_set_output",
+            |mut caller: Caller<'_, PluginState>, ptr: i32, len: i32| {
+                let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
+                    Some(m) => m,
+                    None => return,
+                };
+
+                let start = ptr as usize;
+                let end = start + len as usize;
+                let data = memory.data(&caller);
+
+                if end <= data.len() {
+                    let bytes = data[start..end].to_vec();
+                    caller.data_mut().output_buffer = bytes;
+                }
+            },
+        )
+        .map_err(|e| WasmError::Instantiation(format!("failed to add host_set_output: {}", e)))?;
+
+    // host_log
+    linker
+        .func_wrap(
+            "barbacane",
+            "host_log",
+            |mut caller: Caller<'_, PluginState>, level: i32, msg_ptr: i32, msg_len: i32| {
+                let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
+                    Some(m) => m,
+                    None => return,
+                };
+
+                let start = msg_ptr as usize;
+                let end = start + msg_len as usize;
+                let data = memory.data(&caller);
+
+                if end <= data.len() {
+                    if let Ok(message) = std::str::from_utf8(&data[start..end]) {
+                        let plugin_name = caller.data().plugin_name.clone();
+                        match level {
+                            0 => tracing::error!(plugin = %plugin_name, "{}", message),
+                            1 => tracing::warn!(plugin = %plugin_name, "{}", message),
+                            2 => tracing::info!(plugin = %plugin_name, "{}", message),
+                            _ => tracing::debug!(plugin = %plugin_name, "{}", message),
+                        }
+                    }
+                }
+            },
+        )
+        .map_err(|e| WasmError::Instantiation(format!("failed to add host_log: {}", e)))?;
+
+    // host_context_get
+    linker
+        .func_wrap(
+            "barbacane",
+            "host_context_get",
+            |mut caller: Caller<'_, PluginState>, key_ptr: i32, key_len: i32| -> i32 {
+                let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
+                    Some(m) => m,
+                    None => return -1,
+                };
+
+                let start = key_ptr as usize;
+                let end = start + key_len as usize;
+                let data = memory.data(&caller);
+
+                if end > data.len() {
+                    return -1;
+                }
+
+                let key = match std::str::from_utf8(&data[start..end]) {
+                    Ok(k) => k.to_string(),
+                    Err(_) => return -1,
+                };
+
+                match caller.data().context.values.get(&key).cloned() {
+                    Some(value) => {
+                        let len = value.len() as i32;
+                        caller.data_mut().context.last_get_result = Some(value);
+                        len
+                    }
+                    None => -1,
+                }
+            },
+        )
+        .map_err(|e| WasmError::Instantiation(format!("failed to add host_context_get: {}", e)))?;
+
+    // host_context_read_result
+    linker
+        .func_wrap(
+            "barbacane",
+            "host_context_read_result",
+            |mut caller: Caller<'_, PluginState>, buf_ptr: i32, buf_len: i32| -> i32 {
+                let result = caller.data_mut().context.last_get_result.take();
+                if let Some(value) = result {
+                    let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
+                        Some(m) => m,
+                        None => return 0,
+                    };
+
+                    let bytes = value.as_bytes();
+                    let copy_len = std::cmp::min(bytes.len(), buf_len as usize);
+
+                    if memory
+                        .write(&mut caller, buf_ptr as usize, &bytes[..copy_len])
+                        .is_ok()
+                    {
+                        return copy_len as i32;
+                    }
+                }
+                0
+            },
+        )
+        .map_err(|e| {
+            WasmError::Instantiation(format!("failed to add host_context_read_result: {}", e))
+        })?;
+
+    // host_context_set
+    linker
+        .func_wrap(
+            "barbacane",
+            "host_context_set",
+            |mut caller: Caller<'_, PluginState>,
+             key_ptr: i32,
+             key_len: i32,
+             val_ptr: i32,
+             val_len: i32| {
+                let memory = match caller.get_export("memory").and_then(|e| e.into_memory()) {
+                    Some(m) => m,
+                    None => return,
+                };
+
+                let key_start = key_ptr as usize;
+                let key_end = key_start + key_len as usize;
+                let val_start = val_ptr as usize;
+                let val_end = val_start + val_len as usize;
+
+                // Read data first, then mutate
+                let data = memory.data(&caller);
+                if key_end <= data.len() && val_end <= data.len() {
+                    let key_result = std::str::from_utf8(&data[key_start..key_end]).map(String::from);
+                    let val_result = std::str::from_utf8(&data[val_start..val_end]).map(String::from);
+
+                    if let (Ok(key), Ok(value)) = (key_result, val_result) {
+                        caller.data_mut().context.values.insert(key, value);
+                    }
+                }
+            },
+        )
+        .map_err(|e| WasmError::Instantiation(format!("failed to add host_context_set: {}", e)))?;
+
+    // host_clock_now
+    linker
+        .func_wrap(
+            "barbacane",
+            "host_clock_now",
+            |_caller: Caller<'_, PluginState>| -> i64 {
+                use std::time::Instant;
+
+                static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+                let start = START.get_or_init(Instant::now);
+
+                start.elapsed().as_millis() as i64
+            },
+        )
+        .map_err(|e| WasmError::Instantiation(format!("failed to add host_clock_now: {}", e)))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_context_new() {
+        let ctx = RequestContext::new("trace-123".into(), "req-456".into());
+        assert_eq!(ctx.trace_id, "trace-123");
+        assert_eq!(ctx.request_id, "req-456");
+        assert!(ctx.values.is_empty());
+    }
+
+    #[test]
+    fn plugin_state_take_output() {
+        let limits = PluginLimits::default();
+        let mut state = PluginState::new("test".into(), &limits);
+        state.output_buffer = vec![1, 2, 3];
+
+        let output = state.take_output();
+        assert_eq!(output, vec![1, 2, 3]);
+        assert!(state.output_buffer.is_empty());
+    }
+}

--- a/crates/barbacane-wasm/src/lib.rs
+++ b/crates/barbacane-wasm/src/lib.rs
@@ -14,6 +14,7 @@ mod pool;
 mod schema;
 mod trap;
 mod validate;
+pub mod version;
 
 pub use chain::{
     execute_on_request, execute_on_response, execute_on_response_partial, ChainResult,

--- a/crates/barbacane-wasm/src/lib.rs
+++ b/crates/barbacane-wasm/src/lib.rs
@@ -1,0 +1,33 @@
+//! WASM plugin runtime for Barbacane API gateway.
+//!
+//! This crate provides the wasmtime-based runtime for loading and executing
+//! WASM plugins (middlewares and dispatchers) according to SPEC-003.
+
+mod chain;
+mod engine;
+mod error;
+mod host;
+mod instance;
+mod limits;
+mod manifest;
+mod pool;
+mod schema;
+mod trap;
+mod validate;
+
+pub use chain::{
+    execute_on_request, execute_on_response, execute_on_response_partial, ChainResult,
+    MiddlewareChain, MiddlewareConfig, OnRequestResult,
+};
+pub use engine::WasmEngine;
+pub use error::WasmError;
+pub use instance::{PluginInstance, RequestContext};
+pub use limits::PluginLimits;
+pub use manifest::{Capabilities, PluginManifest, PluginMeta, PluginType};
+pub use pool::InstancePool;
+pub use schema::ConfigSchema;
+pub use trap::{TrapContext, TrapResult};
+pub use validate::{validate_exports, validate_imports};
+
+/// Re-export plugin SDK types for convenience.
+pub use barbacane_plugin_sdk::prelude::{Action, Request, Response};

--- a/crates/barbacane-wasm/src/limits.rs
+++ b/crates/barbacane-wasm/src/limits.rs
@@ -1,0 +1,136 @@
+//! Resource limits for WASM plugin execution.
+//!
+//! Per SPEC-003 section 6.2, each WASM instance is constrained:
+//! - Linear memory: 16 MB
+//! - Execution time per call: 100 ms
+//! - Stack size: 1 MB
+
+/// Resource limits for plugin execution.
+#[derive(Debug, Clone)]
+pub struct PluginLimits {
+    /// Maximum linear memory in bytes (default: 16 MB).
+    pub max_memory_bytes: usize,
+
+    /// Maximum stack size in bytes (default: 1 MB).
+    pub max_stack_bytes: usize,
+
+    /// Maximum execution time per call in milliseconds (default: 100 ms).
+    pub max_execution_ms: u64,
+
+    /// Fuel amount that approximates the execution time limit.
+    /// This is calibrated to roughly correspond to max_execution_ms.
+    pub max_fuel: u64,
+}
+
+impl Default for PluginLimits {
+    fn default() -> Self {
+        Self {
+            max_memory_bytes: 16 * 1024 * 1024,  // 16 MB
+            max_stack_bytes: 1024 * 1024,         // 1 MB
+            max_execution_ms: 100,                // 100 ms
+            // Fuel is calibrated experimentally. This value gives roughly 100ms
+            // on typical hardware. May need adjustment based on benchmarks.
+            max_fuel: 100_000_000,
+        }
+    }
+}
+
+impl PluginLimits {
+    /// Create limits with custom memory size.
+    pub fn with_memory(mut self, bytes: usize) -> Self {
+        self.max_memory_bytes = bytes;
+        self
+    }
+
+    /// Create limits with custom stack size.
+    pub fn with_stack(mut self, bytes: usize) -> Self {
+        self.max_stack_bytes = bytes;
+        self
+    }
+
+    /// Create limits with custom execution timeout.
+    pub fn with_timeout(mut self, ms: u64) -> Self {
+        self.max_execution_ms = ms;
+        // Adjust fuel proportionally
+        self.max_fuel = ms * 1_000_000;
+        self
+    }
+}
+
+/// Resource limiter for wasmtime that enforces memory limits.
+pub struct PluginResourceLimiter {
+    limits: PluginLimits,
+}
+
+impl PluginResourceLimiter {
+    /// Create a new resource limiter with the given limits.
+    pub fn new(limits: PluginLimits) -> Self {
+        Self { limits }
+    }
+}
+
+impl wasmtime::ResourceLimiter for PluginResourceLimiter {
+    fn memory_growing(
+        &mut self,
+        _current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> anyhow::Result<bool> {
+        Ok(desired <= self.limits.max_memory_bytes)
+    }
+
+    fn table_growing(
+        &mut self,
+        _current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> anyhow::Result<bool> {
+        // Allow reasonable table growth (for function references, etc.)
+        Ok(desired <= 10_000)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasmtime::ResourceLimiter;
+
+    #[test]
+    fn default_limits() {
+        let limits = PluginLimits::default();
+        assert_eq!(limits.max_memory_bytes, 16 * 1024 * 1024);
+        assert_eq!(limits.max_stack_bytes, 1024 * 1024);
+        assert_eq!(limits.max_execution_ms, 100);
+    }
+
+    #[test]
+    fn custom_limits() {
+        let limits = PluginLimits::default()
+            .with_memory(32 * 1024 * 1024)
+            .with_stack(2 * 1024 * 1024)
+            .with_timeout(200);
+
+        assert_eq!(limits.max_memory_bytes, 32 * 1024 * 1024);
+        assert_eq!(limits.max_stack_bytes, 2 * 1024 * 1024);
+        assert_eq!(limits.max_execution_ms, 200);
+    }
+
+    #[test]
+    fn resource_limiter_allows_within_limits() {
+        let limits = PluginLimits::default();
+        let mut limiter = PluginResourceLimiter::new(limits);
+
+        // Should allow allocation within limits
+        assert!(limiter.memory_growing(0, 1024 * 1024, None).unwrap());
+        assert!(limiter.memory_growing(0, 16 * 1024 * 1024, None).unwrap());
+    }
+
+    #[test]
+    fn resource_limiter_denies_over_limit() {
+        let limits = PluginLimits::default();
+        let mut limiter = PluginResourceLimiter::new(limits);
+
+        // Should deny allocation over limits
+        assert!(!limiter.memory_growing(0, 17 * 1024 * 1024, None).unwrap());
+    }
+}

--- a/crates/barbacane-wasm/src/manifest.rs
+++ b/crates/barbacane-wasm/src/manifest.rs
@@ -1,0 +1,291 @@
+//! Plugin manifest (plugin.toml) parsing and validation.
+//!
+//! Per SPEC-003 section 2.1, the plugin manifest defines:
+//! - Plugin metadata (name, version, type, description)
+//! - WASM binary path
+//! - Required capabilities (host functions)
+
+use serde::Deserialize;
+
+use crate::error::WasmError;
+
+/// A parsed and validated plugin manifest.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PluginManifest {
+    /// Plugin metadata.
+    pub plugin: PluginMeta,
+
+    /// Plugin capabilities.
+    pub capabilities: Capabilities,
+}
+
+/// Plugin metadata from the [plugin] section.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PluginMeta {
+    /// Unique identifier, lowercase, kebab-case.
+    pub name: String,
+
+    /// Semantic version string.
+    pub version: String,
+
+    /// Plugin type: "middleware" or "dispatcher".
+    #[serde(rename = "type")]
+    pub plugin_type: PluginType,
+
+    /// Optional description for registry display.
+    pub description: Option<String>,
+
+    /// Path to WASM binary, relative to plugin.toml.
+    pub wasm: String,
+}
+
+/// Plugin type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PluginType {
+    /// Middleware plugin (on_request, on_response).
+    Middleware,
+
+    /// Dispatcher plugin (dispatch).
+    Dispatcher,
+}
+
+impl PluginType {
+    /// Get the required WASM exports for this plugin type.
+    pub fn required_exports(&self) -> &'static [&'static str] {
+        match self {
+            PluginType::Middleware => &["init", "on_request", "on_response"],
+            PluginType::Dispatcher => &["init", "dispatch"],
+        }
+    }
+}
+
+/// Plugin capabilities from the [capabilities] section.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Capabilities {
+    /// List of host functions this plugin requires.
+    #[serde(default)]
+    pub host_functions: Vec<String>,
+}
+
+impl PluginManifest {
+    /// Parse a plugin manifest from TOML content.
+    pub fn from_toml(content: &str) -> Result<Self, WasmError> {
+        let manifest: Self = toml::from_str(content)?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    /// Validate the manifest fields.
+    fn validate(&self) -> Result<(), WasmError> {
+        // Validate name: ^[a-z][a-z0-9-]*$, max 64 chars
+        if self.plugin.name.is_empty() || self.plugin.name.len() > 64 {
+            return Err(WasmError::ManifestValidation(
+                "plugin name must be 1-64 characters".into(),
+            ));
+        }
+
+        let name_regex = regex_lite::Regex::new(r"^[a-z][a-z0-9-]*$").unwrap();
+        if !name_regex.is_match(&self.plugin.name) {
+            return Err(WasmError::ManifestValidation(
+                "plugin name must be lowercase, kebab-case (^[a-z][a-z0-9-]*$)".into(),
+            ));
+        }
+
+        // Validate version: valid semver
+        if semver::Version::parse(&self.plugin.version).is_err() {
+            return Err(WasmError::ManifestValidation(format!(
+                "invalid semver version: {}",
+                self.plugin.version
+            )));
+        }
+
+        // Validate description length
+        if let Some(desc) = &self.plugin.description {
+            if desc.len() > 256 {
+                return Err(WasmError::ManifestValidation(
+                    "description must be at most 256 characters".into(),
+                ));
+            }
+        }
+
+        // Validate wasm path is not empty
+        if self.plugin.wasm.is_empty() {
+            return Err(WasmError::ManifestValidation(
+                "wasm path cannot be empty".into(),
+            ));
+        }
+
+        // Validate host functions are known
+        for func in &self.capabilities.host_functions {
+            if !is_known_capability(func) {
+                return Err(WasmError::UnknownCapability(func.clone()));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check if this plugin declares a specific capability.
+    pub fn has_capability(&self, capability: &str) -> bool {
+        self.capabilities.host_functions.iter().any(|c| c == capability)
+    }
+}
+
+/// Known host function capability names.
+const KNOWN_CAPABILITIES: &[&str] = &[
+    "log",
+    "context_get",
+    "context_set",
+    "clock_now",
+    "get_secret",
+    "http_call",
+    "kafka_publish",
+    "nats_publish",
+    "telemetry",
+];
+
+/// Check if a capability name is known.
+fn is_known_capability(name: &str) -> bool {
+    KNOWN_CAPABILITIES.contains(&name)
+}
+
+/// Get the host function names for a capability.
+pub fn capability_to_imports(capability: &str) -> &'static [&'static str] {
+    match capability {
+        "log" => &["host_log"],
+        "context_get" => &["host_context_get", "host_context_read_result"],
+        "context_set" => &["host_context_set"],
+        "clock_now" => &["host_clock_now"],
+        "get_secret" => &["host_get_secret", "host_secret_read_result"],
+        "http_call" => &["host_http_call", "host_http_read_result"],
+        "kafka_publish" => &["host_kafka_publish"],
+        "nats_publish" => &["host_nats_publish"],
+        "telemetry" => &[
+            "host_metric_counter_inc",
+            "host_metric_histogram_observe",
+            "host_span_start",
+            "host_span_end",
+            "host_span_set_attribute",
+        ],
+        _ => &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_MANIFEST: &str = r#"
+[plugin]
+name = "my-plugin"
+version = "1.0.0"
+type = "middleware"
+description = "A test plugin"
+wasm = "my_plugin.wasm"
+
+[capabilities]
+host_functions = ["log", "context_get"]
+"#;
+
+    #[test]
+    fn parse_valid_manifest() {
+        let manifest = PluginManifest::from_toml(VALID_MANIFEST).unwrap();
+        assert_eq!(manifest.plugin.name, "my-plugin");
+        assert_eq!(manifest.plugin.version, "1.0.0");
+        assert_eq!(manifest.plugin.plugin_type, PluginType::Middleware);
+        assert_eq!(manifest.plugin.description, Some("A test plugin".into()));
+        assert_eq!(manifest.plugin.wasm, "my_plugin.wasm");
+        assert_eq!(manifest.capabilities.host_functions.len(), 2);
+    }
+
+    #[test]
+    fn parse_dispatcher_manifest() {
+        let manifest_str = r#"
+[plugin]
+name = "http-upstream"
+version = "2.0.0"
+type = "dispatcher"
+wasm = "http_upstream.wasm"
+
+[capabilities]
+host_functions = ["http_call", "log"]
+"#;
+        let manifest = PluginManifest::from_toml(manifest_str).unwrap();
+        assert_eq!(manifest.plugin.plugin_type, PluginType::Dispatcher);
+    }
+
+    #[test]
+    fn reject_invalid_name() {
+        let manifest_str = r#"
+[plugin]
+name = "MyPlugin"
+version = "1.0.0"
+type = "middleware"
+wasm = "my_plugin.wasm"
+
+[capabilities]
+host_functions = []
+"#;
+        let result = PluginManifest::from_toml(manifest_str);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("kebab-case"));
+    }
+
+    #[test]
+    fn reject_invalid_version() {
+        let manifest_str = r#"
+[plugin]
+name = "my-plugin"
+version = "not-semver"
+type = "middleware"
+wasm = "my_plugin.wasm"
+
+[capabilities]
+host_functions = []
+"#;
+        let result = PluginManifest::from_toml(manifest_str);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("semver"));
+    }
+
+    #[test]
+    fn reject_unknown_capability() {
+        let manifest_str = r#"
+[plugin]
+name = "my-plugin"
+version = "1.0.0"
+type = "middleware"
+wasm = "my_plugin.wasm"
+
+[capabilities]
+host_functions = ["unknown_function"]
+"#;
+        let result = PluginManifest::from_toml(manifest_str);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), WasmError::UnknownCapability(_)));
+    }
+
+    #[test]
+    fn has_capability() {
+        let manifest = PluginManifest::from_toml(VALID_MANIFEST).unwrap();
+        assert!(manifest.has_capability("log"));
+        assert!(manifest.has_capability("context_get"));
+        assert!(!manifest.has_capability("http_call"));
+    }
+
+    #[test]
+    fn required_exports_middleware() {
+        let exports = PluginType::Middleware.required_exports();
+        assert!(exports.contains(&"init"));
+        assert!(exports.contains(&"on_request"));
+        assert!(exports.contains(&"on_response"));
+    }
+
+    #[test]
+    fn required_exports_dispatcher() {
+        let exports = PluginType::Dispatcher.required_exports();
+        assert!(exports.contains(&"init"));
+        assert!(exports.contains(&"dispatch"));
+    }
+}

--- a/crates/barbacane-wasm/src/pool.rs
+++ b/crates/barbacane-wasm/src/pool.rs
@@ -1,0 +1,186 @@
+//! Instance pooling for WASM plugins.
+//!
+//! Per SPEC-003 section 6.1, each (plugin name, config) pair produces a
+//! separate WASM instance. Under load, instances are cloned from the
+//! AOT-compiled module.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use sha2::{Digest, Sha256};
+
+use crate::engine::{CompiledModule, WasmEngine};
+use crate::error::WasmError;
+use crate::instance::PluginInstance;
+use crate::limits::PluginLimits;
+
+/// Key for identifying a plugin instance.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InstanceKey {
+    /// Plugin name.
+    pub name: String,
+
+    /// Hash of the serialized config for deduplication.
+    pub config_hash: String,
+}
+
+impl InstanceKey {
+    /// Create an instance key from a plugin name and config.
+    pub fn new(name: &str, config: &serde_json::Value) -> Self {
+        let config_str = serde_json::to_string(config).unwrap_or_default();
+        let config_hash = compute_hash(&config_str);
+
+        Self {
+            name: name.to_string(),
+            config_hash,
+        }
+    }
+}
+
+/// Compute a short hash of the given string.
+fn compute_hash(s: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    let result = hasher.finalize();
+    // Use first 16 chars of hex for reasonable uniqueness
+    hex::encode(&result[..8])
+}
+
+/// A resolved plugin ready for instantiation.
+pub struct ResolvedPlugin {
+    /// The compiled WASM module.
+    pub module: CompiledModule,
+
+    /// The plugin config (JSON).
+    pub config: serde_json::Value,
+
+    /// Pre-serialized config for passing to init.
+    pub config_json: Vec<u8>,
+}
+
+/// Pool of WASM plugin instances.
+///
+/// Maintains a cache of compiled modules and manages instance creation.
+pub struct InstancePool {
+    /// The WASM engine.
+    engine: Arc<WasmEngine>,
+
+    /// Resource limits for instances.
+    limits: PluginLimits,
+
+    /// Cache of compiled modules by plugin name.
+    modules: DashMap<String, CompiledModule>,
+
+    /// Cache of initialized instances by key.
+    /// In a production implementation, this would be a proper pool with
+    /// checkout/return semantics. For now, we create new instances.
+    instances: DashMap<InstanceKey, ()>,
+
+    /// Plugin configs by key.
+    configs: DashMap<InstanceKey, Vec<u8>>,
+}
+
+impl InstancePool {
+    /// Create a new instance pool.
+    pub fn new(engine: Arc<WasmEngine>, limits: PluginLimits) -> Self {
+        Self {
+            engine,
+            limits,
+            modules: DashMap::new(),
+            instances: DashMap::new(),
+            configs: DashMap::new(),
+        }
+    }
+
+    /// Register a compiled module in the pool.
+    pub fn register_module(&self, module: CompiledModule) {
+        self.modules.insert(module.name.clone(), module);
+    }
+
+    /// Register a plugin config.
+    pub fn register_config(&self, key: InstanceKey, config_json: Vec<u8>) {
+        self.configs.insert(key.clone(), config_json);
+        self.instances.insert(key, ());
+    }
+
+    /// Get or create an instance for the given key.
+    pub fn get_instance(&self, key: &InstanceKey) -> Result<PluginInstance, WasmError> {
+        // Get the compiled module
+        let module = self
+            .modules
+            .get(&key.name)
+            .ok_or_else(|| WasmError::InitFailed(format!("plugin not found: {}", key.name)))?;
+
+        // Get the config
+        let config_json = self
+            .configs
+            .get(key)
+            .ok_or_else(|| WasmError::InitFailed(format!("config not found for: {}", key.name)))?;
+
+        // Create a new instance
+        let mut instance =
+            PluginInstance::new(self.engine.engine(), &module, self.limits.clone())?;
+
+        // Initialize with config
+        let result = instance.init(&config_json)?;
+        if result != 0 {
+            return Err(WasmError::InitFailed(format!(
+                "plugin {} init returned {}",
+                key.name, result
+            )));
+        }
+
+        Ok(instance)
+    }
+
+    /// Check if a plugin is registered.
+    pub fn has_plugin(&self, name: &str) -> bool {
+        self.modules.contains_key(name)
+    }
+
+    /// Get the number of registered modules.
+    pub fn module_count(&self) -> usize {
+        self.modules.len()
+    }
+
+    /// Get the number of registered instance keys.
+    pub fn instance_key_count(&self) -> usize {
+        self.instances.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn instance_key_from_config() {
+        let key1 = InstanceKey::new("rate-limit", &json!({"quota": 100, "window": 60}));
+        let key2 = InstanceKey::new("rate-limit", &json!({"quota": 100, "window": 60}));
+        let key3 = InstanceKey::new("rate-limit", &json!({"quota": 200, "window": 60}));
+
+        // Same config should produce same key
+        assert_eq!(key1, key2);
+
+        // Different config should produce different key
+        assert_ne!(key1, key3);
+    }
+
+    #[test]
+    fn instance_key_different_plugins() {
+        let key1 = InstanceKey::new("plugin-a", &json!({}));
+        let key2 = InstanceKey::new("plugin-b", &json!({}));
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn create_pool() {
+        let engine = Arc::new(WasmEngine::new().unwrap());
+        let pool = InstancePool::new(engine, PluginLimits::default());
+
+        assert_eq!(pool.module_count(), 0);
+        assert_eq!(pool.instance_key_count(), 0);
+    }
+}

--- a/crates/barbacane-wasm/src/schema.rs
+++ b/crates/barbacane-wasm/src/schema.rs
@@ -1,0 +1,142 @@
+//! Config schema validation for plugins.
+//!
+//! Per SPEC-003 section 2.2, each plugin has a config-schema.json that
+//! defines the JSON Schema for its configuration block in specs.
+
+use jsonschema::Validator;
+use serde_json::Value;
+
+use crate::error::WasmError;
+
+/// A compiled config schema for validating plugin configurations.
+pub struct ConfigSchema {
+    validator: Validator,
+}
+
+impl ConfigSchema {
+    /// Create a config schema from JSON Schema content.
+    pub fn from_json(schema_json: &str) -> Result<Self, WasmError> {
+        let schema: Value =
+            serde_json::from_str(schema_json).map_err(|e| WasmError::SchemaParse(e.to_string()))?;
+
+        let validator = Validator::new(&schema)
+            .map_err(|e| WasmError::SchemaParse(format!("invalid JSON Schema: {}", e)))?;
+
+        Ok(Self { validator })
+    }
+
+    /// Create a config schema from a parsed JSON value.
+    pub fn from_value(schema: &Value) -> Result<Self, WasmError> {
+        let validator = Validator::new(schema)
+            .map_err(|e| WasmError::SchemaParse(format!("invalid JSON Schema: {}", e)))?;
+
+        Ok(Self { validator })
+    }
+
+    /// Validate a config value against the schema.
+    pub fn validate(&self, config: &Value) -> Result<(), WasmError> {
+        self.validator
+            .validate(config)
+            .map_err(|e| WasmError::ConfigValidation(e.to_string()))
+    }
+
+    /// Create an empty schema that accepts any object.
+    ///
+    /// Per SPEC-003, if a plugin takes no config, the schema should be:
+    /// ```json
+    /// { "type": "object", "additionalProperties": false }
+    /// ```
+    pub fn empty() -> Result<Self, WasmError> {
+        Self::from_json(r#"{"type": "object", "additionalProperties": false}"#)
+    }
+
+    /// Create a permissive schema that accepts any value.
+    ///
+    /// Useful for testing or when no schema is provided.
+    pub fn any() -> Result<Self, WasmError> {
+        Self::from_json("{}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn validate_against_schema() {
+        let schema = ConfigSchema::from_json(
+            r#"{
+            "type": "object",
+            "required": ["quota", "window"],
+            "properties": {
+                "quota": { "type": "integer", "minimum": 1 },
+                "window": { "type": "integer", "minimum": 1 }
+            }
+        }"#,
+        )
+        .unwrap();
+
+        // Valid config
+        let valid = json!({"quota": 100, "window": 60});
+        assert!(schema.validate(&valid).is_ok());
+
+        // Missing required field
+        let missing = json!({"quota": 100});
+        assert!(schema.validate(&missing).is_err());
+
+        // Invalid type
+        let wrong_type = json!({"quota": "100", "window": 60});
+        assert!(schema.validate(&wrong_type).is_err());
+
+        // Value too low
+        let too_low = json!({"quota": 0, "window": 60});
+        assert!(schema.validate(&too_low).is_err());
+    }
+
+    #[test]
+    fn empty_schema_rejects_properties() {
+        let schema = ConfigSchema::empty().unwrap();
+
+        // Empty object is valid
+        assert!(schema.validate(&json!({})).is_ok());
+
+        // Object with properties is invalid
+        assert!(schema.validate(&json!({"foo": "bar"})).is_err());
+    }
+
+    #[test]
+    fn any_schema_accepts_anything() {
+        let schema = ConfigSchema::any().unwrap();
+
+        assert!(schema.validate(&json!({})).is_ok());
+        assert!(schema.validate(&json!({"anything": "goes"})).is_ok());
+        assert!(schema.validate(&json!(null)).is_ok());
+        assert!(schema.validate(&json!(42)).is_ok());
+    }
+
+    #[test]
+    fn from_value() {
+        let schema_value = json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            }
+        });
+
+        let schema = ConfigSchema::from_value(&schema_value).unwrap();
+        assert!(schema.validate(&json!({"name": "test"})).is_ok());
+    }
+
+    #[test]
+    fn invalid_schema() {
+        // This is not a valid JSON Schema
+        let result = ConfigSchema::from_json(r#"{"type": "not-a-type"}"#);
+        // Note: jsonschema may accept this but fail on validation
+        // The important thing is we handle errors gracefully
+        match result {
+            Ok(_) => {} // Some schemas are permissive
+            Err(e) => assert!(e.to_string().contains("Schema") || e.to_string().contains("invalid")),
+        }
+    }
+}

--- a/crates/barbacane-wasm/src/trap.rs
+++ b/crates/barbacane-wasm/src/trap.rs
@@ -1,0 +1,131 @@
+//! WASM trap handling and error recovery.
+//!
+//! Per SPEC-003 section 6.4, error handling differs by phase:
+//! - Request phase (on_request, dispatch): traps produce 500
+//! - Response phase (on_response): traps are fault-tolerant, log and continue
+
+/// The context in which a WASM trap occurred.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrapContext {
+    /// During plugin initialization.
+    Init,
+    /// During request processing (on_request).
+    OnRequest,
+    /// During response processing (on_response).
+    OnResponse,
+    /// During dispatch.
+    Dispatch,
+}
+
+impl TrapContext {
+    /// Returns true if this context is fault-tolerant.
+    ///
+    /// Only the response phase is fault-tolerant; traps during on_response
+    /// should log the error and continue with the original response.
+    pub fn is_fault_tolerant(&self) -> bool {
+        matches!(self, TrapContext::OnResponse)
+    }
+}
+
+/// The result of handling a WASM trap.
+#[derive(Debug)]
+pub enum TrapResult {
+    /// Fatal error - should return 500 to client.
+    Fatal {
+        /// Human-readable error message.
+        message: String,
+        /// The context where the trap occurred.
+        context: TrapContext,
+    },
+
+    /// Fault-tolerant - log and continue with original response.
+    FaultTolerant {
+        /// Human-readable error message for logging.
+        message: String,
+    },
+}
+
+impl TrapResult {
+    /// Create a trap result from an error and context.
+    pub fn from_error<E: std::fmt::Display>(error: E, context: TrapContext) -> Self {
+        let message = error.to_string();
+
+        if context.is_fault_tolerant() {
+            TrapResult::FaultTolerant { message }
+        } else {
+            TrapResult::Fatal { message, context }
+        }
+    }
+
+    /// Returns true if this is a fatal error.
+    pub fn is_fatal(&self) -> bool {
+        matches!(self, TrapResult::Fatal { .. })
+    }
+
+    /// Get the error message.
+    pub fn message(&self) -> &str {
+        match self {
+            TrapResult::Fatal { message, .. } => message,
+            TrapResult::FaultTolerant { message } => message,
+        }
+    }
+}
+
+/// Classify a wasmtime trap into a human-readable category.
+pub fn classify_trap(trap: &wasmtime::Trap) -> &'static str {
+    // wasmtime::Trap is now opaque, so we examine the message
+    let msg = trap.to_string();
+
+    if msg.contains("out of fuel") {
+        "execution timeout"
+    } else if msg.contains("unreachable") {
+        "unreachable code executed (likely panic)"
+    } else if msg.contains("memory") {
+        "memory access error"
+    } else if msg.contains("stack overflow") {
+        "stack overflow"
+    } else if msg.contains("indirect call") {
+        "invalid indirect call"
+    } else if msg.contains("integer") {
+        "integer overflow or division error"
+    } else {
+        "unknown trap"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_is_fatal() {
+        let result = TrapResult::from_error("init failed", TrapContext::Init);
+        assert!(result.is_fatal());
+    }
+
+    #[test]
+    fn on_request_is_fatal() {
+        let result = TrapResult::from_error("request failed", TrapContext::OnRequest);
+        assert!(result.is_fatal());
+    }
+
+    #[test]
+    fn dispatch_is_fatal() {
+        let result = TrapResult::from_error("dispatch failed", TrapContext::Dispatch);
+        assert!(result.is_fatal());
+    }
+
+    #[test]
+    fn on_response_is_fault_tolerant() {
+        let result = TrapResult::from_error("response failed", TrapContext::OnResponse);
+        assert!(!result.is_fatal());
+    }
+
+    #[test]
+    fn trap_context_fault_tolerance() {
+        assert!(!TrapContext::Init.is_fault_tolerant());
+        assert!(!TrapContext::OnRequest.is_fault_tolerant());
+        assert!(!TrapContext::Dispatch.is_fault_tolerant());
+        assert!(TrapContext::OnResponse.is_fault_tolerant());
+    }
+}

--- a/crates/barbacane-wasm/src/validate.rs
+++ b/crates/barbacane-wasm/src/validate.rs
@@ -59,13 +59,10 @@ pub fn validate_imports(
         }
     }
 
-    // Check each import
+    // Check each import from the "barbacane" module
     for import in module.imports() {
-        // Only check imports from the "barbacane" module
-        if import.module() == "barbacane" {
-            if !allowed.contains(import.name()) {
-                return Err(WasmError::UndeclaredImport(import.name().into()));
-            }
+        if import.module() == "barbacane" && !allowed.contains(import.name()) {
+            return Err(WasmError::UndeclaredImport(import.name().into()));
         }
     }
 

--- a/crates/barbacane-wasm/src/validate.rs
+++ b/crates/barbacane-wasm/src/validate.rs
@@ -1,0 +1,209 @@
+//! WASM module validation for exports and imports.
+//!
+//! Per SPEC-003:
+//! - Section 3: Plugins must export specific functions based on type
+//! - Section 4: Plugins can only import declared host functions
+
+use std::collections::HashSet;
+
+use wasmtime::Module;
+
+use crate::error::WasmError;
+use crate::manifest::{capability_to_imports, PluginType};
+
+/// Validate that a WASM module exports the required functions for its type.
+pub fn validate_exports(module: &Module, plugin_type: PluginType) -> Result<(), WasmError> {
+    let exports: HashSet<&str> = module.exports().map(|e| e.name()).collect();
+
+    // All plugins must export memory
+    if !exports.contains("memory") {
+        return Err(WasmError::MissingExport("memory".into()));
+    }
+
+    // Check type-specific required exports
+    for required in plugin_type.required_exports() {
+        if !exports.contains(required) {
+            return Err(WasmError::MissingExport((*required).into()));
+        }
+    }
+
+    // Validate export signatures
+    for export in module.exports() {
+        match export.name() {
+            "init" => validate_init_signature(&export)?,
+            "on_request" => validate_on_request_signature(&export)?,
+            "on_response" => validate_on_response_signature(&export)?,
+            "dispatch" => validate_dispatch_signature(&export)?,
+            _ => {} // Ignore other exports
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate that a WASM module only imports declared host functions.
+pub fn validate_imports(
+    module: &Module,
+    declared_capabilities: &[String],
+) -> Result<(), WasmError> {
+    // Build the set of allowed imports
+    let mut allowed: HashSet<&str> = HashSet::new();
+
+    // host_set_output is always allowed (not a capability)
+    allowed.insert("host_set_output");
+
+    // Add imports for each declared capability
+    for capability in declared_capabilities {
+        for import_name in capability_to_imports(capability) {
+            allowed.insert(import_name);
+        }
+    }
+
+    // Check each import
+    for import in module.imports() {
+        // Only check imports from the "barbacane" module
+        if import.module() == "barbacane" {
+            if !allowed.contains(import.name()) {
+                return Err(WasmError::UndeclaredImport(import.name().into()));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate the signature of the `init` export.
+/// Expected: (config_ptr: i32, config_len: i32) -> i32
+fn validate_init_signature(export: &wasmtime::ExportType) -> Result<(), WasmError> {
+    let func = match export.ty() {
+        wasmtime::ExternType::Func(f) => f,
+        _ => {
+            return Err(WasmError::InvalidExportSignature {
+                name: "init".into(),
+                expected: "function".into(),
+                actual: format!("{:?}", export.ty()),
+            })
+        }
+    };
+
+    // Check params: (i32, i32)
+    let params: Vec<_> = func.params().collect();
+    if params.len() != 2
+        || !matches!(params[0], wasmtime::ValType::I32)
+        || !matches!(params[1], wasmtime::ValType::I32)
+    {
+        return Err(WasmError::InvalidExportSignature {
+            name: "init".into(),
+            expected: "(i32, i32) -> i32".into(),
+            actual: format!("{:?}", func),
+        });
+    }
+
+    // Check results: (i32)
+    let results: Vec<_> = func.results().collect();
+    if results.len() != 1 || !matches!(results[0], wasmtime::ValType::I32) {
+        return Err(WasmError::InvalidExportSignature {
+            name: "init".into(),
+            expected: "(i32, i32) -> i32".into(),
+            actual: format!("{:?}", func),
+        });
+    }
+
+    Ok(())
+}
+
+/// Validate the signature of the `on_request` export.
+/// Expected: (request_ptr: i32, request_len: i32) -> i32
+fn validate_on_request_signature(export: &wasmtime::ExportType) -> Result<(), WasmError> {
+    validate_standard_handler_signature(export, "on_request")
+}
+
+/// Validate the signature of the `on_response` export.
+/// Expected: (response_ptr: i32, response_len: i32) -> i32
+fn validate_on_response_signature(export: &wasmtime::ExportType) -> Result<(), WasmError> {
+    validate_standard_handler_signature(export, "on_response")
+}
+
+/// Validate the signature of the `dispatch` export.
+/// Expected: (request_ptr: i32, request_len: i32) -> i32
+fn validate_dispatch_signature(export: &wasmtime::ExportType) -> Result<(), WasmError> {
+    validate_standard_handler_signature(export, "dispatch")
+}
+
+/// Validate a standard handler signature: (ptr: i32, len: i32) -> i32
+fn validate_standard_handler_signature(
+    export: &wasmtime::ExportType,
+    name: &str,
+) -> Result<(), WasmError> {
+    let func = match export.ty() {
+        wasmtime::ExternType::Func(f) => f,
+        _ => {
+            return Err(WasmError::InvalidExportSignature {
+                name: name.into(),
+                expected: "function".into(),
+                actual: format!("{:?}", export.ty()),
+            })
+        }
+    };
+
+    let params: Vec<_> = func.params().collect();
+    if params.len() != 2
+        || !matches!(params[0], wasmtime::ValType::I32)
+        || !matches!(params[1], wasmtime::ValType::I32)
+    {
+        return Err(WasmError::InvalidExportSignature {
+            name: name.into(),
+            expected: "(i32, i32) -> i32".into(),
+            actual: format!("{:?}", func),
+        });
+    }
+
+    let results: Vec<_> = func.results().collect();
+    if results.len() != 1 || !matches!(results[0], wasmtime::ValType::I32) {
+        return Err(WasmError::InvalidExportSignature {
+            name: name.into(),
+            expected: "(i32, i32) -> i32".into(),
+            actual: format!("{:?}", func),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests require actual WASM modules with proper exports,
+    // which would be created by the plugin SDK. For now, we test
+    // the logic with unit tests on the helper functions.
+
+    #[test]
+    fn capability_to_imports_log() {
+        let imports = capability_to_imports("log");
+        assert!(imports.contains(&"host_log"));
+    }
+
+    #[test]
+    fn capability_to_imports_context() {
+        let imports = capability_to_imports("context_get");
+        assert!(imports.contains(&"host_context_get"));
+        assert!(imports.contains(&"host_context_read_result"));
+
+        let imports = capability_to_imports("context_set");
+        assert!(imports.contains(&"host_context_set"));
+    }
+
+    #[test]
+    fn capability_to_imports_telemetry() {
+        let imports = capability_to_imports("telemetry");
+        assert!(imports.contains(&"host_metric_counter_inc"));
+        assert!(imports.contains(&"host_span_start"));
+    }
+
+    #[test]
+    fn unknown_capability_returns_empty() {
+        let imports = capability_to_imports("unknown");
+        assert!(imports.is_empty());
+    }
+}

--- a/crates/barbacane-wasm/src/version.rs
+++ b/crates/barbacane-wasm/src/version.rs
@@ -1,0 +1,262 @@
+//! Plugin version resolution.
+//!
+//! Supports version specifiers:
+//! - `name` - latest version
+//! - `name@1.0.0` - exact version
+//! - `name@^1.0.0` - semver compatible (>=1.0.0, <2.0.0)
+//! - `name@~1.0.0` - patch compatible (>=1.0.0, <1.1.0)
+
+use semver::{Version, VersionReq};
+
+/// A parsed plugin reference with name and optional version constraint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginRef {
+    /// Plugin name (kebab-case).
+    pub name: String,
+    /// Version constraint (None = latest).
+    pub version: Option<VersionConstraint>,
+}
+
+/// A version constraint for plugin resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionConstraint {
+    /// Exact version match.
+    Exact(Version),
+    /// Semver range (e.g., ^1.0.0, ~1.0.0, >=1.0.0).
+    Range(VersionReq),
+}
+
+impl PluginRef {
+    /// Parse a plugin reference string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use barbacane_wasm::version::PluginRef;
+    ///
+    /// let ref1 = PluginRef::parse("rate-limit").unwrap();
+    /// assert_eq!(ref1.name, "rate-limit");
+    /// assert!(ref1.version.is_none());
+    ///
+    /// let ref2 = PluginRef::parse("rate-limit@1.0.0").unwrap();
+    /// assert_eq!(ref2.name, "rate-limit");
+    /// assert!(ref2.version.is_some());
+    /// ```
+    pub fn parse(s: &str) -> Result<Self, VersionError> {
+        if let Some(at_pos) = s.find('@') {
+            let name = s[..at_pos].to_string();
+            let version_str = &s[at_pos + 1..];
+
+            if name.is_empty() {
+                return Err(VersionError::EmptyName);
+            }
+
+            let version = parse_version_constraint(version_str)?;
+
+            Ok(PluginRef {
+                name,
+                version: Some(version),
+            })
+        } else {
+            if s.is_empty() {
+                return Err(VersionError::EmptyName);
+            }
+
+            Ok(PluginRef {
+                name: s.to_string(),
+                version: None,
+            })
+        }
+    }
+
+    /// Check if a specific version matches this constraint.
+    pub fn matches(&self, version: &Version) -> bool {
+        match &self.version {
+            None => true, // No constraint = matches any version
+            Some(VersionConstraint::Exact(v)) => v == version,
+            Some(VersionConstraint::Range(req)) => req.matches(version),
+        }
+    }
+
+    /// Select the best matching version from a list of available versions.
+    ///
+    /// Returns the highest version that matches the constraint.
+    pub fn select_version<'a>(&self, available: &'a [Version]) -> Option<&'a Version> {
+        let mut matching: Vec<_> = available.iter().filter(|v| self.matches(v)).collect();
+
+        // Sort descending to get highest version first
+        matching.sort_by(|a, b| b.cmp(a));
+
+        matching.first().copied()
+    }
+}
+
+/// Parse a version constraint string.
+fn parse_version_constraint(s: &str) -> Result<VersionConstraint, VersionError> {
+    // Check for range prefixes
+    if s.starts_with('^') || s.starts_with('~') || s.starts_with('>') || s.starts_with('<') || s.starts_with('=')
+    {
+        let req = VersionReq::parse(s).map_err(|e| VersionError::InvalidRange(e.to_string()))?;
+        Ok(VersionConstraint::Range(req))
+    } else {
+        // Try parsing as exact version
+        let version =
+            Version::parse(s).map_err(|e| VersionError::InvalidVersion(e.to_string()))?;
+        Ok(VersionConstraint::Exact(version))
+    }
+}
+
+/// Errors that can occur during version parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionError {
+    /// Plugin name is empty.
+    EmptyName,
+    /// Invalid version string.
+    InvalidVersion(String),
+    /// Invalid version range.
+    InvalidRange(String),
+}
+
+impl std::fmt::Display for VersionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VersionError::EmptyName => write!(f, "plugin name cannot be empty"),
+            VersionError::InvalidVersion(e) => write!(f, "invalid version: {}", e),
+            VersionError::InvalidRange(e) => write!(f, "invalid version range: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for VersionError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_name_only() {
+        let r = PluginRef::parse("rate-limit").unwrap();
+        assert_eq!(r.name, "rate-limit");
+        assert!(r.version.is_none());
+    }
+
+    #[test]
+    fn parse_exact_version() {
+        let r = PluginRef::parse("rate-limit@1.0.0").unwrap();
+        assert_eq!(r.name, "rate-limit");
+        assert!(matches!(r.version, Some(VersionConstraint::Exact(_))));
+    }
+
+    #[test]
+    fn parse_caret_range() {
+        let r = PluginRef::parse("rate-limit@^1.0.0").unwrap();
+        assert_eq!(r.name, "rate-limit");
+        assert!(matches!(r.version, Some(VersionConstraint::Range(_))));
+    }
+
+    #[test]
+    fn parse_tilde_range() {
+        let r = PluginRef::parse("rate-limit@~1.0.0").unwrap();
+        assert_eq!(r.name, "rate-limit");
+        assert!(matches!(r.version, Some(VersionConstraint::Range(_))));
+    }
+
+    #[test]
+    fn parse_gte_range() {
+        let r = PluginRef::parse("rate-limit@>=1.0.0").unwrap();
+        assert_eq!(r.name, "rate-limit");
+        assert!(matches!(r.version, Some(VersionConstraint::Range(_))));
+    }
+
+    #[test]
+    fn parse_empty_name_fails() {
+        let r = PluginRef::parse("");
+        assert!(matches!(r, Err(VersionError::EmptyName)));
+    }
+
+    #[test]
+    fn parse_empty_name_with_at_fails() {
+        let r = PluginRef::parse("@1.0.0");
+        assert!(matches!(r, Err(VersionError::EmptyName)));
+    }
+
+    #[test]
+    fn parse_invalid_version_fails() {
+        let r = PluginRef::parse("rate-limit@not-a-version");
+        assert!(matches!(r, Err(VersionError::InvalidVersion(_))));
+    }
+
+    #[test]
+    fn matches_no_constraint() {
+        let r = PluginRef::parse("rate-limit").unwrap();
+        assert!(r.matches(&Version::parse("1.0.0").unwrap()));
+        assert!(r.matches(&Version::parse("2.0.0").unwrap()));
+        assert!(r.matches(&Version::parse("0.1.0").unwrap()));
+    }
+
+    #[test]
+    fn matches_exact_version() {
+        let r = PluginRef::parse("rate-limit@1.0.0").unwrap();
+        assert!(r.matches(&Version::parse("1.0.0").unwrap()));
+        assert!(!r.matches(&Version::parse("1.0.1").unwrap()));
+        assert!(!r.matches(&Version::parse("2.0.0").unwrap()));
+    }
+
+    #[test]
+    fn matches_caret_range() {
+        let r = PluginRef::parse("rate-limit@^1.0.0").unwrap();
+        assert!(r.matches(&Version::parse("1.0.0").unwrap()));
+        assert!(r.matches(&Version::parse("1.5.0").unwrap()));
+        assert!(r.matches(&Version::parse("1.9.9").unwrap()));
+        assert!(!r.matches(&Version::parse("2.0.0").unwrap()));
+        assert!(!r.matches(&Version::parse("0.9.0").unwrap()));
+    }
+
+    #[test]
+    fn matches_tilde_range() {
+        let r = PluginRef::parse("rate-limit@~1.2.0").unwrap();
+        assert!(r.matches(&Version::parse("1.2.0").unwrap()));
+        assert!(r.matches(&Version::parse("1.2.5").unwrap()));
+        assert!(!r.matches(&Version::parse("1.3.0").unwrap()));
+        assert!(!r.matches(&Version::parse("2.0.0").unwrap()));
+    }
+
+    #[test]
+    fn select_version_highest() {
+        let r = PluginRef::parse("rate-limit@^1.0.0").unwrap();
+        let versions = vec![
+            Version::parse("1.0.0").unwrap(),
+            Version::parse("1.2.0").unwrap(),
+            Version::parse("1.5.0").unwrap(),
+            Version::parse("2.0.0").unwrap(),
+        ];
+
+        let selected = r.select_version(&versions);
+        assert_eq!(selected, Some(&Version::parse("1.5.0").unwrap()));
+    }
+
+    #[test]
+    fn select_version_no_match() {
+        let r = PluginRef::parse("rate-limit@^3.0.0").unwrap();
+        let versions = vec![
+            Version::parse("1.0.0").unwrap(),
+            Version::parse("2.0.0").unwrap(),
+        ];
+
+        let selected = r.select_version(&versions);
+        assert!(selected.is_none());
+    }
+
+    #[test]
+    fn select_version_latest_when_no_constraint() {
+        let r = PluginRef::parse("rate-limit").unwrap();
+        let versions = vec![
+            Version::parse("1.0.0").unwrap(),
+            Version::parse("2.0.0").unwrap(),
+            Version::parse("1.5.0").unwrap(),
+        ];
+
+        let selected = r.select_version(&versions);
+        assert_eq!(selected, Some(&Version::parse("2.0.0").unwrap()));
+    }
+}

--- a/crates/barbacane/Cargo.toml
+++ b/crates/barbacane/Cargo.toml
@@ -10,6 +10,7 @@ barbacane-compiler = { workspace = true }
 barbacane-router = { workspace = true }
 barbacane-validator = { workspace = true }
 barbacane-spec-parser = { workspace = true }
+barbacane-wasm = { workspace = true }
 tokio = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
@@ -20,3 +21,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 clap = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }


### PR DESCRIPTION
## Summary

Implements the WASM plugin system per SPEC-003, enabling extensible middlewares and dispatchers via wasmtime.

- **New crate: `barbacane-wasm`** — wasmtime-based runtime with AOT compilation, instance pooling, and resource limits (16MB RAM, 1MB stack, 100ms timeout)
- **New crate: `barbacane-plugin-macros`** — proc macros (`#[barbacane_middleware]`, `#[barbacane_dispatcher]`) for plugin development
- **Host functions** — `host_set_output`, `host_log`, `host_context_get/set`, `host_clock_now`
- **Middleware chain** — ordered `on_request` calls, reverse `on_response` calls, short-circuit support
- **Plugin manifest** — `plugin.toml` parsing with capability declarations and config schema validation
- **Version resolution** — semver support (`name`, `name@1.0.0`, `name@^1.0.0`, `name@~1.0.0`)
- **Artifact bundling** — WASM files bundled in `plugins/` directory with SHA-256 checksums

### Deferred to M8
- `barbacane-control plugin register` CLI
- Compiler plugin resolution (E1020-E1024 checks)

## Test plan
- [x] All 132 workspace tests passing
- [x] Clippy clean (only expected dead_code warnings for future host functions)
- [ ] Integration tests with real WASM plugins (requires M4 for http-upstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)