### PR TITLE
M11: Production readiness, HTTP/2 & repository review

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Pre-commit hook for Barbacane
+# Checks formatting and lints before allowing commit
+
+set -e
+
+echo "Running pre-commit checks..."
+
+# Source cargo environment if available
+if [ -f "$HOME/.cargo/env" ]; then
+    source "$HOME/.cargo/env"
+fi
+
+# Check if cargo is available
+if ! command -v cargo &> /dev/null; then
+    echo "Warning: cargo not found, skipping checks"
+    exit 0
+fi
+
+# Check formatting
+echo "Checking formatting..."
+if ! cargo fmt --all -- --check; then
+    echo ""
+    echo "ERROR: Formatting check failed!"
+    echo "Run 'cargo fmt --all' to fix formatting issues."
+    exit 1
+fi
+
+# Run clippy (optional, can be slow)
+# Uncomment to enable:
+# echo "Running clippy..."
+# cargo clippy --workspace --all-targets -- -D warnings
+
+echo "Pre-commit checks passed!"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -26,9 +26,13 @@ if ! cargo fmt --all -- --check; then
     exit 1
 fi
 
-# Run clippy (optional, can be slow)
-# Uncomment to enable:
-# echo "Running clippy..."
-# cargo clippy --workspace --all-targets -- -D warnings
+# Run clippy
+echo "Running clippy..."
+if ! cargo clippy --workspace --all-targets -- -D warnings; then
+    echo ""
+    echo "ERROR: Clippy check failed!"
+    echo "Fix the warnings above before committing."
+    exit 1
+fi
 
 echo "Pre-commit checks passed!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,144 @@
+# Changelog
+
+All notable changes to Barbacane are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- HTTP/2 support with automatic protocol detection via ALPN
+- API lifecycle support with `deprecated` flag and `x-barbacane-sunset` extension
+- `Deprecation` and `Sunset` response headers for deprecated routes
+- Fixture-based test specs for comprehensive integration testing
+- SLO violation metrics (`barbacane_slo_violation_total`)
+- Deprecation metrics (`barbacane_deprecated_route_requests_total`)
+
+### Changed
+- Improved test fixtures with more comprehensive scenarios
+
+## [0.1.0] - 2026-01-28
+
+### Added
+
+#### Core Gateway (M1)
+- OpenAPI 3.x parser with `x-barbacane-*` extension support
+- Prefix trie router with O(path length) lookups
+- `.bca` artifact format (tar.gz with manifest, routes, specs, plugins)
+- `barbacane compile` CLI command
+- `barbacane validate` CLI command
+- `barbacane serve` data plane binary
+- Path parameter extraction and matching
+- 404/405 responses with RFC 9457 format
+- Health endpoint at `GET /__barbacane/health`
+- Path normalization (trailing slashes, double slashes)
+
+#### Request Validation (M2)
+- JSON Schema validation for request bodies
+- Path, query, and header parameter validation
+- Content-Type enforcement
+- Request limits (body size, header count/size, URI length)
+- Format validation (date-time, email, uuid, uri, ipv4, ipv6)
+- Development mode with verbose error details
+- Compiler validation codes E1001-E1024
+
+#### WASM Plugin System (M3)
+- Wasmtime 28 integration with AOT compilation
+- Instance pooling per (plugin, config) pair
+- Plugin manifest (`plugin.toml`) format
+- Config schema validation (`config-schema.json`)
+- Middleware chain with request/response phases
+- Short-circuit support for early responses
+- Resource limits: 16 MB memory, 100ms timeout, 1 MB stack
+- Host functions:
+  - `host_log` - structured logging
+  - `host_context_get/set` - per-request context
+  - `host_clock_now` - monotonic time
+  - `host_set_output` - plugin output
+- Plugin SDK with `#[barbacane_middleware]` and `#[barbacane_dispatcher]` macros
+
+#### Built-in Dispatchers (M4)
+- `http-upstream` dispatcher - reverse proxy with path rewriting
+- `mock` dispatcher - static responses from config
+- `lambda` dispatcher - AWS Lambda invocation
+- Connection pooling for upstream requests
+- Circuit breaker with threshold/window config
+- Upstream TLS with rustls
+- Upstream mTLS support
+- Host function: `host_http_call` / `host_http_read_result`
+- Compiler check E1031 for plaintext HTTP upstreams
+
+#### Plugin Manifest System (M5)
+- `barbacane.yaml` project manifest
+- Plugin sources: `path` (local file)
+- Plugin reference extraction from specs
+- Validation E1040 for undeclared plugins
+- Artifact bundling of resolved WASM plugins
+- Manifest embedding in artifacts
+
+#### TLS & Authentication (M6a, M6b)
+- TLS termination with rustls
+- ALPN negotiation (HTTP/1.1, HTTP/2)
+- `jwt-auth` middleware - RS256/ES256 JWT validation
+- Claims validation (iss, aud, exp, nbf)
+- `apikey-auth` middleware - API key from header/query
+- `oauth2-auth` middleware - RFC 7662 token introspection
+- Auth context headers (x-auth-sub, x-auth-claims, etc.)
+
+#### Secrets Management (M6c)
+- Secret references: `env://VAR_NAME`, `file:///path`
+- Resolution at startup with exit code 13 on failure
+- Host function: `host_get_secret` / `host_secret_read_result`
+
+#### Rate Limiting & Caching (M7)
+- `rate-limit` middleware - sliding window algorithm
+- IETF draft alignment (RateLimit-Policy, RateLimit headers)
+- Partition keys: client_ip, header, context
+- `cache` middleware - in-memory response caching
+- Cache key: path + method + vary headers
+
+#### Observability (M8)
+- Structured JSON logging via tracing
+- Prometheus metrics endpoint at `/__barbacane/metrics`
+- Request metrics: total, duration, sizes
+- Connection metrics: active, total
+- Validation failure metrics
+- Middleware/dispatch duration metrics
+- WASM execution metrics
+- Distributed tracing with W3C Trace Context
+- OTLP export to OpenTelemetry Collector
+- Plugin telemetry host functions
+- `x-barbacane-observability` extension
+
+#### Control Plane (M9)
+- `barbacane-control serve` REST API server
+- PostgreSQL database with auto-migrations
+- Specs API: upload, list, retrieve, delete, history
+- Compilation API: async compilation with job queue
+- Artifacts API: list, download, delete
+- Plugins API: register, list, download, delete
+- OpenAPI specification for control plane
+
+#### Production Readiness (M11)
+- Graceful shutdown with configurable timeout
+- HTTP keep-alive with configurable idle timeout
+- `X-Request-Id` header (UUID v4, propagates incoming)
+- `X-Trace-Id` header (from traceparent or generated)
+- `Server` header with version
+- Artifact checksum verification (SHA-256)
+- Startup exit codes 10-15 for failure categories
+- Multiple specs in one artifact
+- Routing conflict detection across specs
+- `barbacane-test` crate with `TestGateway`
+- CI/CD pipeline with fmt, clippy, audit, tests
+
+### Infrastructure
+- Cargo workspace with 14 crates
+- 17 Architecture Decision Records (ADRs)
+- 7 formal specifications
+- Comprehensive documentation
+- GitHub Actions CI
+
+[Unreleased]: https://github.com/barbacane/barbacane/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/barbacane/barbacane/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +428,9 @@ dependencies = [
 [[package]]
 name = "barbacane-router"
 version = "0.1.0"
+dependencies = [
+ "criterion",
+]
 
 [[package]]
 name = "barbacane-spec-parser"
@@ -475,6 +484,7 @@ name = "barbacane-validator"
 version = "0.1.0"
 dependencies = [
  "barbacane-spec-parser",
+ "criterion",
  "jsonschema",
  "serde",
  "serde_json",
@@ -670,6 +680,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +721,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -959,6 +1002,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1070,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1549,6 +1634,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,10 +2040,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2382,6 +2498,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opentelemetry"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +2708,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,7 +2820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -3150,6 +3300,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -3777,6 +3936,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4224,6 +4393,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4488,7 +4667,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "object 0.36.7",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,9 @@ syn = { version = "2", features = ["full", "parsing"] }
 quote = "1"
 proc-macro2 = "1"
 
+# Benchmarking
+criterion = { version = "0.5", features = ["html_reports"] }
+
 # Workspace crates
 barbacane-spec-parser = { path = "crates/barbacane-spec-parser" }
 barbacane-compiler = { path = "crates/barbacane-compiler" }

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -390,7 +390,7 @@ Performance, testing infrastructure, lifecycle features, and hardening.
 - [x] `X-Trace-Id` header — trace ID on every response (extracted from traceparent or generated)
 - [x] `Server` header — `barbacane/<version>` on every response
 - [ ] HTTP/2 support — ALPN negotiation configured, needs connection-level implementation
-- [ ] API lifecycle — `deprecated: true` support, `x-barbacane-sunset` header
+- [x] API lifecycle — `deprecated: true` support, `x-barbacane-sunset` extension, `Deprecation` and `Sunset` response headers
 
 ### Testing Infrastructure
 - [x] `barbacane-test` crate — `TestGateway`, `PluginHarness`, `SpecBuilder`, `RequestBuilder`
@@ -399,7 +399,7 @@ Performance, testing infrastructure, lifecycle features, and hardening.
 - [ ] Benchmark regression check — fail CI on >10% regression
 
 ### CI/CD
-- [ ] CI/CD pipeline — fmt, clippy, test, bench, build, integration test
+- [x] CI/CD pipeline — fmt, clippy, audit, build, unit tests, integration tests (`.github/workflows/ci.yml`)
 
 ### Already Implemented (from previous milestones)
 - [x] Artifact checksum verification — SHA-256 check at data plane startup (exit code 11)

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -389,12 +389,12 @@ Performance, testing infrastructure, lifecycle features, and hardening.
 - [x] `X-Request-Id` header — UUID v4 on every response (propagates incoming header if present)
 - [x] `X-Trace-Id` header — trace ID on every response (extracted from traceparent or generated)
 - [x] `Server` header — `barbacane/<version>` on every response
-- [ ] HTTP/2 support — ALPN negotiation configured, needs connection-level implementation
+- [x] HTTP/2 support — auto protocol detection via ALPN (HTTP/1.1 or HTTP/2)
 - [x] API lifecycle — `deprecated: true` support, `x-barbacane-sunset` extension, `Deprecation` and `Sunset` response headers
 
 ### Testing Infrastructure
 - [x] `barbacane-test` crate — `TestGateway`, `PluginHarness`, `SpecBuilder`, `RequestBuilder`
-- [ ] Fixture specs — minimal, full-crud, async-kafka, multi-spec, invalid-* specs
+- [x] Fixture specs — minimal, full-crud, deprecated, multi-spec, invalid-* specs
 - [ ] Performance benchmarks — criterion suite (routing, validation, WASM, full pipeline)
 - [ ] Benchmark regression check — fail CI on >10% regression
 

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -377,25 +377,32 @@ Event-driven API support — AsyncAPI parsing, Kafka and NATS dispatchers.
 
 ---
 
-## M11 — Production Readiness
+## M11 — Production Readiness (In Progress)
 
 Performance, testing infrastructure, lifecycle features, and hardening.
 
 **Specs:** SPEC-002 (sections 6, 7), SPEC-007
 
-- [ ] Graceful shutdown — SIGTERM handling, drain in-flight requests (30s), force-close
-- [ ] HTTP/2 — ALPN negotiation, max concurrent streams, window size, frame size
-- [ ] HTTP keep-alive — idle timeout (60s)
-- [ ] `X-Request-Id` header — UUID v4 on every response
-- [ ] `X-Trace-Id` header — trace ID on every response
-- [ ] `Server` header — `barbacane/<version>`, strip upstream `Server`
+### Server Hardening
+- [x] Graceful shutdown — SIGTERM/SIGINT handling, drain in-flight requests with configurable timeout (--shutdown-timeout)
+- [x] HTTP keep-alive — enabled with configurable idle timeout (--keepalive-timeout)
+- [x] `X-Request-Id` header — UUID v4 on every response (propagates incoming header if present)
+- [x] `X-Trace-Id` header — trace ID on every response (extracted from traceparent or generated)
+- [x] `Server` header — `barbacane/<version>` on every response
+- [ ] HTTP/2 support — ALPN negotiation configured, needs connection-level implementation
 - [ ] API lifecycle — `deprecated: true` support, `x-barbacane-sunset` header
-- [ ] `barbacane-test` crate — `TestGateway`, `PluginHarness`, `SpecBuilder`, `RequestBuilder`
+
+### Testing Infrastructure
+- [x] `barbacane-test` crate — `TestGateway`, `PluginHarness`, `SpecBuilder`, `RequestBuilder`
 - [ ] Fixture specs — minimal, full-crud, async-kafka, multi-spec, invalid-* specs
 - [ ] Performance benchmarks — criterion suite (routing, validation, WASM, full pipeline)
-- [ ] CI/CD pipeline — fmt, clippy, test, bench, build, integration test
 - [ ] Benchmark regression check — fail CI on >10% regression
-- [ ] Artifact checksum verification — SHA-256 check at data plane startup (exit code 11)
-- [ ] Startup exit codes — 10–15 for each failure category
-- [ ] Multiple specs in one artifact — `barbacane-control compile --specs a.yaml b.yaml`
-- [ ] Routing conflict detection — E1010 across specs
+
+### CI/CD
+- [ ] CI/CD pipeline — fmt, clippy, test, bench, build, integration test
+
+### Already Implemented (from previous milestones)
+- [x] Artifact checksum verification — SHA-256 check at data plane startup (exit code 11)
+- [x] Startup exit codes — 10–15 for each failure category (13 for secret resolution failure)
+- [x] Multiple specs in one artifact — `barbacane compile --spec a.yaml --spec b.yaml`
+- [x] Routing conflict detection — E1010 across specs

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 <p align="center"><i>Your spec is your gateway.</i></p>
 
+<p align="center">
+  <a href="https://github.com/barbacane/barbacane/actions/workflows/ci.yml"><img src="https://github.com/barbacane/barbacane/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <img src="https://img.shields.io/badge/tests-255%20passing-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/rust-1.75%2B-orange" alt="Rust Version">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
+</p>
+
 ---
 
 Barbacane is a spec-driven API gateway built in Rust. Point it at an OpenAPI or AsyncAPI spec and it becomes your gateway — routing, validation, authentication, and all. No proprietary config language, no drift between your spec and your infrastructure.
@@ -16,3 +23,53 @@ Barbacane is a spec-driven API gateway built in Rust. Point it at an OpenAPI or 
 - **Edge-ready** — Stateless data plane instances designed to run close to your users, with a separate control plane handling compilation and distribution.
 - **Extensible** — Write plugins in any language that compiles to WebAssembly. They run in a sandbox, so a buggy plugin can't take down the gateway.
 - **Observable** — Prometheus metrics, structured JSON logging, and distributed tracing with W3C Trace Context and OTLP export.
+
+## Quick Start
+
+```bash
+# Clone and build
+git clone https://github.com/barbacane/barbacane.git
+cd barbacane
+cargo build --release
+
+# Compile your OpenAPI spec
+./target/release/barbacane compile --spec api.yaml --manifest barbacane.yaml --output api.bca
+
+# Run the gateway
+./target/release/barbacane serve --artifact api.bca --listen 0.0.0.0:8080
+```
+
+## Documentation
+
+- [Getting Started](docs/guide/getting-started.md) — First steps with Barbacane
+- [Spec Configuration](docs/guide/spec-configuration.md) — Configure routing and middleware
+- [Middlewares](docs/guide/middlewares.md) — Authentication, rate limiting, caching
+- [Dispatchers](docs/guide/dispatchers.md) — Route requests to backends
+- [Plugin Development](docs/contributing/plugins.md) — Build custom WASM plugins
+- [Architecture](docs/contributing/architecture.md) — System design overview
+
+## Official Plugins
+
+| Plugin | Type | Description |
+|--------|------|-------------|
+| `http-upstream` | Dispatcher | Reverse proxy to HTTP/HTTPS backends |
+| `mock` | Dispatcher | Return static responses |
+| `lambda` | Dispatcher | Invoke AWS Lambda functions |
+| `jwt-auth` | Middleware | JWT token validation |
+| `apikey-auth` | Middleware | API key authentication |
+| `oauth2-auth` | Middleware | OAuth2 token introspection |
+| `rate-limit` | Middleware | Sliding window rate limiting |
+| `cache` | Middleware | Response caching |
+| `cors` | Middleware | CORS header management |
+
+## Project Status
+
+Barbacane is under active development. See [MILESTONES.md](MILESTONES.md) for the roadmap and [CHANGELOG.md](CHANGELOG.md) for release history.
+
+## Contributing
+
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ cargo build --release
 | `cache` | Middleware | Response caching |
 | `cors` | Middleware | CORS header management |
 
+## Performance
+
+Benchmark results on Apple M4 (MacBook Air 16GB):
+
+| Operation | Latency |
+|-----------|---------|
+| Route lookup (1000 routes) | ~83 ns |
+| Request validation (full) | ~1.2 µs |
+| Body validation (JSON) | ~458 ns |
+| Router build (500 routes) | ~130 µs |
+
+Run your own benchmarks:
+
+```bash
+cargo bench --workspace
+```
+
 ## Project Status
 
 Barbacane is under active development. See [MILESTONES.md](MILESTONES.md) for the roadmap and [CHANGELOG.md](CHANGELOG.md) for release history.

--- a/crates/barbacane-compiler/Cargo.toml
+++ b/crates/barbacane-compiler/Cargo.toml
@@ -15,6 +15,7 @@ sha2 = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }
 thiserror = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -298,8 +298,8 @@ pub fn compile_with_manifest(
         .into_iter()
         .map(|p| PluginBundle {
             name: p.name,
-            version: "0.1.0".to_string(), // TODO: Get version from plugin manifest
-            plugin_type: "plugin".to_string(), // TODO: Detect type from plugin manifest
+            version: p.version.unwrap_or_else(|| "0.1.0".to_string()),
+            plugin_type: p.plugin_type.unwrap_or_else(|| "plugin".to_string()),
             wasm_bytes: p.wasm_bytes,
         })
         .collect();

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -92,6 +92,12 @@ pub struct CompiledOperation {
     /// Otherwise, uses the global middlewares from the spec.
     #[serde(default)]
     pub middlewares: Vec<MiddlewareConfig>,
+    /// Whether this operation is deprecated.
+    #[serde(default)]
+    pub deprecated: bool,
+    /// Sunset date for deprecated operations (HTTP-date format per RFC 9110).
+    #[serde(default)]
+    pub sunset: Option<String>,
 }
 
 /// Compile one or more spec files into a .bca artifact.
@@ -173,6 +179,8 @@ pub fn compile_with_options(
                 request_body: op.request_body.clone(),
                 dispatch,
                 middlewares,
+                deprecated: op.deprecated,
+                sunset: op.sunset.clone(),
             });
         }
     }
@@ -346,6 +354,8 @@ pub fn compile_with_manifest(
                 request_body: op.request_body.clone(),
                 dispatch,
                 middlewares,
+                deprecated: op.deprecated,
+                sunset: op.sunset.clone(),
             });
         }
     }
@@ -617,6 +627,8 @@ pub fn compile_with_plugins(
                 request_body: op.request_body.clone(),
                 dispatch,
                 middlewares,
+                deprecated: op.deprecated,
+                sunset: op.sunset.clone(),
             });
         }
     }

--- a/crates/barbacane-compiler/src/manifest.rs
+++ b/crates/barbacane-compiler/src/manifest.rs
@@ -426,6 +426,8 @@ plugins:
                     }),
                     middlewares: None,
                     observability: None,
+                    deprecated: false,
+                    sunset: None,
                     extensions: BTreeMap::new(),
                 },
                 Operation {
@@ -443,6 +445,8 @@ plugins:
                         config: serde_json::json!({}),
                     }]),
                     observability: None,
+                    deprecated: false,
+                    sunset: None,
                     extensions: BTreeMap::new(),
                 },
             ],
@@ -485,6 +489,8 @@ plugins:
                 }),
                 middlewares: None,
                 observability: None,
+                deprecated: false,
+                sunset: None,
                 extensions: BTreeMap::new(),
             }],
         };
@@ -526,6 +532,8 @@ plugins:
                 }),
                 middlewares: None,
                 observability: None,
+                deprecated: false,
+                sunset: None,
                 extensions: BTreeMap::new(),
             }],
         };

--- a/crates/barbacane-compiler/src/manifest.rs
+++ b/crates/barbacane-compiler/src/manifest.rs
@@ -11,6 +11,27 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::CompileError;
 
+/// Minimal plugin.toml structure for extracting metadata.
+#[derive(Debug, Deserialize)]
+struct PluginToml {
+    plugin: PluginMeta,
+}
+
+#[derive(Debug, Deserialize)]
+struct PluginMeta {
+    version: String,
+    #[serde(rename = "type")]
+    plugin_type: String,
+}
+
+/// Try to read plugin metadata from plugin.toml in the same directory as the WASM file.
+fn read_plugin_metadata(wasm_path: &Path) -> Option<(String, String)> {
+    let plugin_toml_path = wasm_path.parent()?.join("plugin.toml");
+    let content = std::fs::read_to_string(&plugin_toml_path).ok()?;
+    let parsed: PluginToml = toml::from_str(&content).ok()?;
+    Some((parsed.plugin.version, parsed.plugin.plugin_type))
+}
+
 /// A project manifest (`barbacane.yaml`).
 ///
 /// Declares the plugins available for use in OpenAPI specs.
@@ -64,6 +85,10 @@ pub struct ResolvedPlugin {
     pub source: String,
     /// WASM binary content.
     pub wasm_bytes: Vec<u8>,
+    /// Plugin version (from plugin.toml if available).
+    pub version: Option<String>,
+    /// Plugin type: "middleware" or "dispatcher" (from plugin.toml if available).
+    pub plugin_type: Option<String>,
 }
 
 impl ProjectManifest {
@@ -138,10 +163,27 @@ impl ProjectManifest {
                 )));
             }
 
+            // Try to read plugin metadata from plugin.toml
+            let (version, plugin_type) = match source {
+                PluginSource::Path(path_source) => {
+                    let wasm_path = if Path::new(&path_source.path).is_absolute() {
+                        Path::new(&path_source.path).to_path_buf()
+                    } else {
+                        base_path.join(&path_source.path)
+                    };
+                    read_plugin_metadata(&wasm_path)
+                        .map(|(v, t)| (Some(v), Some(t)))
+                        .unwrap_or((None, None))
+                }
+                PluginSource::Url(_) => (None, None),
+            };
+
             resolved.push(ResolvedPlugin {
                 name: name.clone(),
                 source: source.description(),
                 wasm_bytes,
+                version,
+                plugin_type,
             });
         }
 
@@ -223,10 +265,27 @@ impl ProjectManifest {
                 )));
             }
 
+            // Try to read plugin metadata from plugin.toml
+            let (version, plugin_type) = match source {
+                PluginSource::Path(path_source) => {
+                    let wasm_path = if Path::new(&path_source.path).is_absolute() {
+                        Path::new(&path_source.path).to_path_buf()
+                    } else {
+                        base_path.join(&path_source.path)
+                    };
+                    read_plugin_metadata(&wasm_path)
+                        .map(|(v, t)| (Some(v), Some(t)))
+                        .unwrap_or((None, None))
+                }
+                PluginSource::Url(_) => (None, None),
+            };
+
             resolved.push(ResolvedPlugin {
                 name: name.clone(),
                 source: source.description(),
                 wasm_bytes,
+                version,
+                plugin_type,
             });
         }
 

--- a/crates/barbacane-router/Cargo.toml
+++ b/crates/barbacane-router/Cargo.toml
@@ -6,3 +6,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "routing"
+harness = false

--- a/crates/barbacane-router/benches/routing.rs
+++ b/crates/barbacane-router/benches/routing.rs
@@ -1,0 +1,144 @@
+//! Routing benchmarks for the prefix-trie router.
+//!
+//! Run with: cargo bench -p barbacane-router
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use barbacane_router::{RouteEntry, Router};
+
+/// Generate a set of realistic API routes.
+fn generate_routes(count: usize) -> Vec<(String, String)> {
+    let resources = [
+        "users",
+        "orders",
+        "products",
+        "customers",
+        "invoices",
+        "payments",
+    ];
+    let methods = ["GET", "POST", "PUT", "DELETE"];
+
+    let mut routes = Vec::new();
+
+    // Add base resource routes
+    for resource in &resources {
+        routes.push((format!("/{}", resource), "GET".to_string()));
+        routes.push((format!("/{}", resource), "POST".to_string()));
+        routes.push((format!("/{}/{{id}}", resource), "GET".to_string()));
+        routes.push((format!("/{}/{{id}}", resource), "PUT".to_string()));
+        routes.push((format!("/{}/{{id}}", resource), "DELETE".to_string()));
+    }
+
+    // Add nested routes
+    routes.push(("/users/{userId}/orders".to_string(), "GET".to_string()));
+    routes.push((
+        "/users/{userId}/orders/{orderId}".to_string(),
+        "GET".to_string(),
+    ));
+    routes.push((
+        "/products/{productId}/reviews".to_string(),
+        "GET".to_string(),
+    ));
+    routes.push((
+        "/products/{productId}/reviews/{reviewId}".to_string(),
+        "GET".to_string(),
+    ));
+
+    // Fill to desired count with variations
+    while routes.len() < count {
+        let i = routes.len();
+        let resource = resources[i % resources.len()];
+        let method = methods[i % methods.len()];
+        routes.push((format!("/api/v{}/{}", i / 10, resource), method.to_string()));
+    }
+
+    routes.truncate(count);
+    routes
+}
+
+/// Build a router with the given routes.
+fn build_router(routes: &[(String, String)]) -> Router {
+    let mut router = Router::new();
+    for (i, (path, method)) in routes.iter().enumerate() {
+        router.insert(path, method, RouteEntry { operation_index: i });
+    }
+    router
+}
+
+fn bench_router_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("router_lookup");
+
+    for route_count in [10, 50, 100, 500, 1000] {
+        let routes = generate_routes(route_count);
+        let router = build_router(&routes);
+
+        // Benchmark static path lookup
+        group.bench_with_input(
+            BenchmarkId::new("static_path", route_count),
+            &router,
+            |b, router| {
+                b.iter(|| {
+                    black_box(router.lookup("/users", "GET"));
+                });
+            },
+        );
+
+        // Benchmark parameterized path lookup
+        group.bench_with_input(
+            BenchmarkId::new("param_path", route_count),
+            &router,
+            |b, router| {
+                b.iter(|| {
+                    black_box(router.lookup("/users/12345", "GET"));
+                });
+            },
+        );
+
+        // Benchmark nested param path lookup
+        group.bench_with_input(
+            BenchmarkId::new("nested_param_path", route_count),
+            &router,
+            |b, router| {
+                b.iter(|| {
+                    black_box(router.lookup("/users/12345/orders/67890", "GET"));
+                });
+            },
+        );
+
+        // Benchmark not found path
+        group.bench_with_input(
+            BenchmarkId::new("not_found", route_count),
+            &router,
+            |b, router| {
+                b.iter(|| {
+                    black_box(router.lookup("/nonexistent/path/here", "GET"));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_router_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group("router_insert");
+
+    for route_count in [10, 50, 100, 500] {
+        let routes = generate_routes(route_count);
+
+        group.bench_with_input(
+            BenchmarkId::new("build_router", route_count),
+            &routes,
+            |b, routes| {
+                b.iter(|| {
+                    black_box(build_router(routes));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_router_lookup, bench_router_insert);
+criterion_main!(benches);

--- a/crates/barbacane-spec-parser/src/model.rs
+++ b/crates/barbacane-spec-parser/src/model.rs
@@ -53,6 +53,12 @@ pub struct Operation {
     /// Operation-level observability config (overrides global).
     #[serde(default)]
     pub observability: Option<ObservabilityConfig>,
+    /// Whether this operation is deprecated (OpenAPI `deprecated` field).
+    #[serde(default)]
+    pub deprecated: bool,
+    /// Sunset date for deprecated operations (from `x-barbacane-sunset`).
+    /// Format: HTTP-date per RFC 9110 (e.g., "Sat, 31 Dec 2024 23:59:59 GMT").
+    pub sunset: Option<String>,
     /// Operation-level `x-barbacane-*` extensions.
     pub extensions: BTreeMap<String, serde_json::Value>,
 }

--- a/crates/barbacane-test/src/gateway.rs
+++ b/crates/barbacane-test/src/gateway.rs
@@ -2023,4 +2023,369 @@ paths:
             "Metrics should contain connections_total counter"
         );
     }
+
+    // ==================== API Lifecycle / Deprecation Tests ====================
+
+    #[tokio::test]
+    async fn test_deprecation_header_not_present_on_current_endpoint() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/deprecated.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Current (non-deprecated) endpoint should not have deprecation headers
+        let resp = gateway.get("/v2/users").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        assert!(
+            !resp.headers().contains_key("deprecation"),
+            "Current endpoint should not have Deprecation header"
+        );
+        assert!(
+            !resp.headers().contains_key("sunset"),
+            "Current endpoint should not have Sunset header"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deprecation_header_present_on_deprecated_endpoint() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/deprecated.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Deprecated endpoint (without sunset) should have Deprecation header only
+        let resp = gateway.get("/v1/users").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let deprecation = resp.headers().get("deprecation");
+        assert!(
+            deprecation.is_some(),
+            "Deprecated endpoint should have Deprecation header"
+        );
+        assert_eq!(
+            deprecation.unwrap().to_str().unwrap(),
+            "true",
+            "Deprecation header should be 'true'"
+        );
+
+        // This endpoint has no sunset date configured
+        assert!(
+            !resp.headers().contains_key("sunset"),
+            "Endpoint without x-barbacane-sunset should not have Sunset header"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deprecation_and_sunset_headers_present() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/deprecated.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Deprecated endpoint with sunset date should have both headers
+        let resp = gateway.get("/v1/users/123").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let deprecation = resp.headers().get("deprecation");
+        assert!(
+            deprecation.is_some(),
+            "Deprecated endpoint should have Deprecation header"
+        );
+        assert_eq!(deprecation.unwrap().to_str().unwrap(), "true");
+
+        let sunset = resp.headers().get("sunset");
+        assert!(
+            sunset.is_some(),
+            "Endpoint with x-barbacane-sunset should have Sunset header"
+        );
+        let sunset_val = sunset.unwrap().to_str().unwrap();
+        assert!(
+            sunset_val.contains("2025"),
+            "Sunset header should contain the configured date: {}",
+            sunset_val
+        );
+    }
+
+    #[tokio::test]
+    async fn test_legacy_endpoint_with_far_future_sunset() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/deprecated.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        let resp = gateway.get("/legacy/status").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // Check both headers
+        assert!(resp.headers().contains_key("deprecation"));
+        let sunset = resp.headers().get("sunset");
+        assert!(sunset.is_some());
+        let sunset_val = sunset.unwrap().to_str().unwrap();
+        assert!(
+            sunset_val.contains("2030"),
+            "Sunset header should contain 2030: {}",
+            sunset_val
+        );
+    }
+
+    // ==================== Full CRUD Tests ====================
+
+    #[tokio::test]
+    async fn test_full_crud_list_users() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        let resp = gateway.get("/users").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert!(body.get("users").is_some());
+        assert!(body.get("total").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_full_crud_list_users_with_pagination() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // With valid pagination params
+        let resp = gateway.get("/users?limit=10&offset=0").await.unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_full_crud_list_users_invalid_limit() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Limit exceeds maximum (100)
+        let resp = gateway.get("/users?limit=200").await.unwrap();
+        assert_eq!(resp.status(), 400);
+    }
+
+    #[tokio::test]
+    async fn test_full_crud_create_user_valid() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        let resp = gateway
+            .post("/users", r#"{"email":"test@example.com","name":"Test User"}"#)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 201);
+
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert!(body.get("id").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_full_crud_create_user_missing_required() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Missing required 'name' field
+        let resp = gateway
+            .post("/users", r#"{"email":"test@example.com"}"#)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+    }
+
+    #[tokio::test]
+    async fn test_full_crud_create_user_invalid_email() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Invalid email format
+        let resp = gateway
+            .post("/users", r#"{"email":"not-an-email","name":"Test"}"#)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+    }
+
+    #[tokio::test]
+    async fn test_full_crud_get_user() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Valid UUID
+        let resp = gateway
+            .get("/users/550e8400-e29b-41d4-a716-446655440000")
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_full_crud_get_user_invalid_uuid() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Invalid UUID format
+        let resp = gateway.get("/users/not-a-uuid").await.unwrap();
+        assert_eq!(resp.status(), 400);
+    }
+
+    #[tokio::test]
+    async fn test_full_crud_update_user() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        let resp = gateway
+            .put(
+                "/users/550e8400-e29b-41d4-a716-446655440000",
+                r#"{"name":"Updated Name"}"#,
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_full_crud_delete_user() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        let resp = gateway
+            .request(
+                reqwest::Method::DELETE,
+                "/users/550e8400-e29b-41d4-a716-446655440000",
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 204);
+    }
+
+    #[tokio::test]
+    async fn test_full_crud_nested_resource() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Get orders for a user
+        let resp = gateway
+            .get("/users/550e8400-e29b-41d4-a716-446655440000/orders")
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert!(body.get("orders").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_full_crud_nested_resource_with_filter() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/full-crud.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Get orders with status filter
+        let resp = gateway
+            .get("/users/550e8400-e29b-41d4-a716-446655440000/orders?status=pending")
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    // ==================== Multi-Spec Compilation Tests ====================
+
+    #[tokio::test]
+    async fn test_multi_spec_routes_from_both_specs() {
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway with multiple specs");
+
+        // Routes from users.yaml
+        let resp = gateway.get("/users").await.unwrap();
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert!(body.get("users").is_some());
+
+        // Routes from orders.yaml
+        let resp = gateway.get("/orders").await.unwrap();
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert!(body.get("orders").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_multi_spec_user_crud() {
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway");
+
+        // Create user
+        let resp = gateway
+            .post("/users", r#"{"name":"Test","email":"test@example.com"}"#)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 201);
+
+        // Get user
+        let resp = gateway.get("/users/123").await.unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_multi_spec_order_crud() {
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway");
+
+        // Create order
+        let resp = gateway
+            .post(
+                "/orders",
+                r#"{"userId":"123","items":[{"productId":"p1","quantity":2}]}"#,
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 201);
+
+        // Get order
+        let resp = gateway.get("/orders/order-1").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // Update order status
+        let resp = gateway
+            .put("/orders/order-1/status", r#"{"status":"shipped"}"#)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_multi_spec_health_from_both() {
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway");
+
+        // Built-in health endpoint should work
+        let resp = gateway.get("/__barbacane/health").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body: serde_json::Value = resp.json().await.unwrap();
+        // Should show combined routes count
+        assert!(body.get("routes_count").is_some());
+    }
 }

--- a/crates/barbacane-test/src/gateway.rs
+++ b/crates/barbacane-test/src/gateway.rs
@@ -2170,7 +2170,10 @@ paths:
             .expect("failed to start gateway");
 
         let resp = gateway
-            .post("/users", r#"{"email":"test@example.com","name":"Test User"}"#)
+            .post(
+                "/users",
+                r#"{"email":"test@example.com","name":"Test User"}"#,
+            )
             .await
             .unwrap();
         assert_eq!(resp.status(), 201);

--- a/crates/barbacane-validator/Cargo.toml
+++ b/crates/barbacane-validator/Cargo.toml
@@ -14,3 +14,8 @@ thiserror = { workspace = true }
 barbacane-spec-parser = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "validation"
+harness = false

--- a/crates/barbacane-validator/benches/validation.rs
+++ b/crates/barbacane-validator/benches/validation.rs
@@ -120,13 +120,13 @@ fn bench_path_param_validation(c: &mut Criterion) {
 
     group.bench_function("valid_uuid", |b| {
         b.iter(|| {
-            black_box(validator.validate_path_params(&valid_params));
+            let _ = black_box(validator.validate_path_params(&valid_params));
         });
     });
 
     group.bench_function("invalid_uuid", |b| {
         b.iter(|| {
-            black_box(validator.validate_path_params(&invalid_params));
+            let _ = black_box(validator.validate_path_params(&invalid_params));
         });
     });
 
@@ -144,13 +144,13 @@ fn bench_query_param_validation(c: &mut Criterion) {
 
     group.bench_function("valid_params", |b| {
         b.iter(|| {
-            black_box(validator.validate_query_params(Some(valid_query)));
+            let _ = black_box(validator.validate_query_params(Some(valid_query)));
         });
     });
 
     group.bench_function("invalid_params", |b| {
         b.iter(|| {
-            black_box(validator.validate_query_params(Some(invalid_query)));
+            let _ = black_box(validator.validate_query_params(Some(invalid_query)));
         });
     });
 
@@ -196,7 +196,8 @@ fn bench_body_validation(c: &mut Criterion) {
             &body_bytes,
             |b, body_bytes| {
                 b.iter(|| {
-                    black_box(validator.validate_body(Some("application/json"), body_bytes));
+                    let _ =
+                        black_box(validator.validate_body(Some("application/json"), body_bytes));
                 });
             },
         );
@@ -235,7 +236,7 @@ fn bench_full_request_validation(c: &mut Criterion) {
 
     c.bench_function("full_request_validation", |b| {
         b.iter(|| {
-            black_box(validator.validate_request(
+            let _ = black_box(validator.validate_request(
                 &path_params,
                 Some(query_string),
                 &headers,

--- a/crates/barbacane-validator/benches/validation.rs
+++ b/crates/barbacane-validator/benches/validation.rs
@@ -1,0 +1,272 @@
+//! Validation benchmarks for the request validator.
+//!
+//! Run with: cargo bench -p barbacane-validator
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use serde_json::json;
+use std::collections::HashMap;
+
+use barbacane_spec_parser::{Parameter, RequestBody, RequestBodyContent};
+use barbacane_validator::OperationValidator;
+
+/// Create parameters for benchmarking.
+fn create_parameters() -> Vec<Parameter> {
+    vec![
+        Parameter {
+            name: "id".to_string(),
+            location: "path".to_string(),
+            required: true,
+            schema: Some(json!({
+                "type": "string",
+                "format": "uuid"
+            })),
+        },
+        Parameter {
+            name: "page".to_string(),
+            location: "query".to_string(),
+            required: false,
+            schema: Some(json!({
+                "type": "integer",
+                "minimum": 1
+            })),
+        },
+        Parameter {
+            name: "limit".to_string(),
+            location: "query".to_string(),
+            required: false,
+            schema: Some(json!({
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100
+            })),
+        },
+        Parameter {
+            name: "x-api-key".to_string(),
+            location: "header".to_string(),
+            required: true,
+            schema: Some(json!({
+                "type": "string",
+                "minLength": 32
+            })),
+        },
+    ]
+}
+
+/// Create a request body schema for benchmarking.
+fn create_request_body() -> RequestBody {
+    let mut content = HashMap::new();
+    content.insert(
+        "application/json".to_string(),
+        RequestBodyContent {
+            schema: Some(json!({
+                "type": "object",
+                "required": ["name", "email"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 100
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "age": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 150
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "maxItems": 10
+                    }
+                }
+            })),
+        },
+    );
+
+    RequestBody {
+        required: true,
+        content,
+    }
+}
+
+fn bench_validator_creation(c: &mut Criterion) {
+    let params = create_parameters();
+    let body = create_request_body();
+
+    c.bench_function("validator_creation", |b| {
+        b.iter(|| {
+            black_box(OperationValidator::new(&params, Some(&body)));
+        });
+    });
+}
+
+fn bench_path_param_validation(c: &mut Criterion) {
+    let params = create_parameters();
+    let validator = OperationValidator::new(&params, None);
+
+    let valid_params = vec![(
+        "id".to_string(),
+        "550e8400-e29b-41d4-a716-446655440000".to_string(),
+    )];
+
+    let invalid_params = vec![("id".to_string(), "not-a-uuid".to_string())];
+
+    let mut group = c.benchmark_group("path_param_validation");
+
+    group.bench_function("valid_uuid", |b| {
+        b.iter(|| {
+            black_box(validator.validate_path_params(&valid_params));
+        });
+    });
+
+    group.bench_function("invalid_uuid", |b| {
+        b.iter(|| {
+            black_box(validator.validate_path_params(&invalid_params));
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_query_param_validation(c: &mut Criterion) {
+    let params = create_parameters();
+    let validator = OperationValidator::new(&params, None);
+
+    let valid_query: HashMap<String, String> = [
+        ("page".to_string(), "1".to_string()),
+        ("limit".to_string(), "50".to_string()),
+    ]
+    .into_iter()
+    .collect();
+
+    let invalid_query: HashMap<String, String> = [
+        ("page".to_string(), "0".to_string()),     // Below minimum
+        ("limit".to_string(), "1000".to_string()), // Above maximum
+    ]
+    .into_iter()
+    .collect();
+
+    let mut group = c.benchmark_group("query_param_validation");
+
+    group.bench_function("valid_params", |b| {
+        b.iter(|| {
+            black_box(validator.validate_query_params(&valid_query));
+        });
+    });
+
+    group.bench_function("invalid_params", |b| {
+        b.iter(|| {
+            black_box(validator.validate_query_params(&invalid_query));
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_body_validation(c: &mut Criterion) {
+    let params = create_parameters();
+    let body = create_request_body();
+    let validator = OperationValidator::new(&params, Some(&body));
+
+    // Small valid body
+    let small_body = json!({
+        "name": "John Doe",
+        "email": "john@example.com"
+    });
+
+    // Large valid body
+    let large_body = json!({
+        "name": "John Doe",
+        "email": "john@example.com",
+        "age": 30,
+        "tags": ["tag1", "tag2", "tag3", "tag4", "tag5"]
+    });
+
+    // Invalid body
+    let invalid_body = json!({
+        "name": "",
+        "email": "not-an-email"
+    });
+
+    let mut group = c.benchmark_group("body_validation");
+
+    for (name, body_json) in [
+        ("small_valid", &small_body),
+        ("large_valid", &large_body),
+        ("invalid", &invalid_body),
+    ] {
+        let body_bytes = serde_json::to_vec(body_json).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new("json", name),
+            &body_bytes,
+            |b, body_bytes| {
+                b.iter(|| {
+                    black_box(validator.validate_body(Some("application/json"), body_bytes));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_full_request_validation(c: &mut Criterion) {
+    let params = create_parameters();
+    let body = create_request_body();
+    let validator = OperationValidator::new(&params, Some(&body));
+
+    let path_params = vec![(
+        "id".to_string(),
+        "550e8400-e29b-41d4-a716-446655440000".to_string(),
+    )];
+
+    let query_params: HashMap<String, String> = [
+        ("page".to_string(), "1".to_string()),
+        ("limit".to_string(), "50".to_string()),
+    ]
+    .into_iter()
+    .collect();
+
+    let headers: HashMap<String, String> = [
+        (
+            "x-api-key".to_string(),
+            "12345678901234567890123456789012".to_string(),
+        ),
+        ("content-type".to_string(), "application/json".to_string()),
+    ]
+    .into_iter()
+    .collect();
+
+    let body_json = json!({
+        "name": "John Doe",
+        "email": "john@example.com"
+    });
+    let body_bytes = serde_json::to_vec(&body_json).unwrap();
+
+    c.bench_function("full_request_validation", |b| {
+        b.iter(|| {
+            black_box(validator.validate_request(
+                &path_params,
+                &query_params,
+                &headers,
+                &body_bytes,
+            ));
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_validator_creation,
+    bench_path_param_validation,
+    bench_query_param_validation,
+    bench_body_validation,
+    bench_full_request_validation
+);
+criterion_main!(benches);

--- a/crates/barbacane/Cargo.toml
+++ b/crates/barbacane/Cargo.toml
@@ -26,3 +26,4 @@ tracing = { workspace = true }
 rustls = { workspace = true }
 tokio-rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
+uuid = { workspace = true }

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -584,7 +584,14 @@ impl Gateway {
                 }
 
                 let response = self
-                    .dispatch(operation, params, query_string, &body_bytes, &headers, client_addr)
+                    .dispatch(
+                        operation,
+                        params,
+                        query_string,
+                        &body_bytes,
+                        &headers,
+                        client_addr,
+                    )
                     .await?;
 
                 // Add deprecation headers if the operation is deprecated

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -367,8 +367,7 @@ cargo test --workspace
 
 ## Future Directions
 
-- **HTTP/2 support**: Already in hyper, needs exposure
-- **gRPC passthrough**: Transparent proxying
+- **gRPC passthrough**: Transparent proxying for gRPC services
 - **Hot reload**: Reload artifacts without restart
-- **Cluster mode**: Distributed configuration
-- **Metrics**: Prometheus endpoint
+- **Cluster mode**: Distributed configuration across multiple nodes
+- **AsyncAPI support**: Event-driven APIs with Kafka/NATS dispatch

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -306,9 +306,12 @@ cargo test -p barbacane-test test_gateway_health -- --nocapture
 
 ## Performance Profiling
 
-### Benchmarks (coming soon)
+### Benchmarks (planned)
+
+Criterion benchmarks are planned for the router, validator, and WASM runtime.
 
 ```bash
+# Once implemented:
 cargo bench -p barbacane-router
 ```
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -306,14 +306,33 @@ cargo test -p barbacane-test test_gateway_health -- --nocapture
 
 ## Performance Profiling
 
-### Benchmarks (planned)
+### Benchmarks
 
-Criterion benchmarks are planned for the router, validator, and WASM runtime.
+Criterion benchmarks are available for performance-critical components:
 
 ```bash
-# Once implemented:
+# Run all benchmarks
+cargo bench --workspace
+
+# Run router benchmarks (trie lookup and insertion)
 cargo bench -p barbacane-router
+
+# Run validator benchmarks (schema validation)
+cargo bench -p barbacane-validator
 ```
+
+**Router benchmarks** (`crates/barbacane-router/benches/routing.rs`):
+- `router_lookup` - Measures lookup performance for static paths, parameterized paths, and not-found cases
+- `router_insert` - Measures route insertion performance at various route counts (10-1000 routes)
+
+**Validator benchmarks** (`crates/barbacane-validator/benches/validation.rs`):
+- `validator_creation` - Measures schema compilation time
+- `path_param_validation` - Validates path parameters against schemas
+- `query_param_validation` - Validates query parameters
+- `body_validation` - Validates JSON request bodies
+- `full_request_validation` - End-to-end request validation
+
+Benchmark results are saved to `target/criterion/` with HTML reports.
 
 ### Flamegraph
 

--- a/docs/contributing/plugins.md
+++ b/docs/contributing/plugins.md
@@ -1,0 +1,422 @@
+# Plugin Development Guide
+
+This guide explains how to create WASM plugins for Barbacane.
+
+## Overview
+
+Barbacane plugins are WebAssembly (WASM) modules that extend gateway functionality. There are two types:
+
+| Type | Purpose | Exports |
+|------|---------|---------|
+| **Middleware** | Process requests/responses in a chain | `init`, `on_request`, `on_response` |
+| **Dispatcher** | Handle requests and generate responses | `init`, `dispatch` |
+
+## Prerequisites
+
+- Rust stable with `wasm32-unknown-unknown` target
+- `barbacane-plugin-sdk` crate
+
+```bash
+# Add the WASM target
+rustup target add wasm32-unknown-unknown
+```
+
+## Quick Start
+
+### 1. Create a New Plugin
+
+```bash
+cargo new --lib my-plugin
+cd my-plugin
+```
+
+### 2. Configure Cargo.toml
+
+```toml
+[package]
+name = "my-plugin"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+barbacane-plugin-sdk = { path = "../path/to/barbacane/crates/barbacane-plugin-sdk" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+```
+
+### 3. Write the Plugin
+
+**Middleware example:**
+
+```rust
+use barbacane_plugin_sdk::prelude::*;
+use serde::Deserialize;
+
+#[barbacane_middleware]
+#[derive(Deserialize)]
+pub struct MyMiddleware {
+    // Configuration fields from the spec
+    header_name: String,
+    header_value: String,
+}
+
+impl MyMiddleware {
+    pub fn on_request(&mut self, req: Request) -> Action {
+        // Add a header to the request
+        let mut req = req;
+        req.headers.insert(
+            self.header_name.clone(),
+            self.header_value.clone(),
+        );
+        Action::Continue(req)
+    }
+
+    pub fn on_response(&mut self, resp: Response) -> Response {
+        // Pass through unchanged
+        resp
+    }
+}
+```
+
+**Dispatcher example:**
+
+```rust
+use barbacane_plugin_sdk::prelude::*;
+use serde::Deserialize;
+
+#[barbacane_dispatcher]
+#[derive(Deserialize)]
+pub struct MyDispatcher {
+    status: u16,
+    body: String,
+}
+
+impl MyDispatcher {
+    pub fn dispatch(&mut self, _req: Request) -> Response {
+        Response {
+            status: self.status,
+            headers: Default::default(),
+            body: Some(self.body.clone()),
+        }
+    }
+}
+```
+
+### 4. Create plugin.toml
+
+```toml
+[plugin]
+name = "my-plugin"
+version = "0.1.0"
+type = "middleware"  # or "dispatcher"
+description = "My custom plugin"
+wasm = "my_plugin.wasm"
+
+[capabilities]
+host_functions = ["log"]
+```
+
+### 5. Create config-schema.json
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["header_name", "header_value"],
+  "properties": {
+    "header_name": {
+      "type": "string",
+      "description": "Header name to add"
+    },
+    "header_value": {
+      "type": "string",
+      "description": "Header value to set"
+    }
+  }
+}
+```
+
+### 6. Build
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+cp target/wasm32-unknown-unknown/release/my_plugin.wasm .
+```
+
+## Plugin SDK Types
+
+### Request
+
+```rust
+pub struct Request {
+    pub method: String,      // HTTP method (GET, POST, etc.)
+    pub path: String,        // Request path
+    pub query: Option<String>, // Query string
+    pub headers: BTreeMap<String, String>,
+    pub body: Option<String>,
+    pub client_ip: String,
+    pub path_params: BTreeMap<String, String>,
+}
+```
+
+### Response
+
+```rust
+pub struct Response {
+    pub status: u16,
+    pub headers: BTreeMap<String, String>,
+    pub body: Option<String>,
+}
+```
+
+### Action (Middleware only)
+
+```rust
+pub enum Action {
+    /// Continue to next middleware/dispatcher with (possibly modified) request
+    Continue(Request),
+    /// Short-circuit the chain and return this response immediately
+    Respond(Response),
+}
+```
+
+## Host Functions
+
+Plugins can call host functions to access gateway capabilities. Declare required capabilities in `plugin.toml`:
+
+### Logging
+
+```toml
+[capabilities]
+host_functions = ["log"]
+```
+
+```rust
+use barbacane_plugin_sdk::host;
+
+host::log("info", "Processing request");
+host::log("error", "Something went wrong");
+```
+
+### Context (per-request key-value store)
+
+```toml
+[capabilities]
+host_functions = ["context_get", "context_set"]
+```
+
+```rust
+use barbacane_plugin_sdk::host;
+
+// Set a value for downstream middleware/dispatcher
+host::context_set("user_id", "12345");
+
+// Get a value set by upstream middleware
+if let Some(value) = host::context_get("auth_token") {
+    // use value
+}
+```
+
+### Clock
+
+```toml
+[capabilities]
+host_functions = ["clock_now"]
+```
+
+```rust
+use barbacane_plugin_sdk::host;
+
+let timestamp_ms = host::clock_now();
+```
+
+### Secrets
+
+```toml
+[capabilities]
+host_functions = ["get_secret"]
+```
+
+```rust
+use barbacane_plugin_sdk::host;
+
+// Secrets are resolved at gateway startup from env:// or file:// references
+if let Some(api_key) = host::get_secret("api_key") {
+    // use api_key
+}
+```
+
+### HTTP Calls (Dispatcher only)
+
+```toml
+[capabilities]
+host_functions = ["http_call"]
+```
+
+```rust
+use barbacane_plugin_sdk::host;
+
+let response = host::http_call(HttpRequest {
+    method: "GET".to_string(),
+    url: "https://api.example.com/data".to_string(),
+    headers: Default::default(),
+    body: None,
+    timeout_ms: Some(5000),
+})?;
+```
+
+## Using Plugins in Specs
+
+### Declare in barbacane.yaml
+
+```yaml
+plugins:
+  my-plugin:
+    path: ./plugins/my_plugin.wasm
+```
+
+### Use in OpenAPI spec
+
+**As middleware:**
+
+```yaml
+paths:
+  /users:
+    get:
+      x-barbacane-middlewares:
+        - name: my-plugin
+          config:
+            header_name: "X-Custom"
+            header_value: "hello"
+```
+
+**As dispatcher:**
+
+```yaml
+paths:
+  /mock:
+    get:
+      x-barbacane-dispatch:
+        name: my-plugin
+        config:
+          status: 200
+          body: '{"message": "Hello"}'
+```
+
+## Testing Plugins
+
+### Unit Testing
+
+Test your plugin logic directly:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_adds_header() {
+        let mut plugin = MyMiddleware {
+            header_name: "X-Test".to_string(),
+            header_value: "value".to_string(),
+        };
+
+        let req = Request {
+            method: "GET".to_string(),
+            path: "/test".to_string(),
+            headers: Default::default(),
+            ..Default::default()
+        };
+
+        let action = plugin.on_request(req);
+        match action {
+            Action::Continue(req) => {
+                assert_eq!(req.headers.get("X-Test"), Some(&"value".to_string()));
+            }
+            _ => panic!("Expected Continue"),
+        }
+    }
+}
+```
+
+### Integration Testing
+
+Use fixture specs with `barbacane-test`:
+
+```rust
+use barbacane_test::TestGateway;
+
+#[tokio::test]
+async fn test_my_plugin() {
+    let gw = TestGateway::from_spec("tests/fixtures/my-plugin-test.yaml")
+        .await
+        .unwrap();
+
+    let resp = gw.get("/test").await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.headers().get("X-Test"), Some("value"));
+}
+```
+
+## Official Plugins
+
+Barbacane includes these official plugins in the `plugins/` directory:
+
+| Plugin | Type | Description |
+|--------|------|-------------|
+| `mock` | Dispatcher | Return static responses |
+| `http-upstream` | Dispatcher | Reverse proxy to HTTP backends |
+| `lambda` | Dispatcher | Invoke AWS Lambda functions |
+| `jwt-auth` | Middleware | JWT token validation |
+| `apikey-auth` | Middleware | API key authentication |
+| `oauth2-auth` | Middleware | OAuth2 token introspection |
+| `rate-limit` | Middleware | Sliding window rate limiting |
+| `cache` | Middleware | Response caching |
+| `cors` | Middleware | CORS header management |
+
+Use these as references for your own plugins.
+
+## Best Practices
+
+1. **Keep plugins focused** - One plugin, one responsibility
+2. **Validate configuration** - Use JSON Schema to catch config errors at compile time
+3. **Handle errors gracefully** - Return appropriate error responses, don't panic
+4. **Document capabilities** - Only declare host functions you actually use
+5. **Test thoroughly** - Unit test logic, integration test with the gateway
+6. **Use semantic versioning** - Follow semver for plugin versions
+
+## Resource Limits
+
+Plugins run in a sandboxed WASM environment with these limits:
+
+| Resource | Limit |
+|----------|-------|
+| Linear memory | 16 MB |
+| Stack size | 1 MB |
+| Execution time | 100 ms |
+
+Exceeding these limits results in a trap (500 error for request phase, fault-tolerant for response phase).
+
+## Troubleshooting
+
+### Plugin not found
+
+Ensure the plugin is declared in `barbacane.yaml` and the WASM file exists at the specified path.
+
+### Config validation failed
+
+Check that your plugin's configuration in the OpenAPI spec matches the JSON Schema in `config-schema.json`.
+
+### WASM trap
+
+Your plugin exceeded resource limits or panicked. Check logs for details. Common causes:
+- Infinite loops
+- Large memory allocations
+- Unhandled errors causing panic
+
+### Unknown capability
+
+You're using a host function not declared in `plugin.toml`. Add it to `capabilities.host_functions`.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -19,9 +19,10 @@ cargo build --release
 # Binary is in target/release/barbacane
 ```
 
-### Using Cargo (coming soon)
+### Using Cargo (planned for v1.0)
 
 ```bash
+# Not yet published to crates.io
 cargo install barbacane
 ```
 
@@ -105,7 +106,7 @@ plugins:
 
 The manifest declares all WASM plugins used by your spec. Plugins can be sourced from:
 - **Local path**: `path: ./plugins/name.wasm`
-- **URL** (coming soon): `url: https://plugins.example.com/name.wasm`
+- **URL** (planned): `url: https://plugins.example.com/name.wasm`
 
 ### 3. Validate the Spec
 

--- a/docs/guide/spec-configuration.md
+++ b/docs/guide/spec-configuration.md
@@ -311,6 +311,64 @@ paths:
           description: Payment processed
 ```
 
+## API Lifecycle
+
+Barbacane supports API lifecycle management through standard OpenAPI deprecation and the `x-barbacane-sunset` extension.
+
+### Marking Operations as Deprecated
+
+Use the standard OpenAPI `deprecated` field:
+
+```yaml
+paths:
+  /v1/users:
+    get:
+      deprecated: true
+      summary: List users (deprecated, use /v2/users)
+      x-barbacane-dispatch:
+        name: http-upstream
+        config:
+          url: "https://api.example.com"
+```
+
+When a client calls a deprecated endpoint, the response includes a `Deprecation: true` header per [draft-ietf-httpapi-deprecation-header](https://datatracker.ietf.org/doc/draft-ietf-httpapi-deprecation-header/).
+
+### Setting a Sunset Date
+
+Use `x-barbacane-sunset` to specify when an endpoint will be removed:
+
+```yaml
+paths:
+  /v1/users:
+    get:
+      deprecated: true
+      x-barbacane-sunset: "Sat, 31 Dec 2025 23:59:59 GMT"
+      x-barbacane-dispatch:
+        name: http-upstream
+        config:
+          url: "https://api.example.com"
+```
+
+The sunset date must be in HTTP-date format (RFC 9110). When set, the response includes a `Sunset` header per [RFC 8594](https://datatracker.ietf.org/doc/html/rfc8594).
+
+### Example Response Headers
+
+```
+HTTP/1.1 200 OK
+Deprecation: true
+Sunset: Sat, 31 Dec 2025 23:59:59 GMT
+Content-Type: application/json
+```
+
+### Best Practices
+
+1. **Mark deprecated first**: Set `deprecated: true` before setting a sunset date
+2. **Give advance notice**: Set the sunset date at least 6 months in advance
+3. **Update API docs**: Include migration instructions in the operation summary or description
+4. **Monitor usage**: Track calls to deprecated endpoints via metrics
+
+---
+
 ## Validation
 
 The compiler validates your spec:

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,15 +13,16 @@
 ## Quick Start
 
 ```bash
-# Install (coming soon)
-cargo install barbacane
+# Build from source (crates.io publishing planned for v1.0)
+git clone https://github.com/barbacane/barbacane.git
+cd barbacane && cargo build --release
 
 # Add x-barbacane-dispatch to your OpenAPI spec
 # Compile
-barbacane compile --spec api.yaml --output api.bca
+./target/release/barbacane compile --spec api.yaml --output api.bca
 
 # Run
-barbacane serve --artifact api.bca --listen 0.0.0.0:8080
+./target/release/barbacane serve --artifact api.bca --listen 0.0.0.0:8080
 ```
 
 ## Documentation

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -311,6 +311,27 @@ X-Trace-Id: 4bf92f3577b34da6a3ce929d0e0e4736
 Content-Type: application/json
 ```
 
+### API Lifecycle Headers
+
+For deprecated operations, additional headers are included:
+
+| Header | Description |
+|--------|-------------|
+| `Deprecation` | `true` - indicates the endpoint is deprecated (per draft-ietf-httpapi-deprecation-header) |
+| `Sunset` | HTTP-date when the endpoint will be removed (per RFC 8594) |
+
+Example for deprecated endpoint:
+
+```
+HTTP/1.1 200 OK
+Server: barbacane/0.1.0
+Deprecation: true
+Sunset: Sat, 31 Dec 2025 23:59:59 GMT
+Content-Type: application/json
+```
+
+See [API Lifecycle](#api-lifecycle) for configuration details.
+
 ### Exit Codes
 
 | Code | Meaning |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -176,6 +176,8 @@ barbacane serve --artifact <PATH> [OPTIONS]
 | `--allow-plaintext-upstream` | No | `false` | Allow `http://` upstream URLs (dev only) |
 | `--tls-cert` | No | - | Path to TLS certificate file (PEM format) |
 | `--tls-key` | No | - | Path to TLS private key file (PEM format) |
+| `--keepalive-timeout` | No | `60` | HTTP keep-alive idle timeout in seconds |
+| `--shutdown-timeout` | No | `30` | Graceful shutdown timeout in seconds |
 
 ### Examples
 
@@ -268,6 +270,45 @@ Requests exceeding limits receive an RFC 9457 problem details response:
   "status": 400,
   "detail": "request body too large: 2000000 bytes exceeds limit of 1048576 bytes"
 }
+```
+
+### Graceful Shutdown
+
+The gateway handles shutdown signals (SIGTERM, SIGINT) gracefully:
+
+1. **Stop accepting** new connections immediately
+2. **Drain** in-flight requests for up to `--shutdown-timeout` seconds (default: 30)
+3. **Force close** any remaining connections after timeout
+4. **Exit** with code 0 on successful shutdown
+
+```bash
+# Send SIGTERM to gracefully shutdown
+kill -TERM $(pgrep barbacane)
+
+# Output during graceful shutdown
+barbacane: received shutdown signal, draining connections...
+barbacane: waiting for 3 active connection(s) to complete...
+barbacane: all connections drained, shutting down
+```
+
+### Response Headers
+
+Every response includes these standard headers:
+
+| Header | Description |
+|--------|-------------|
+| `Server` | `barbacane/<version>` (e.g., `barbacane/0.1.0`) |
+| `X-Request-Id` | Request ID - propagates incoming header or generates UUID v4 |
+| `X-Trace-Id` | Trace ID - extracted from `traceparent` header or generated |
+
+Example response headers:
+
+```
+HTTP/1.1 200 OK
+Server: barbacane/0.1.0
+X-Request-Id: 550e8400-e29b-41d4-a716-446655440000
+X-Trace-Id: 4bf92f3577b34da6a3ce929d0e0e4736
+Content-Type: application/json
 ```
 
 ### Exit Codes

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -243,6 +243,30 @@ barbacane serve --artifact api.bca \
 - Certificate file can contain the full chain (cert + intermediates)
 - Both `--tls-cert` and `--tls-key` must be provided together
 
+### HTTP/2 Support
+
+The gateway supports both HTTP/1.1 and HTTP/2 with automatic protocol detection:
+
+- **With TLS**: HTTP/2 is negotiated via ALPN (Application-Layer Protocol Negotiation). Clients that support HTTP/2 will automatically use it when connecting over HTTPS.
+- **Without TLS**: HTTP/1.1 is used by default. HTTP/2 cleartext (h2c) is also supported via protocol detection.
+
+**HTTP/2 Features:**
+- Multiplexed streams over a single connection
+- Header compression (HPACK)
+- Keep-alive with configurable ping intervals (20 seconds)
+- Full support for all gateway features (routing, validation, middlewares)
+
+No configuration is needed—HTTP/2 works automatically when TLS is enabled. To verify HTTP/2 is working:
+
+```bash
+# Test HTTP/2 with curl
+curl -v --http2 https://localhost:8080/__barbacane/health
+
+# Expected output shows HTTP/2:
+# * Using HTTP/2
+# < HTTP/2 200
+```
+
 ### Development Mode
 
 The `--dev` flag enables:

--- a/tests/api.http
+++ b/tests/api.http
@@ -1,4 +1,4 @@
-### Barbacane API Test Scenarios (M2-M4)
+### Barbacane API Test Scenarios (M2-M11)
 ### Usage: Start gateway first with:
 ###   cargo build
 ###   ./target/debug/barbacane compile --spec tests/fixtures/validation.yaml --output /tmp/test.bca
@@ -269,3 +269,247 @@ GET {{baseUrl}}/delay/2
 
 ### Slow response (6 seconds, exceeds 5s timeout -> 504)
 GET {{baseUrl}}/delay/6
+
+### ================================================================
+### M11: API Lifecycle / Deprecation Tests
+### ================================================================
+### Usage: Start gateway with deprecated.yaml:
+###   ./target/debug/barbacane compile --spec tests/fixtures/deprecated.yaml -m tests/fixtures/barbacane.yaml -o /tmp/deprecated.bca
+###   ./target/debug/barbacane serve --artifact /tmp/deprecated.bca --dev
+
+### Current endpoint - no deprecation headers
+# Expected: 200 OK, no Deprecation/Sunset headers
+GET {{baseUrl}}/v2/users
+
+###
+
+### Deprecated endpoint (no sunset date)
+# Expected: 200 OK with Deprecation: true header
+GET {{baseUrl}}/v1/users
+
+###
+
+### Deprecated endpoint with sunset date
+# Expected: 200 OK with Deprecation: true AND Sunset headers
+GET {{baseUrl}}/v1/users/123
+
+###
+
+### Legacy endpoint with far-future sunset (2030)
+# Expected: 200 OK with Deprecation: true AND Sunset: 2030 headers
+GET {{baseUrl}}/legacy/status
+
+### ================================================================
+### M11: Full CRUD API Tests
+### ================================================================
+### Usage: Start gateway with full-crud.yaml:
+###   ./target/debug/barbacane compile --spec tests/fixtures/full-crud.yaml -m tests/fixtures/barbacane.yaml -o /tmp/full-crud.bca
+###   ./target/debug/barbacane serve --artifact /tmp/full-crud.bca --dev
+
+### ================================
+### List Users
+### ================================
+
+### List users - no params
+# Expected: 200 OK
+GET {{baseUrl}}/users
+
+###
+
+### List users - with pagination
+# Expected: 200 OK
+GET {{baseUrl}}/users?limit=10&offset=0
+
+###
+
+### List users - invalid limit (exceeds 100)
+# Expected: 400 Bad Request
+GET {{baseUrl}}/users?limit=200
+
+### ================================
+### Create User
+### ================================
+
+### Create user - valid
+# Expected: 201 Created
+POST {{baseUrl}}/users
+Content-Type: application/json
+
+{"email": "test@example.com", "name": "Test User"}
+
+###
+
+### Create user - with optional age
+# Expected: 201 Created
+POST {{baseUrl}}/users
+Content-Type: application/json
+
+{"email": "test@example.com", "name": "Test User", "age": 30}
+
+###
+
+### Create user - missing required name
+# Expected: 400 Bad Request
+POST {{baseUrl}}/users
+Content-Type: application/json
+
+{"email": "test@example.com"}
+
+###
+
+### Create user - invalid email format
+# Expected: 400 Bad Request
+POST {{baseUrl}}/users
+Content-Type: application/json
+
+{"email": "not-an-email", "name": "Test User"}
+
+### ================================
+### Get User
+### ================================
+
+### Get user - valid UUID
+# Expected: 200 OK
+GET {{baseUrl}}/users/550e8400-e29b-41d4-a716-446655440000
+
+###
+
+### Get user - invalid UUID format
+# Expected: 400 Bad Request
+GET {{baseUrl}}/users/not-a-uuid
+
+### ================================
+### Update User
+### ================================
+
+### Update user - valid
+# Expected: 200 OK
+PUT {{baseUrl}}/users/550e8400-e29b-41d4-a716-446655440000
+Content-Type: application/json
+
+{"name": "Updated Name", "email": "updated@example.com"}
+
+###
+
+### Update user - partial update
+# Expected: 200 OK
+PUT {{baseUrl}}/users/550e8400-e29b-41d4-a716-446655440000
+Content-Type: application/json
+
+{"name": "Just Name"}
+
+### ================================
+### Delete User
+### ================================
+
+### Delete user
+# Expected: 204 No Content
+DELETE {{baseUrl}}/users/550e8400-e29b-41d4-a716-446655440000
+
+### ================================
+### Nested Resources (User Orders)
+### ================================
+
+### Get user orders
+# Expected: 200 OK
+GET {{baseUrl}}/users/550e8400-e29b-41d4-a716-446655440000/orders
+
+###
+
+### Get user orders - with status filter
+# Expected: 200 OK
+GET {{baseUrl}}/users/550e8400-e29b-41d4-a716-446655440000/orders?status=pending
+
+###
+
+### Get user orders - invalid status enum
+# Expected: 400 Bad Request
+GET {{baseUrl}}/users/550e8400-e29b-41d4-a716-446655440000/orders?status=invalid
+
+### ================================================================
+### M11: Multi-Spec API Tests
+### ================================================================
+### Usage: Start gateway with combined specs:
+###   ./target/debug/barbacane compile --spec tests/fixtures/multi-spec/users.yaml --spec tests/fixtures/multi-spec/orders.yaml -m tests/fixtures/multi-spec/barbacane.yaml -o /tmp/multi.bca
+###   ./target/debug/barbacane serve --artifact /tmp/multi.bca --dev
+
+### ================================
+### Users Service (from users.yaml)
+### ================================
+
+### List users
+# Expected: 200 OK
+GET {{baseUrl}}/users
+
+###
+
+### Create user
+# Expected: 201 Created
+POST {{baseUrl}}/users
+Content-Type: application/json
+
+{"name": "Alice", "email": "alice@example.com"}
+
+###
+
+### Get user by ID
+# Expected: 200 OK
+GET {{baseUrl}}/users/user-123
+
+### ================================
+### Orders Service (from orders.yaml)
+### ================================
+
+### List orders
+# Expected: 200 OK
+GET {{baseUrl}}/orders
+
+###
+
+### List orders - with status filter
+# Expected: 200 OK
+GET {{baseUrl}}/orders?status=pending
+
+###
+
+### Create order
+# Expected: 201 Created
+POST {{baseUrl}}/orders
+Content-Type: application/json
+
+{
+  "userId": "user-123",
+  "items": [
+    {"productId": "prod-1", "quantity": 2},
+    {"productId": "prod-2", "quantity": 1}
+  ]
+}
+
+###
+
+### Get order by ID
+# Expected: 200 OK
+GET {{baseUrl}}/orders/order-123
+
+###
+
+### Update order status
+# Expected: 200 OK
+PUT {{baseUrl}}/orders/order-123/status
+Content-Type: application/json
+
+{"status": "shipped"}
+
+### ================================
+### Combined Health Check
+### ================================
+
+### Gateway health (should show combined routes count)
+# Expected: 200 OK with routes from both specs
+GET {{baseUrl}}/__barbacane/health
+
+###
+
+### OpenAPI specs list
+# Expected: 200 OK with list of both specs
+GET {{baseUrl}}/__barbacane/openapi

--- a/tests/fixtures/deprecated.yaml
+++ b/tests/fixtures/deprecated.yaml
@@ -1,0 +1,69 @@
+openapi: "3.1.0"
+info:
+  title: API with Deprecated Endpoints
+  version: "2.0.0"
+  description: Demonstrates API lifecycle features (deprecated + sunset headers)
+
+paths:
+  /v2/users:
+    get:
+      operationId: listUsersV2
+      summary: List users (current version)
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"users":[],"version":"v2"}'
+      responses:
+        "200":
+          description: List of users
+
+  /v1/users:
+    get:
+      operationId: listUsersV1
+      summary: List users (deprecated, use /v2/users)
+      deprecated: true
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"users":[],"version":"v1"}'
+      responses:
+        "200":
+          description: List of users (deprecated response)
+
+  /v1/users/{id}:
+    get:
+      operationId: getUserV1
+      summary: Get user by ID (deprecated with sunset date)
+      deprecated: true
+      x-barbacane-sunset: "Sat, 31 Dec 2025 23:59:59 GMT"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"id":"1","name":"Alice","version":"v1"}'
+      responses:
+        "200":
+          description: User found
+
+  /legacy/status:
+    get:
+      operationId: legacyStatus
+      summary: Legacy status endpoint (deprecated with far future sunset)
+      deprecated: true
+      x-barbacane-sunset: "Wed, 01 Jan 2030 00:00:00 GMT"
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"status":"operational","deprecated":true}'
+      responses:
+        "200":
+          description: Legacy status response

--- a/tests/fixtures/full-crud.yaml
+++ b/tests/fixtures/full-crud.yaml
@@ -1,0 +1,189 @@
+openapi: "3.1.0"
+info:
+  title: Full CRUD API
+  version: "1.0.0"
+  description: Complete example with all HTTP methods, request bodies, and validation
+
+servers:
+  - url: https://api.example.com
+    x-barbacane-upstream:
+      name: main-backend
+      timeout: 30s
+
+x-barbacane-middlewares:
+  - name: rate-limit
+    config:
+      quota: 1000
+      window: 60
+
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      summary: List all users
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"users":[],"total":0}'
+      responses:
+        "200":
+          description: List of users
+
+    post:
+      operationId: createUser
+      summary: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - name
+              properties:
+                email:
+                  type: string
+                  format: email
+                name:
+                  type: string
+                  minLength: 1
+                  maxLength: 100
+                age:
+                  type: integer
+                  minimum: 0
+                  maximum: 150
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 201
+          body: '{"id":"uuid-123","email":"test@example.com","name":"Test User"}'
+      responses:
+        "201":
+          description: User created
+        "400":
+          description: Validation error
+
+  /users/{userId}:
+    get:
+      operationId: getUser
+      summary: Get user by ID
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"id":"uuid-123","email":"test@example.com","name":"Test User"}'
+      responses:
+        "200":
+          description: User found
+        "404":
+          description: User not found
+
+    put:
+      operationId: updateUser
+      summary: Update user
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                name:
+                  type: string
+                  minLength: 1
+                  maxLength: 100
+                age:
+                  type: integer
+                  minimum: 0
+                  maximum: 150
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"id":"uuid-123","email":"updated@example.com","name":"Updated User"}'
+      responses:
+        "200":
+          description: User updated
+        "400":
+          description: Validation error
+        "404":
+          description: User not found
+
+    delete:
+      operationId: deleteUser
+      summary: Delete user
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 204
+          body: ''
+      responses:
+        "204":
+          description: User deleted
+        "404":
+          description: User not found
+
+  /users/{userId}/orders:
+    get:
+      operationId: getUserOrders
+      summary: Get orders for a user
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [pending, processing, shipped, delivered, cancelled]
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"orders":[]}'
+      responses:
+        "200":
+          description: List of orders

--- a/tests/fixtures/full-crud.yaml
+++ b/tests/fixtures/full-crud.yaml
@@ -25,16 +25,15 @@ paths:
         - name: limit
           in: query
           schema:
-            type: integer
-            minimum: 1
-            maximum: 100
-            default: 20
+            type: string
+            pattern: "^[1-9][0-9]?$|^100$"
+            default: "20"
         - name: offset
           in: query
           schema:
-            type: integer
-            minimum: 0
-            default: 0
+            type: string
+            pattern: "^[0-9]+$"
+            default: "0"
       x-barbacane-dispatch:
         name: mock
         config:

--- a/tests/fixtures/invalid-missing-dispatch.yaml
+++ b/tests/fixtures/invalid-missing-dispatch.yaml
@@ -1,0 +1,14 @@
+openapi: "3.1.0"
+info:
+  title: Invalid - Missing Dispatch
+  version: "1.0.0"
+  description: This spec is invalid because an operation is missing x-barbacane-dispatch
+
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      # Missing x-barbacane-dispatch - should trigger E1020 warning
+      responses:
+        "200":
+          description: OK

--- a/tests/fixtures/invalid-parse-error.yaml
+++ b/tests/fixtures/invalid-parse-error.yaml
@@ -1,0 +1,15 @@
+openapi: "3.1.0"
+info:
+  title: Invalid - Parse Error
+  version: "1.0.0"
+
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      # Intentionally malformed YAML - bad indentation causes E1002
+        x-barbacane-dispatch:
+        name: mock
+      responses:
+        "200":
+          description: OK

--- a/tests/fixtures/invalid-routing-conflict/spec-a.yaml
+++ b/tests/fixtures/invalid-routing-conflict/spec-a.yaml
@@ -1,0 +1,32 @@
+openapi: "3.1.0"
+info:
+  title: Service A - Users
+  version: "1.0.0"
+  description: First spec defining /users
+
+paths:
+  /users:
+    get:
+      operationId: listUsersA
+      summary: List users (from Service A)
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"source":"service-a","users":[]}'
+      responses:
+        "200":
+          description: List of users
+
+  /service-a/health:
+    get:
+      operationId: healthA
+      summary: Service A health
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"status":"ok","service":"a"}'
+      responses:
+        "200":
+          description: OK

--- a/tests/fixtures/invalid-routing-conflict/spec-b.yaml
+++ b/tests/fixtures/invalid-routing-conflict/spec-b.yaml
@@ -1,0 +1,34 @@
+openapi: "3.1.0"
+info:
+  title: Service B - Users
+  version: "1.0.0"
+  description: Second spec also defining /users (causes E1010 conflict)
+
+paths:
+  /users:
+    get:
+      # This conflicts with spec-a.yaml's GET /users
+      # Should cause E1010 routing conflict error
+      operationId: listUsersB
+      summary: List users (from Service B) - CONFLICT!
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"source":"service-b","users":[]}'
+      responses:
+        "200":
+          description: List of users
+
+  /service-b/health:
+    get:
+      operationId: healthB
+      summary: Service B health (no conflict)
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"status":"ok","service":"b"}'
+      responses:
+        "200":
+          description: OK

--- a/tests/fixtures/invalid-unknown-extension.yaml
+++ b/tests/fixtures/invalid-unknown-extension.yaml
@@ -1,0 +1,25 @@
+openapi: "3.1.0"
+info:
+  title: Invalid - Unknown Extension
+  version: "1.0.0"
+  description: This spec has unknown x-barbacane-* extensions (E1015 warning)
+
+# Unknown global extension - should trigger E1015 warning
+x-barbacane-unknown-global:
+  some: config
+
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      # Unknown operation-level extension - should trigger E1015 warning
+      x-barbacane-custom-feature:
+        enabled: true
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"status":"ok"}'
+      responses:
+        "200":
+          description: OK

--- a/tests/fixtures/multi-spec/barbacane.yaml
+++ b/tests/fixtures/multi-spec/barbacane.yaml
@@ -1,0 +1,5 @@
+# Multi-spec test fixtures manifest
+
+plugins:
+  mock:
+    path: ../../../plugins/mock/mock.wasm

--- a/tests/fixtures/multi-spec/orders.yaml
+++ b/tests/fixtures/multi-spec/orders.yaml
@@ -1,0 +1,109 @@
+openapi: "3.1.0"
+info:
+  title: Orders Service API
+  version: "1.0.0"
+  description: Order management endpoints
+
+paths:
+  /orders:
+    get:
+      operationId: listOrders
+      summary: List all orders
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [pending, processing, shipped, delivered]
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"orders":[{"id":"order-1","status":"pending"}]}'
+      responses:
+        "200":
+          description: List of orders
+
+    post:
+      operationId: createOrder
+      summary: Create a new order
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId, items]
+              properties:
+                userId:
+                  type: string
+                items:
+                  type: array
+                  items:
+                    type: object
+                    required: [productId, quantity]
+                    properties:
+                      productId:
+                        type: string
+                      quantity:
+                        type: integer
+                        minimum: 1
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 201
+          body: '{"id":"order-new","status":"pending"}'
+      responses:
+        "201":
+          description: Order created
+
+  /orders/{orderId}:
+    get:
+      operationId: getOrder
+      summary: Get order by ID
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"id":"order-1","status":"pending","items":[]}'
+      responses:
+        "200":
+          description: Order found
+        "404":
+          description: Order not found
+
+  /orders/{orderId}/status:
+    put:
+      operationId: updateOrderStatus
+      summary: Update order status
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum: [pending, processing, shipped, delivered, cancelled]
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"id":"order-1","status":"shipped"}'
+      responses:
+        "200":
+          description: Status updated

--- a/tests/fixtures/multi-spec/users.yaml
+++ b/tests/fixtures/multi-spec/users.yaml
@@ -1,0 +1,65 @@
+openapi: "3.1.0"
+info:
+  title: Users Service API
+  version: "1.0.0"
+  description: User management endpoints
+
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      summary: List all users
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"users":[{"id":"1","name":"Alice"},{"id":"2","name":"Bob"}]}'
+      responses:
+        "200":
+          description: List of users
+
+    post:
+      operationId: createUser
+      summary: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, email]
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                  format: email
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 201
+          body: '{"id":"3","name":"New User"}'
+      responses:
+        "201":
+          description: User created
+
+  /users/{userId}:
+    get:
+      operationId: getUser
+      summary: Get user by ID
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"id":"1","name":"Alice","email":"alice@example.com"}'
+      responses:
+        "200":
+          description: User found
+        "404":
+          description: User not found


### PR DESCRIPTION
## Summary

Implements M11 production readiness features and comprehensive repository review:

- **HTTP/2 support**: Automatic protocol detection via ALPN (TLS) and h2c (plaintext)
- **API lifecycle**: Deprecation headers per RFC 9110
- **Graceful shutdown**: SIGTERM/SIGINT handling with configurable drain timeout
- **Response headers**: Server, X-Request-Id, X-Trace-Id on every response
- **Repository review**: Documentation, code fixes, 255 tests

## Features

### HTTP/2 Support
- Auto protocol detection via ALPN for TLS connections
- HTTP/2 prior knowledge (h2c) for plaintext connections
- HTTP/1.1 keep-alive with configurable timeout

### API Lifecycle
- `deprecated: true` support in OpenAPI operations
- `x-barbacane-sunset` extension for sunset dates
- `Deprecation` and `Sunset` response headers
- `barbacane_deprecated_route_requests_total` metric

### Production Headers
Every response includes:
```
Server: barbacane/0.1.0
X-Request-Id: <uuid>
X-Trace-Id: <trace-id>
```

## Documentation Improvements

- **CHANGELOG.md**: Full release history (M1-M11)
- **docs/contributing/plugins.md**: Plugin development guide
- **README.md**: Badges, quick start, documentation links
- Updated "coming soon" → "planned" across docs

## Code Fixes

- Client IP extraction (was hardcoded `0.0.0.0`)
- http-upstream: forward query strings, detect protocol
- artifact.rs: read plugin version/type from plugin.toml

## Test Summary

| Crate | Tests |
|-------|-------|
| barbacane-wasm | 93 |
| barbacane-test | 82 |
| barbacane-validator | 24 |
| barbacane-compiler | 17 |
| barbacane-telemetry | 16 |
| barbacane-router | 13 |
| barbacane-spec-parser | 10 |
| **Total** | **255** |

## Test plan

- [x] `cargo test --workspace` passes (255 tests)
- [x] `cargo clippy --workspace` passes (no warnings)
- [x] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.ai/code)