### PR TITLE
feat: new /__barbacane/specs endpoint with merged spec support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated CLI Reference with `seed-plugins` command documentation
 - Added Interactive API Documentation section (Scalar at `/api/docs`)
 
+#### API Spec Endpoint
+- New `/__barbacane/specs` endpoint replacing `/__barbacane/openapi`
+- Merged spec endpoints: `/__barbacane/specs/openapi` and `/__barbacane/specs/asyncapi`
+- Format selection via `?format=json` or `?format=yaml` query parameter
+- Type-aware index response separating OpenAPI and AsyncAPI specs
+- Internal `x-barbacane-*` extensions stripped from served specs
+
 #### Other
 - HTTP/2 support with automatic protocol detection via ALPN
-- API lifecycle support with `deprecated` flag and `x-barbacane-sunset` extension
+- API lifecycle support with `deprecated` flag and `x-sunset` extension (RFC 8594)
 - `Deprecation` and `Sunset` response headers for deprecated routes
 - Fixture-based test specs for comprehensive integration testing
 - SLO violation metrics (`barbacane_slo_violation_total`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,3 +130,5 @@ barbacane-plugin-macros = { path = "crates/barbacane-plugin-macros", version = "
 barbacane-wasm = { path = "crates/barbacane-wasm", version = "0.1.0" }
 barbacane-telemetry = { path = "crates/barbacane-telemetry", version = "0.1.0" }
 barbacane-test = { path = "crates/barbacane-test", version = "0.1.0" }
+barbacane = { path = "crates/barbacane", version = "0.1.0" }
+barbacane-control = { path = "crates/barbacane-control", version = "0.1.0" }

--- a/adr/0015-api-versioning-lifecycle.md
+++ b/adr/0015-api-versioning-lifecycle.md
@@ -53,7 +53,7 @@ paths:
   /users/{id}/legacy-profile:
     get:
       deprecated: true
-      x-barbacane-sunset: "2026-06-01"
+      x-sunset: "Sat, 01 Jun 2026 00:00:00 GMT"
 ```
 
 Produces response header:

--- a/crates/barbacane-spec-parser/src/model.rs
+++ b/crates/barbacane-spec-parser/src/model.rs
@@ -56,7 +56,7 @@ pub struct Operation {
     /// Whether this operation is deprecated (OpenAPI `deprecated` field).
     #[serde(default)]
     pub deprecated: bool,
-    /// Sunset date for deprecated operations (from `x-barbacane-sunset`).
+    /// Sunset date for deprecated operations (from `x-sunset` per RFC 8594).
     /// Format: HTTP-date per RFC 9110 (e.g., "Sat, 31 Dec 2024 23:59:59 GMT").
     pub sunset: Option<String>,
     /// Operation-level `x-barbacane-*` extensions.

--- a/crates/barbacane-spec-parser/src/parser.rs
+++ b/crates/barbacane-spec-parser/src/parser.rs
@@ -203,9 +203,9 @@ fn parse_openapi_paths(
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
 
-                // Extract sunset date from x-barbacane-sunset extension
+                // Extract sunset date from x-sunset extension (RFC 8594)
                 let sunset = op_obj
-                    .get("x-barbacane-sunset")
+                    .get("x-sunset")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
 
@@ -385,7 +385,7 @@ fn parse_asyncapi_channels(
             .unwrap_or(false);
 
         let sunset = op_obj
-            .get("x-barbacane-sunset")
+            .get("x-sunset")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
@@ -923,7 +923,7 @@ paths:
   /old-endpoint:
     get:
       deprecated: true
-      x-barbacane-sunset: "Sat, 31 Dec 2025 23:59:59 GMT"
+      x-sunset: "Sat, 31 Dec 2025 23:59:59 GMT"
       x-barbacane-dispatch:
         name: mock
   /new-endpoint:

--- a/crates/barbacane-test/Cargo.toml
+++ b/crates/barbacane-test/Cargo.toml
@@ -10,6 +10,7 @@ barbacane-compiler = { workspace = true }
 tokio = { workspace = true }
 reqwest = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 tempfile = "3"
 thiserror = { workspace = true }
 rcgen = { workspace = true }

--- a/crates/barbacane-test/src/gateway.rs
+++ b/crates/barbacane-test/src/gateway.rs
@@ -2591,4 +2591,321 @@ paths:
 
         assert_eq!(resp.status(), 400);
     }
+
+    // ========================
+    // Specs Endpoint Tests
+    // ========================
+
+    #[tokio::test]
+    async fn test_specs_index_response() {
+        // Test the /__barbacane/specs endpoint returns correct JSON structure
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway");
+
+        let resp = gateway.get("/__barbacane/specs").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body: serde_json::Value = resp.json().await.unwrap();
+
+        // Check openapi section exists with correct structure
+        assert!(body.get("openapi").is_some());
+        assert!(body["openapi"]["specs"].is_array());
+        assert_eq!(body["openapi"]["count"], 2);
+        assert_eq!(body["openapi"]["merged_url"], "/__barbacane/specs/openapi");
+
+        // Check asyncapi section exists (should be empty for these fixtures)
+        assert!(body.get("asyncapi").is_some());
+        assert!(body["asyncapi"]["specs"].is_array());
+        assert_eq!(body["asyncapi"]["count"], 0);
+    }
+
+    #[tokio::test]
+    async fn test_specs_merged_openapi() {
+        // Test merged OpenAPI from multiple specs
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway");
+
+        let resp = gateway.get("/__barbacane/specs/openapi").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // Check content-type is YAML by default
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            content_type.contains("yaml"),
+            "expected yaml content-type, got: {}",
+            content_type
+        );
+
+        // Parse the YAML response
+        let body = resp.text().await.unwrap();
+        let spec: serde_json::Value =
+            serde_yaml::from_str(&body).expect("failed to parse merged spec");
+
+        // Check it's a valid OpenAPI spec
+        assert!(
+            spec.get("openapi").is_some(),
+            "merged spec should have openapi field"
+        );
+
+        // Check paths from both specs are merged
+        let paths = spec.get("paths").and_then(|p| p.as_object());
+        assert!(paths.is_some(), "merged spec should have paths");
+        let paths = paths.unwrap();
+
+        // Check paths from users.yaml
+        assert!(paths.contains_key("/users"), "should contain /users path");
+        assert!(
+            paths.contains_key("/users/{userId}"),
+            "should contain /users/{{userId}} path"
+        );
+
+        // Check paths from orders.yaml
+        assert!(paths.contains_key("/orders"), "should contain /orders path");
+        assert!(
+            paths.contains_key("/orders/{orderId}"),
+            "should contain /orders/{{orderId}} path"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_specs_merged_openapi_strips_extensions() {
+        // Test that merged specs strip x-barbacane-* extensions
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway");
+
+        let resp = gateway.get("/__barbacane/specs/openapi").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body = resp.text().await.unwrap();
+        let spec: serde_json::Value =
+            serde_yaml::from_str(&body).expect("failed to parse merged spec");
+
+        // Check that x-barbacane-dispatch is NOT in the merged spec
+        let spec_str = serde_json::to_string(&spec).unwrap();
+        assert!(
+            !spec_str.contains("x-barbacane-"),
+            "merged spec should not contain x-barbacane-* extensions"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_specs_individual_file() {
+        // Test individual spec endpoint
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway");
+
+        let resp = gateway.get("/__barbacane/specs/users.yaml").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body = resp.text().await.unwrap();
+        let spec: serde_json::Value = serde_yaml::from_str(&body).expect("failed to parse spec");
+
+        // Check it's the users spec
+        assert_eq!(
+            spec.pointer("/info/title"),
+            Some(&serde_json::json!("Users Service API"))
+        );
+
+        // Check paths are present
+        assert!(
+            spec.pointer("/paths/~1users").is_some(),
+            "should have /users path"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_specs_individual_strips_extensions() {
+        // Test that individual specs strip x-barbacane-* extensions
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway");
+
+        let resp = gateway.get("/__barbacane/specs/users.yaml").await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body = resp.text().await.unwrap();
+
+        // x-barbacane-dispatch should be stripped
+        assert!(
+            !body.contains("x-barbacane-"),
+            "individual spec should not contain x-barbacane-* extensions"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_specs_preserves_sunset_extension() {
+        // Test that x-sunset (RFC 8594) is preserved
+        let gateway = TestGateway::from_spec("../../tests/fixtures/deprecated.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        let resp = gateway
+            .get("/__barbacane/specs/deprecated.yaml")
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body = resp.text().await.unwrap();
+        let spec: serde_json::Value = serde_yaml::from_str(&body).expect("failed to parse spec");
+
+        // x-sunset should be preserved (it's a standard extension per RFC 8594)
+        let spec_str = serde_json::to_string(&spec).unwrap();
+        assert!(
+            spec_str.contains("x-sunset"),
+            "x-sunset extension should be preserved"
+        );
+
+        // But x-barbacane-* should be stripped
+        assert!(
+            !spec_str.contains("x-barbacane-"),
+            "x-barbacane-* extensions should be stripped"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_specs_format_json() {
+        // Test ?format=json query parameter
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway");
+
+        let resp = gateway
+            .get("/__barbacane/specs/openapi?format=json")
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // Check content-type is JSON
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            content_type.contains("json"),
+            "expected json content-type, got: {}",
+            content_type
+        );
+
+        // Parse as JSON (not YAML)
+        let body: serde_json::Value = resp.json().await.expect("should parse as JSON");
+        assert!(body.get("openapi").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_specs_format_yaml_explicit() {
+        // Test ?format=yaml query parameter (explicit)
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway");
+
+        let resp = gateway
+            .get("/__barbacane/specs/openapi?format=yaml")
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // Check content-type is YAML
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            content_type.contains("yaml"),
+            "expected yaml content-type, got: {}",
+            content_type
+        );
+    }
+
+    #[tokio::test]
+    async fn test_specs_individual_format_json() {
+        // Test format=json for individual spec file
+        let gateway = TestGateway::from_spec("../../tests/fixtures/minimal.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        let resp = gateway
+            .get("/__barbacane/specs/minimal.yaml?format=json")
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // Check content-type is JSON
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            content_type.contains("json"),
+            "expected json content-type, got: {}",
+            content_type
+        );
+
+        // Should parse as JSON
+        let _body: serde_json::Value = resp.json().await.expect("should parse as JSON");
+    }
+
+    #[tokio::test]
+    async fn test_specs_not_found() {
+        // Test 404 for non-existent spec file
+        let gateway = TestGateway::from_spec("../../tests/fixtures/minimal.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        let resp = gateway
+            .get("/__barbacane/specs/nonexistent.yaml")
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn test_specs_merged_asyncapi_empty() {
+        // Test merged AsyncAPI endpoint when there are no AsyncAPI specs
+        let gateway = TestGateway::from_specs(&[
+            "../../tests/fixtures/multi-spec/users.yaml",
+            "../../tests/fixtures/multi-spec/orders.yaml",
+        ])
+        .await
+        .expect("failed to start gateway");
+
+        // Should return 404 when no AsyncAPI specs exist
+        let resp = gateway.get("/__barbacane/specs/asyncapi").await.unwrap();
+        assert_eq!(resp.status(), 404);
+    }
 }

--- a/crates/barbacane-test/src/gateway.rs
+++ b/crates/barbacane-test/src/gateway.rs
@@ -2070,7 +2070,7 @@ paths:
         // This endpoint has no sunset date configured
         assert!(
             !resp.headers().contains_key("sunset"),
-            "Endpoint without x-barbacane-sunset should not have Sunset header"
+            "Endpoint without x-sunset should not have Sunset header"
         );
     }
 
@@ -2094,7 +2094,7 @@ paths:
         let sunset = resp.headers().get("sunset");
         assert!(
             sunset.is_some(),
-            "Endpoint with x-barbacane-sunset should have Sunset header"
+            "Endpoint with x-sunset should have Sunset header"
         );
         let sunset_val = sunset.unwrap().to_str().unwrap();
         assert!(

--- a/crates/barbacane/Cargo.toml
+++ b/crates/barbacane/Cargo.toml
@@ -27,6 +27,7 @@ http-body-util = { workspace = true }
 bytes = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 clap = { workspace = true }
 tracing = { workspace = true }
 rustls = { workspace = true }

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -335,7 +335,7 @@ Plugins are WebAssembly (WASM) modules that implement dispatchers or middlewares
 **Decision**: Embed source specs in the artifact.
 
 **Rationale**:
-- Self-documenting: `/__barbacane/openapi` always works
+- Self-documenting: `/__barbacane/specs` always works
 - No external dependencies at runtime
 - Version consistency
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -219,7 +219,7 @@ compiled 1 spec(s) to api.bca (3 routes, 2 plugin(s) bundled)
 
 The `.bca` (Barbacane Compiled Artifact) file contains:
 - Compiled routing table
-- Embedded source specs (for `/__barbacane/openapi`)
+- Embedded source specs (for `/__barbacane/specs`)
 - Bundled WASM plugins
 - Manifest with checksums
 
@@ -246,9 +246,9 @@ curl http://127.0.0.1:8080/health
 curl http://127.0.0.1:8080/__barbacane/health
 # {"status":"healthy","artifact_version":1,"compiler_version":"0.1.0","routes_count":3}
 
-# View the OpenAPI spec
-curl http://127.0.0.1:8080/__barbacane/openapi
-# Returns your original spec
+# View the API specs
+curl http://127.0.0.1:8080/__barbacane/specs
+# Returns index of specs with links to merged OpenAPI/AsyncAPI
 
 # Try a non-existent route
 curl http://127.0.0.1:8080/nonexistent

--- a/docs/guide/spec-configuration.md
+++ b/docs/guide/spec-configuration.md
@@ -416,7 +416,7 @@ operations:
 
 ## API Lifecycle
 
-Barbacane supports API lifecycle management through standard OpenAPI deprecation and the `x-barbacane-sunset` extension.
+Barbacane supports API lifecycle management through standard OpenAPI deprecation and the `x-sunset` extension.
 
 ### Marking Operations as Deprecated
 
@@ -438,14 +438,14 @@ When a client calls a deprecated endpoint, the response includes a `Deprecation:
 
 ### Setting a Sunset Date
 
-Use `x-barbacane-sunset` to specify when an endpoint will be removed:
+Use `x-sunset` to specify when an endpoint will be removed (per [RFC 8594](https://datatracker.ietf.org/doc/html/rfc8594)):
 
 ```yaml
 paths:
   /v1/users:
     get:
       deprecated: true
-      x-barbacane-sunset: "Sat, 31 Dec 2025 23:59:59 GMT"
+      x-sunset: "Sat, 31 Dec 2025 23:59:59 GMT"
       x-barbacane-dispatch:
         name: http-upstream
         config:

--- a/docs/reference/artifact.md
+++ b/docs/reference/artifact.md
@@ -135,7 +135,7 @@ Compiled operations with routing information.
 
 Directory containing the original source specifications. These are embedded for:
 
-- Serving via `/__barbacane/openapi` endpoint
+- Serving via `/__barbacane/specs` endpoint
 - Documentation and debugging
 - Audit trail
 
@@ -198,7 +198,7 @@ sha256sum extracted/routes.json
 
 ### Contents
 
-- Source specs are embedded and served publicly via `/__barbacane/openapi`
+- Source specs are embedded and served publicly via `/__barbacane/specs`
 - Do not include secrets in spec files
 - Use environment variables or secret management for sensitive config
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -619,7 +619,7 @@ barbacane serve --artifact api.bca --dev --listen 127.0.0.1:8080 &
 # Test endpoints
 curl http://localhost:8080/health
 curl http://localhost:8080/__barbacane/health
-curl http://localhost:8080/__barbacane/openapi
+curl http://localhost:8080/__barbacane/specs
 
 # Stop gateway
 kill %1

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -47,69 +47,92 @@ curl -f http://localhost:8080/__barbacane/health
 
 ---
 
-## OpenAPI Spec
+## API Specs
 
 ```
-GET /__barbacane/openapi
+GET /__barbacane/specs
 ```
 
-Returns the embedded OpenAPI specification(s).
+Returns an index of all embedded API specifications (OpenAPI and AsyncAPI).
 
-### Single Spec
-
-When the artifact contains one spec, returns it directly:
+### Index Response
 
 ```bash
-curl http://localhost:8080/__barbacane/openapi
-```
-
-Response: The original YAML/JSON spec
-
-Headers:
-- `Content-Type: application/x-yaml` (for YAML files)
-- `Content-Type: application/json` (for JSON files)
-
-### Multiple Specs
-
-When the artifact contains multiple specs, returns an index:
-
-```bash
-curl http://localhost:8080/__barbacane/openapi
+curl http://localhost:8080/__barbacane/specs
 ```
 
 ```json
 {
-  "specs": [
-    {
-      "name": "users-api.yaml",
-      "url": "/__barbacane/openapi/users-api.yaml"
-    },
-    {
-      "name": "orders-api.yaml",
-      "url": "/__barbacane/openapi/orders-api.yaml"
-    }
-  ],
-  "count": 2
+  "openapi": {
+    "specs": [
+      { "name": "users-api.yaml", "url": "/__barbacane/specs/users-api.yaml" },
+      { "name": "orders-api.yaml", "url": "/__barbacane/specs/orders-api.yaml" }
+    ],
+    "count": 2,
+    "merged_url": "/__barbacane/specs/openapi"
+  },
+  "asyncapi": {
+    "specs": [
+      { "name": "events.yaml", "url": "/__barbacane/specs/events.yaml" }
+    ],
+    "count": 1,
+    "merged_url": "/__barbacane/specs/asyncapi"
+  }
 }
 ```
 
-Then fetch individual specs:
+### Merged Specs
+
+Get all OpenAPI specs merged into one (for Swagger UI):
 
 ```bash
-curl http://localhost:8080/__barbacane/openapi/users-api.yaml
+curl http://localhost:8080/__barbacane/specs/openapi
 ```
+
+Get all AsyncAPI specs merged into one (for AsyncAPI Studio):
+
+```bash
+curl http://localhost:8080/__barbacane/specs/asyncapi
+```
+
+### Individual Specs
+
+Fetch a specific spec by filename:
+
+```bash
+curl http://localhost:8080/__barbacane/specs/users-api.yaml
+```
+
+### Format Selection
+
+Request specs in JSON or YAML format using the `format` query parameter:
+
+```bash
+# Get merged OpenAPI as JSON (for tools that prefer JSON)
+curl "http://localhost:8080/__barbacane/specs/openapi?format=json"
+
+# Get merged OpenAPI as YAML (default)
+curl "http://localhost:8080/__barbacane/specs/openapi?format=yaml"
+```
+
+### Extension Stripping
+
+All specs served via these endpoints have internal `x-barbacane-*` extensions stripped automatically. Only standard OpenAPI/AsyncAPI fields and the `x-sunset` extension (RFC 8594) are preserved.
 
 ### Usage
 
 ```bash
-# Swagger UI integration
-# Point Swagger UI to: http://your-gateway/__barbacane/openapi
+# Swagger UI integration (for OpenAPI specs)
+# Point Swagger UI to: http://your-gateway/__barbacane/specs/openapi
 
-# Download spec for documentation
-curl -o api.yaml http://localhost:8080/__barbacane/openapi
+# AsyncAPI Studio integration (for AsyncAPI specs)
+# Point to: http://your-gateway/__barbacane/specs/asyncapi
+
+# Download merged spec for documentation
+curl -o api.yaml http://localhost:8080/__barbacane/specs/openapi
 
 # API client generation
-curl http://localhost:8080/__barbacane/openapi | \
+curl http://localhost:8080/__barbacane/specs/openapi | \
   openapi-generator generate -i /dev/stdin -g typescript-fetch -o ./client
 ```
 

--- a/specs/SPEC-001-compilation.md
+++ b/specs/SPEC-001-compilation.md
@@ -103,15 +103,17 @@ x-barbacane-cache:
   vary: [<string>]              # optional — headers that vary the cache key
 ```
 
-### 3.5 `x-barbacane-sunset`
+### 3.5 `x-sunset`
 
 **Placement:** operation level, alongside `deprecated: true`.
 
+Per [RFC 8594](https://datatracker.ietf.org/doc/html/rfc8594), this extension specifies when an endpoint will be removed:
+
 ```yaml
-x-barbacane-sunset: "<ISO-8601 date>"   # e.g. "2026-06-01"
+x-sunset: "<HTTP-date>"   # e.g. "Sat, 31 Dec 2025 23:59:59 GMT"
 ```
 
-If `x-barbacane-sunset` is present but `deprecated` is not `true`, compilation fails with `E1030`.
+If `x-sunset` is present but `deprecated` is not `true`, compilation fails with `E1030`.
 
 ### 3.6 `x-barbacane-observability`
 
@@ -164,7 +166,7 @@ The compiler performs validation in order. Compilation stops at the first catego
 
 | Code | Condition |
 |------|-----------|
-| `E1030` | `x-barbacane-sunset` present but `deprecated` is not `true` |
+| `E1030` | `x-sunset` present but `deprecated` is not `true` |
 | `E1031` | `http://` upstream URL in production mode |
 | `E1032` | Operation declares `security` but no matching auth middleware in the chain |
 

--- a/specs/SPEC-002-request-lifecycle.md
+++ b/specs/SPEC-002-request-lifecycle.md
@@ -233,7 +233,7 @@ The final response is sent to the client. The gateway adds these headers to ever
 |--------|-------|----------------|
 | `X-Request-Id` | UUID v4 (generated at request start) | Yes |
 | `X-Trace-Id` | W3C trace ID (from `traceparent`) | Yes |
-| `Sunset` | RFC 8594 date (if `x-barbacane-sunset` is set on the operation) | Conditional |
+| `Sunset` | RFC 8594 date (if `x-sunset` is set on the operation) | Conditional |
 | `Server` | `barbacane/<version>` | Yes |
 | `RateLimit-Policy` | Quota policy per [draft-ietf-httpapi-ratelimit-headers](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/) | If rate limiting is active on the operation |
 | `RateLimit` | Remaining quota and reset time | If rate limiting is active on the operation |

--- a/tests/fixtures/deprecated.yaml
+++ b/tests/fixtures/deprecated.yaml
@@ -37,7 +37,7 @@ paths:
       operationId: getUserV1
       summary: Get user by ID (deprecated with sunset date)
       deprecated: true
-      x-barbacane-sunset: "Sat, 31 Dec 2025 23:59:59 GMT"
+      x-sunset: "Sat, 31 Dec 2025 23:59:59 GMT"
       parameters:
         - name: id
           in: path
@@ -58,7 +58,7 @@ paths:
       operationId: legacyStatus
       summary: Legacy status endpoint (deprecated with far future sunset)
       deprecated: true
-      x-barbacane-sunset: "Wed, 01 Jan 2030 00:00:00 GMT"
+      x-sunset: "Wed, 01 Jan 2030 00:00:00 GMT"
       x-barbacane-dispatch:
         name: mock
         config:


### PR DESCRIPTION
## Summary

- Replace `/__barbacane/openapi` with new `/__barbacane/specs` endpoint structure
- Add merged spec endpoints for Swagger UI and AsyncAPI Studio integration
- Rename `x-barbacane-sunset` to `x-sunset` (RFC 8594)
- Strip internal `x-barbacane-*` extensions from served specs

## New Endpoints

| Endpoint | Description |
|----------|-------------|
| `/__barbacane/specs` | JSON index with OpenAPI and AsyncAPI specs listed separately |
| `/__barbacane/specs/openapi` | Merged OpenAPI spec (all OpenAPI specs combined) |
| `/__barbacane/specs/asyncapi` | Merged AsyncAPI spec (all AsyncAPI specs combined) |
| `/__barbacane/specs/{filename}` | Individual spec by name |

## Format Selection

```bash
# YAML (default)
curl http://localhost:8080/__barbacane/specs/openapi

# JSON
curl "http://localhost:8080/__barbacane/specs/openapi?format=json"
```

## Test plan

- [x] All existing tests pass (92 tests)
- [x] Spec parser correctly parses `x-sunset` extension
- [x] Deprecation/sunset headers still work
- [x] Build and clippy pass