### PR TITLE
fix: update time crate to 0.3.47 for RUSTSEC-2026-0009

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3797,9 +3797,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "num-conv",


### PR DESCRIPTION
## Summary
- Updates `time` crate from 0.3.46 to 0.3.47 to fix RUSTSEC-2026-0009 (severity 6.8 medium)

## Details
The vulnerability was introduced as a transitive dependency via `rcgen` used by `barbacane-test`.

Dependency chain:
```
time 0.3.46
├── yasna 0.5.2
│   └── rcgen 0.13.2
│       └── barbacane-test 0.1.0
└── rcgen 0.13.2
```

## Test plan
- [x] `cargo audit` no longer reports RUSTSEC-2026-0009
- [x] `cargo test -p barbacane-test` passes