### PR TITLE
refactor: remove outdated extensions and add compile-time validations

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -23,6 +23,7 @@ Items are tagged with their source ADR or SPEC for traceability.
 
 | Plugin | Type | Description | Source |
 |--------|------|-------------|--------|
+| `observability` | Middleware | Trace sampling, detailed validation logs, latency SLO monitoring | ADR-0010 |
 | `acl` | Middleware | Access control by consumer/group after auth | Competitive analysis |
 | `request-size-limit` | Middleware | Reject requests exceeding size (per-route) | Competitive analysis |
 | `bot-detection` | Middleware | Block known bots by User-Agent patterns | Competitive analysis |
@@ -86,6 +87,9 @@ Items are tagged with their source ADR or SPEC for traceability.
 | VS Code extension | Spec editing with validation and autocomplete | P2 | — |
 | OpenAPI diff | Show changes between spec versions | P2 | — |
 | Improved error messages | More actionable validation and compilation errors | P2 | ADR-0012 |
+| Compile-time error catalog | Document all E-codes with examples and remediation | P2 | Tech review |
+| Extension documentation | Complete `x-barbacane-*` extension reference (ratelimit, cache, sunset) | P1 | Tech review |
+| Middleware ordering guide | Best practices for middleware execution order | P2 | Tech review |
 
 ### Integrations
 
@@ -110,6 +114,33 @@ Items are tagged with their source ADR or SPEC for traceability.
 
 ## Technical Debt
 
+### Compile-Time Safety Gaps
+
+| Item | Description | Priority | Status |
+|------|-------------|----------|--------|
+| ~~Ambiguous route detection~~ | E1050: Detect overlapping path templates | P0 | **DONE** |
+| ~~Schema complexity limits~~ | E1051/E1052: Depth (32) and property (256) limits | P0 | **DONE** |
+| ~~Circular `$ref` detection~~ | E1053: Detect circular JSON Schema references | P0 | **DONE** |
+| ~~Move E1011 to compile~~ | E1011: Missing middleware name validation | P1 | **DONE** |
+| Move E1015 to compile | Move unknown extension warning from `validate` to `compile` | P1 | Tech review |
+| ~~Path template syntax validation~~ | E1054: Validate braces, param names, duplicates | P2 | **DONE** |
+| ~~Duplicate operationId detection~~ | E1055: Detect non-unique operationId | P2 | **DONE** |
+| Spec pointers in errors | Add JSON Pointer (e.g., `#/paths/~1users/get`) to all compile errors | P2 | Tech review |
+| Deterministic artifact builds | Sort plugin/spec/route collections before serialization | P2 | Tech review |
+
+**Test cases added:**
+- `compile_detects_ambiguous_routes` ✓
+- `compile_detects_invalid_path_template_*` (3 tests) ✓
+- `compile_detects_schema_too_deep` ✓
+- `compile_detects_schema_too_complex` ✓
+- `compile_detects_duplicate_operation_ids` ✓
+- `compile_detects_missing_middleware_name` ✓
+- `compile_detects_missing_global_middleware_name` ✓
+- `validate_path_template_*` (2 unit tests) ✓
+- `normalize_path_template_works` ✓
+
+### Other Technical Debt
+
 | Item | Description | Priority | Source |
 |------|-------------|----------|--------|
 | JWKS fetch | Load JWT public keys from `jwks_uri` | P1 | M6a deferred |
@@ -117,6 +148,7 @@ Items are tagged with their source ADR or SPEC for traceability.
 | Auth plugin auditing | Security review process for auth plugins (security-critical WASM) | P1 | ADR-0009 |
 | Trace volume guidance | Documentation for managing trace volume at scale | P1 | ADR-0010 |
 | Integration tests | Full control plane API lifecycle tests with PostgreSQL | P2 | M9 deferred |
+| Compile safety CI | Add fitness functions: deterministic build verification, fuzz testing for compiler | P2 | Tech review |
 | CLI subcommands | `barbacane-control spec/artifact/plugin` REST-based commands | P2 | M9 deferred |
 | E1032 validation | Warn on OpenAPI security scheme without matching auth middleware | P2 | M6c deferred |
 | HTTP/2 stream config | Expose configuration for stream limits (currently fixed) | P3 | SPEC-002 |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml"><img src="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://docs.barbacane.dev"><img src="https://img.shields.io/badge/docs-docs.barbacane.dev-blue" alt="Documentation"></a>
-  <img src="https://img.shields.io/badge/tests-255%20passing-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-332%20passing-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rust-1.75%2B-orange" alt="Rust Version">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
 </p>

--- a/adr/0004-spec-driven-configuration.md
+++ b/adr/0004-spec-driven-configuration.md
@@ -61,34 +61,35 @@ AsyncAPI specs configure event-driven APIs with a **protocol-agnostic adapter la
 
 | Concern | OpenAPI | AsyncAPI |
 |---------|---------|----------|
-| Routing | `paths`, `servers` | `channels`, `servers` |
+| Routing | `paths` | `channels` |
 | Validation | `schemas`, `parameters` | `schemas`, `messages` |
 | Security | `securitySchemes` | `securitySchemes` |
-| Rate limiting | `x-barbacane-ratelimit` extension | `x-barbacane-ratelimit` extension |
-| Dispatch | `servers`, `x-barbacane-dispatch` | `servers`, bindings |
+| Middlewares | `x-barbacane-middlewares` (rate-limit, cache, auth, etc.) | `x-barbacane-middlewares` |
+| Dispatch | `x-barbacane-dispatch` | `x-barbacane-dispatch`, bindings |
 
 ### Gateway-Specific Extensions
 
 Where OpenAPI/AsyncAPI lack expressiveness, we use `x-barbacane-*` vendor extensions:
 
 ```yaml
-x-barbacane-ratelimit:
-  quota: 100
-  window: 60
-  key: header:x-api-key
+# Middleware chain (global or per-operation)
+x-barbacane-middlewares:
+  - name: rate-limit
+    config:
+      quota: 100
+      window: 60
+      partition_key: "header:x-api-key"
+  - name: cache
+    config:
+      ttl: 60
+      vary: [Accept, Authorization]
 
-x-barbacane-cache:
-  ttl: 60s
-  vary: [Accept, Authorization]
-
+# Dispatcher (required on each operation)
 x-barbacane-dispatch:
   name: http-upstream
   config:
-    timeout: 5s
-    retries: 2
-    circuit-breaker:
-      threshold: 5
-      window: 30s
+    url: "https://api.example.com"
+    timeout: 5.0
 ```
 
 ## Consequences

--- a/adr/0010-observability.md
+++ b/adr/0010-observability.md
@@ -110,17 +110,6 @@ Data planes push telemetry to an **OpenTelemetry Collector** via OTLP (gRPC or H
 - Data plane never talks directly to observability backends
 - If collector is unreachable, telemetry is dropped (never blocks request processing)
 
-### Spec Integration
-
-Observability can be tuned per-API via extensions:
-
-```yaml
-x-barbacane-observability:
-  trace_sampling: 0.1        # sample 10% of traces
-  detailed_validation_logs: true  # log every validation failure
-  latency_slo: 50ms          # emit alert metric when exceeded
-```
-
 ## Consequences
 
 - **Easier:** Unified observability format (OTel), correlation across traces/metrics/logs, plugins get telemetry "for free" via host functions

--- a/crates/barbacane-compiler/src/error.rs
+++ b/crates/barbacane-compiler/src/error.rs
@@ -1,4 +1,16 @@
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+/// A warning produced during compilation (non-blocking).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompileWarning {
+    /// Warning code (e.g., "E1015").
+    pub code: String,
+    /// Warning message.
+    pub message: String,
+    /// Location in the spec (e.g., "GET /users in 'api.yaml'").
+    pub location: Option<String>,
+}
 
 /// Errors produced during compilation.
 #[derive(Debug, Error)]
@@ -22,6 +34,34 @@ pub enum CompileError {
     /// E1040: Plugin used in spec but not declared in manifest.
     #[error("E1040: plugin '{0}' used in spec but not declared in barbacane.yaml")]
     UndeclaredPlugin(String),
+
+    /// E1011: Middleware entry missing required 'name' field.
+    #[error("E1011: middleware missing 'name': {0}")]
+    MissingMiddlewareName(String),
+
+    /// E1050: Ambiguous route - paths are structurally equivalent but differ in parameter names.
+    #[error("E1050: ambiguous route: {0}")]
+    AmbiguousRoute(String),
+
+    /// E1051: Schema exceeds maximum nesting depth.
+    #[error("E1051: schema too deep: {0}")]
+    SchemaTooDeep(String),
+
+    /// E1052: Schema exceeds maximum property count.
+    #[error("E1052: schema too complex: {0}")]
+    SchemaTooComplex(String),
+
+    /// E1053: Circular $ref detected in schema.
+    #[error("E1053: circular schema reference: {0}")]
+    CircularSchemaRef(String),
+
+    /// E1054: Invalid path template syntax.
+    #[error("E1054: invalid path template: {0}")]
+    InvalidPathTemplate(String),
+
+    /// E1055: Duplicate operationId across specs.
+    #[error("E1055: duplicate operationId '{0}': {1}")]
+    DuplicateOperationId(String, String),
 
     /// Manifest parsing or loading error.
     #[error("manifest error: {0}")]

--- a/crates/barbacane-compiler/src/lib.rs
+++ b/crates/barbacane-compiler/src/lib.rs
@@ -9,10 +9,11 @@ pub mod manifest;
 
 pub use artifact::{
     compile, compile_with_manifest, compile_with_options, compile_with_plugins, load_manifest,
-    load_plugins, load_routes, load_specs, BundledPlugin, CompileOptions, CompiledOperation,
-    CompiledRoutes, Manifest, PluginBundle, SourceSpec, ARTIFACT_VERSION, COMPILER_VERSION,
+    load_plugins, load_routes, load_specs, BundledPlugin, CompileOptions, CompileResult,
+    CompiledOperation, CompiledRoutes, Manifest, PluginBundle, SourceSpec, ARTIFACT_VERSION,
+    COMPILER_VERSION,
 };
-pub use error::CompileError;
+pub use error::{CompileError, CompileWarning};
 pub use manifest::{PathSource, PluginSource, ProjectManifest, ResolvedPlugin, UrlSource};
 // Re-export validation types from spec-parser
 pub use barbacane_spec_parser::{ContentSchema, MiddlewareConfig, Parameter, RequestBody};

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -123,12 +123,6 @@ info:
   title: My API
   version: "1.0.0"
 
-servers:
-  - url: https://api.example.com
-    x-barbacane-upstream:
-      name: backend
-      timeout: 30s
-
 paths:
   /health:
     get:

--- a/docs/guide/spec-configuration.md
+++ b/docs/guide/spec-configuration.md
@@ -6,47 +6,8 @@ Barbacane extends OpenAPI and AsyncAPI specs with custom `x-barbacane-*` extensi
 
 | Extension | Location | Purpose |
 |-----------|----------|---------|
-| `x-barbacane-upstream` | Server object | Define named backend connections |
-| `x-barbacane-dispatch` | Operation | Route request to a dispatcher |
+| `x-barbacane-dispatch` | Operation | Route request to a dispatcher (required) |
 | `x-barbacane-middlewares` | Root or Operation | Apply middleware chain |
-
-## Upstreams
-
-Define backend connections on the `servers` array:
-
-```yaml
-servers:
-  - url: https://api.example.com
-    description: Production API
-    x-barbacane-upstream:
-      name: main-backend
-      timeout: 30s
-      retries: 3
-
-  - url: https://auth.example.com
-    description: Auth Service
-    x-barbacane-upstream:
-      name: auth-service
-      timeout: 10s
-```
-
-### Upstream Properties
-
-| Property | Type | Required | Description |
-|----------|------|----------|-------------|
-| `name` | string | Yes | Unique identifier for this upstream |
-| `timeout` | duration | No | Request timeout (default: 30s) |
-| `retries` | integer | No | Number of retry attempts (default: 0) |
-
-Upstreams are a design pattern for named backends. The `http-upstream` dispatcher uses the `url` config directly:
-
-```yaml
-x-barbacane-dispatch:
-  name: http-upstream
-  config:
-    url: "https://api.example.com"  # Direct URL to backend
-    path: /api/resource
-```
 
 ## Dispatchers
 
@@ -220,18 +181,6 @@ openapi: "3.1.0"
 info:
   title: E-Commerce API
   version: "2.0.0"
-
-servers:
-  - url: https://api.shop.example.com
-    x-barbacane-upstream:
-      name: shop-backend
-      timeout: 30s
-      retries: 2
-
-  - url: https://payments.example.com
-    x-barbacane-upstream:
-      name: payments
-      timeout: 60s
 
 # Global middlewares
 x-barbacane-middlewares:

--- a/specs/SPEC-001-compilation.md
+++ b/specs/SPEC-001-compilation.md
@@ -68,42 +68,7 @@ x-barbacane-dispatch:
 
 An operation without `x-barbacane-dispatch` fails compilation with `E1020`.
 
-### 3.3 `x-barbacane-ratelimit`
-
-**Placement:** spec root (global) or operation level (override).
-
-Aligned with [draft-ietf-httpapi-ratelimit-headers](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/) for vocabulary and response header behavior.
-
-```yaml
-x-barbacane-ratelimit:
-  policy_name: <string>         # optional — policy identifier, appears in RateLimit-Policy header (default: "default")
-  quota: <integer>              # required — max quota units allowed in the window
-  window: <integer>             # required — time window in seconds
-  quota_unit: <string>          # optional — "requests" | "content-bytes" | "concurrent-requests" (default: "requests")
-  key: <string>                 # optional — partition key, default "client_ip"
-                                #   format: "client_ip" | "header:<name>" | "context:<key>"
-```
-
-Rate limiting is implemented as a built-in middleware. This extension is syntactic sugar — the compiler transforms it into a middleware entry in the chain.
-
-The rate-limit middleware emits `RateLimit-Policy` and `RateLimit` response headers on every response (not just 429s), following the IETF draft format:
-
-```
-RateLimit-Policy: "default";q=100;w=60
-RateLimit: "default";r=73;t=45
-```
-
-### 3.4 `x-barbacane-cache`
-
-**Placement:** operation level only.
-
-```yaml
-x-barbacane-cache:
-  ttl: <duration>               # required — cache duration (e.g. "60s", "5m")
-  vary: [<string>]              # optional — headers that vary the cache key
-```
-
-### 3.5 `x-sunset`
+### 3.3 `x-sunset`
 
 **Placement:** operation level, alongside `deprecated: true`.
 
@@ -114,17 +79,6 @@ x-sunset: "<HTTP-date>"   # e.g. "Sat, 31 Dec 2025 23:59:59 GMT"
 ```
 
 If `x-sunset` is present but `deprecated` is not `true`, compilation fails with `E1030`.
-
-### 3.6 `x-barbacane-observability`
-
-**Placement:** spec root (global) or operation level (override).
-
-```yaml
-x-barbacane-observability:
-  trace_sampling: <float>       # optional — 0.0 to 1.0, default 1.0
-  detailed_validation_logs: <boolean>  # optional — default false
-  latency_slo: <duration>       # optional — emit alert metric when exceeded
-```
 
 ---
 
@@ -147,9 +101,6 @@ The compiler performs validation in order. Compilation stops at the first catego
 |------|-----------|
 | `E1010` | Routing conflict: same path + method declared in multiple specs |
 | `E1011` | `x-barbacane-middlewares` entry missing `name` |
-| `E1012` | `x-barbacane-ratelimit` missing required field (`quota` or `window`) |
-| `E1013` | `x-barbacane-ratelimit.quota_unit` is not one of `requests`, `content-bytes`, `concurrent-requests` |
-| `E1014` | `x-barbacane-cache.ttl` is not a valid duration |
 | `E1015` | Unknown `x-barbacane-*` extension key (warning, not error) |
 
 ### 4.3 Plugin resolution

--- a/specs/SPEC-002-request-lifecycle.md
+++ b/specs/SPEC-002-request-lifecycle.md
@@ -243,7 +243,7 @@ Upstream `Server` headers are stripped and replaced.
 
 #### Rate limit headers
 
-When `x-barbacane-ratelimit` is configured on an operation, the rate-limit middleware emits standardized headers on every response:
+When the `rate-limit` middleware is configured on an operation (via `x-barbacane-middlewares`), it emits standardized headers on every response:
 
 ```
 RateLimit-Policy: "default";q=100;w=60

--- a/tests/fixtures/full-crud.yaml
+++ b/tests/fixtures/full-crud.yaml
@@ -6,9 +6,6 @@ info:
 
 servers:
   - url: https://api.example.com
-    x-barbacane-upstream:
-      name: main-backend
-      timeout: 30s
 
 x-barbacane-middlewares:
   - name: rate-limit

--- a/tests/fixtures/train-travel-3.0.yaml
+++ b/tests/fixtures/train-travel-3.0.yaml
@@ -16,9 +16,6 @@ info:
 servers:
   - url: https://api.trains.example.com/v1
     description: Production
-    x-barbacane-upstream:
-      name: trains-backend
-      timeout: 30s
 
 # Global Barbacane middlewares
 x-barbacane-middlewares:

--- a/tests/fixtures/train-travel-3.1.yaml
+++ b/tests/fixtures/train-travel-3.1.yaml
@@ -23,15 +23,8 @@ info:
 servers:
   - url: https://api.trains.example.com/v2
     description: Production
-    x-barbacane-upstream:
-      name: trains-backend
-      timeout: 30s
-      retries: 3
   - url: https://staging-api.trains.example.com/v2
     description: Staging
-    x-barbacane-upstream:
-      name: trains-backend-staging
-      timeout: 60s
 
 # Global Barbacane middlewares
 x-barbacane-middlewares:

--- a/tests/fixtures/train-travel-3.2.yaml
+++ b/tests/fixtures/train-travel-3.2.yaml
@@ -28,13 +28,6 @@ jsonSchemaDialect: "https://json-schema.org/draft/2020-12/schema"
 servers:
   - url: https://api.trains.example.com/v3
     description: Production
-    x-barbacane-upstream:
-      name: trains-backend-v3
-      timeout: 30s
-      retries: 3
-      circuit_breaker:
-        threshold: 5
-        timeout: 60s
 
 # Global Barbacane configuration
 x-barbacane-middlewares:


### PR DESCRIPTION
## Summary
- Remove unimplemented `x-barbacane-*` extensions from documentation and KNOWN_EXTENSIONS
- Add compile-time safety validations (E1011, E1015, E1050-E1055)
- Add `observability` middleware to backlog as P1

## Removed Extensions

| Extension | Replacement |
|-----------|-------------|
| `x-barbacane-upstream` | `http-upstream` dispatcher |
| `x-barbacane-ratelimit` | `rate-limit` middleware |
| `x-barbacane-cache` | `cache` middleware |
| `x-barbacane-observability` | Future `observability` middleware (added to backlog) |

These extensions were documented but never implemented. Their functionality is already available through dispatchers/middlewares.

## New Compile-Time Validations

| Code | Description |
|------|-------------|
| E1011 | Middleware missing 'name' field |
| E1015 | Unknown x-barbacane-* extension (warning) |
| E1050 | Ambiguous route detection |
| E1051 | Schema too deep (max: 32) |
| E1052 | Schema too complex (max properties: 256) |
| E1053 | Circular schema reference detection |
| E1054 | Invalid path template syntax |
| E1055 | Duplicate operationId across specs |

## KNOWN_EXTENSIONS (now only structural)
- `x-barbacane-dispatch` (required, operation level)
- `x-barbacane-middlewares` (root or operation level)

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets` passes
- [x] `cargo test -p barbacane-compiler` passes (33 tests)