### PR TITLE
feat: automatic CORS preflight handling

### DIFF
--- a/crates/barbacane-test/src/gateway.rs
+++ b/crates/barbacane-test/src/gateway.rs
@@ -2908,4 +2908,196 @@ paths:
         let resp = gateway.get("/__barbacane/specs/asyncapi").await.unwrap();
         assert_eq!(resp.status(), 404);
     }
+
+    // =========================================================================
+    // CORS Middleware Tests (Automatic Preflight Handling)
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_cors_preflight_any_origin() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/cors.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Send preflight OPTIONS request (no OPTIONS defined in spec - auto-handled)
+        let resp = gateway
+            .request_builder(reqwest::Method::OPTIONS, "/cors-any")
+            .header("Origin", "https://any-site.com")
+            .header("Access-Control-Request-Method", "POST")
+            .header("Access-Control-Request-Headers", "Content-Type")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 204, "Preflight should return 204 No Content");
+
+        // Check CORS headers
+        assert_eq!(
+            resp.headers()
+                .get("access-control-allow-origin")
+                .map(|v| v.to_str().unwrap()),
+            Some("*"),
+            "Should allow any origin"
+        );
+        assert!(
+            resp.headers().get("access-control-allow-methods").is_some(),
+            "Should have allow-methods header"
+        );
+        assert!(
+            resp.headers().get("access-control-max-age").is_some(),
+            "Should have max-age header"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cors_preflight_specific_origin_allowed() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/cors.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Send preflight from allowed origin
+        let resp = gateway
+            .request_builder(reqwest::Method::OPTIONS, "/cors-specific")
+            .header("Origin", "https://example.com")
+            .header("Access-Control-Request-Method", "GET")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 204, "Preflight should return 204");
+        assert_eq!(
+            resp.headers()
+                .get("access-control-allow-origin")
+                .map(|v| v.to_str().unwrap()),
+            Some("https://example.com"),
+            "Should echo back allowed origin"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cors_preflight_specific_origin_denied() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/cors.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Send preflight from disallowed origin
+        let resp = gateway
+            .request_builder(reqwest::Method::OPTIONS, "/cors-specific")
+            .header("Origin", "https://evil-site.com")
+            .header("Access-Control-Request-Method", "GET")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 403, "Should reject disallowed origin");
+    }
+
+    #[tokio::test]
+    async fn test_cors_preflight_method_not_allowed() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/cors.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Request DELETE method which is not allowed on cors-specific
+        let resp = gateway
+            .request_builder(reqwest::Method::OPTIONS, "/cors-specific")
+            .header("Origin", "https://example.com")
+            .header("Access-Control-Request-Method", "DELETE")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 403, "Should reject disallowed method");
+    }
+
+    #[tokio::test]
+    async fn test_cors_simple_request_with_origin() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/cors.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Simple GET request with Origin header
+        let resp = gateway
+            .request_builder(reqwest::Method::GET, "/cors-any")
+            .header("Origin", "https://example.com")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        assert_eq!(
+            resp.headers()
+                .get("access-control-allow-origin")
+                .map(|v| v.to_str().unwrap()),
+            Some("*"),
+            "Response should include CORS header"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cors_request_without_origin() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/cors.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Request without Origin header (same-origin or non-browser)
+        let resp = gateway.get("/cors-any").await.unwrap();
+
+        assert_eq!(resp.status(), 200, "Non-CORS request should pass through");
+    }
+
+    #[tokio::test]
+    async fn test_cors_credentials_header() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/cors.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Preflight for credentials endpoint
+        let resp = gateway
+            .request_builder(reqwest::Method::OPTIONS, "/cors-credentials")
+            .header("Origin", "https://trusted.example.com")
+            .header("Access-Control-Request-Method", "GET")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 204);
+        assert_eq!(
+            resp.headers()
+                .get("access-control-allow-credentials")
+                .map(|v| v.to_str().unwrap()),
+            Some("true"),
+            "Should include credentials header"
+        );
+        // With credentials, origin should be echoed, not *
+        assert_eq!(
+            resp.headers()
+                .get("access-control-allow-origin")
+                .map(|v| v.to_str().unwrap()),
+            Some("https://trusted.example.com"),
+            "With credentials, should echo origin not *"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cors_preflight_no_cors_middleware_returns_405() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/cors.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Preflight for endpoint without CORS middleware should return 405
+        let resp = gateway
+            .request_builder(reqwest::Method::OPTIONS, "/no-cors")
+            .header("Origin", "https://example.com")
+            .header("Access-Control-Request-Method", "GET")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            405,
+            "Should return 405 when no CORS middleware configured"
+        );
+    }
 }

--- a/tests/fixtures/barbacane.yaml
+++ b/tests/fixtures/barbacane.yaml
@@ -16,3 +16,5 @@ plugins:
     path: ../../plugins/rate-limit/rate-limit.wasm
   cache:
     path: ../../plugins/cache/cache.wasm
+  cors:
+    path: ../../plugins/cors/cors.wasm

--- a/tests/fixtures/cors.yaml
+++ b/tests/fixtures/cors.yaml
@@ -1,0 +1,85 @@
+openapi: "3.1.0"
+info:
+  title: CORS Test API
+  version: "1.0.0"
+  description: API for testing CORS middleware with automatic preflight handling
+
+paths:
+  /cors-any:
+    get:
+      operationId: corsAnyGet
+      summary: Endpoint allowing any origin
+      x-barbacane-middlewares:
+        - name: cors
+          config:
+            allowed_origins: ["*"]
+            allowed_methods: ["GET", "POST", "PUT", "DELETE"]
+            allowed_headers: ["Content-Type", "Authorization"]
+            max_age: 3600
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"message":"ok"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Success
+
+  /cors-specific:
+    get:
+      operationId: corsSpecificGet
+      summary: Endpoint allowing specific origins
+      x-barbacane-middlewares:
+        - name: cors
+          config:
+            allowed_origins: ["https://example.com", "https://app.example.com"]
+            allowed_methods: ["GET", "POST"]
+            allowed_headers: ["Content-Type"]
+            expose_headers: ["X-Response-Id"]
+            max_age: 7200
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"message":"specific origin"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Success
+
+  /cors-credentials:
+    get:
+      operationId: corsCredentialsGet
+      summary: Endpoint allowing credentials
+      x-barbacane-middlewares:
+        - name: cors
+          config:
+            allowed_origins: ["https://trusted.example.com"]
+            allowed_methods: ["GET", "POST"]
+            allowed_headers: ["Content-Type", "Authorization"]
+            allow_credentials: true
+            max_age: 3600
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"message":"with credentials"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Success
+
+  /no-cors:
+    get:
+      operationId: noCorsGet
+      summary: Endpoint without CORS middleware
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"message":"no cors"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Success

--- a/tests/fixtures/cors.yaml
+++ b/tests/fixtures/cors.yaml
@@ -4,7 +4,31 @@ info:
   version: "1.0.0"
   description: API for testing CORS middleware with automatic preflight handling
 
+# Global CORS middleware - applies to all endpoints by default
+x-barbacane-middlewares:
+  - name: cors
+    config:
+      allowed_origins: ["*"]
+      allowed_methods: ["GET", "POST", "PUT", "DELETE"]
+      allowed_headers: ["Content-Type", "Authorization"]
+      max_age: 3600
+
 paths:
+  /global-cors:
+    get:
+      operationId: globalCorsGet
+      summary: Endpoint inheriting global CORS config
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"message":"global cors"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Success
+
+
   /cors-any:
     get:
       operationId: corsAnyGet
@@ -73,7 +97,8 @@ paths:
   /no-cors:
     get:
       operationId: noCorsGet
-      summary: Endpoint without CORS middleware
+      summary: Endpoint without CORS middleware (overrides global)
+      x-barbacane-middlewares: []  # Empty array removes global middleware
       x-barbacane-dispatch:
         name: mock
         config:


### PR DESCRIPTION
## Summary
- Add automatic handling of CORS preflight (OPTIONS) requests without requiring users to define OPTIONS operations in their specs
- The gateway intercepts OPTIONS requests with CORS headers and executes the CORS middleware automatically

## How it works
When a request matches:
1. Method is OPTIONS
2. Has `Origin` header
3. Has `Access-Control-Request-Method` header
4. Path exists with other methods (GET, POST, etc.)
5. Those operations have a `cors` middleware configured

The gateway automatically executes the CORS middleware to handle the preflight.

## User experience
Before: Users had to define OPTIONS operations for every path that needed CORS
```yaml
paths:
  /api/users:
    get:
      x-barbacane-middlewares: [{name: cors, config: {...}}]
    options:  # Required for preflight!
      x-barbacane-middlewares: [{name: cors, config: {...}}]
```

After: Just add CORS to actual operations
```yaml
paths:
  /api/users:
    get:
      x-barbacane-middlewares: [{name: cors, config: {...}}]
    # No OPTIONS needed - preflight handled automatically!
```

## Test plan
- [x] 8 integration tests for CORS preflight handling
- [x] Test preflight with wildcard origin
- [x] Test preflight with specific allowed/denied origins
- [x] Test preflight with disallowed method
- [x] Test credentials header
- [x] Test 405 when no CORS middleware configured
- [x] All existing tests pass