### PR TITLE
fix: merge global middlewares with operation-level middlewares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,10 +80,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved test fixtures with more comprehensive scenarios
 - Improved foreign key error handling in control plane API
 - Plugin deletion now returns "resource is in use" error when referenced by projects
+- Refactored compiler: extracted shared `compile_inner` core, eliminating ~380 lines of duplication across `compile_with_options`, `compile_with_manifest`, and `compile_with_plugins`
 
 ### Fixed
 - CORS plugin now includes JSON Schema (`config-schema.json`) for UI configuration
 - Plugin deletion errors now display user-friendly messages in the UI
+- Global middlewares are now merged with operation-level middlewares instead of being overridden; operation middlewares override globals by name while preserving non-overridden globals
+- `compile_with_plugins` now enforces the plaintext HTTP URL check (E1031), previously missing from this code path
 
 ### Removed
 - `x-barbacane-observability` extension (dead code - was parsed but never used at runtime)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml"><img src="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://docs.barbacane.dev"><img src="https://img.shields.io/badge/docs-docs.barbacane.dev-blue" alt="Documentation"></a>
-  <img src="https://img.shields.io/badge/tests-355%20passing-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-367%20passing-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rust-1.75%2B-orange" alt="Rust Version">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
 </p>

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -277,11 +277,28 @@ pub fn compile_with_options(
                 }
             }
 
-            // Resolve middleware chain: operation-level overrides global
-            let middlewares = op
-                .middlewares
-                .clone()
-                .unwrap_or_else(|| spec.global_middlewares.clone());
+            // Resolve middleware chain:
+            // - None: use global middlewares only
+            // - Some([]): explicit opt-out, no middlewares at all
+            // - Some([items]): global middlewares (excluding any overridden by name) + operation-level
+            let middlewares = match &op.middlewares {
+                None => spec.global_middlewares.clone(),
+                Some(op_mw) if op_mw.is_empty() => Vec::new(),
+                Some(op_mw) => {
+                    // Collect operation middleware names for deduplication
+                    let op_names: std::collections::HashSet<_> =
+                        op_mw.iter().map(|m| m.name.as_str()).collect();
+                    // Include global middlewares except those overridden by operation
+                    let mut merged: Vec<_> = spec
+                        .global_middlewares
+                        .iter()
+                        .filter(|m| !op_names.contains(m.name.as_str()))
+                        .cloned()
+                        .collect();
+                    merged.extend(op_mw.clone());
+                    merged
+                }
+            };
 
             // Validate middleware names (E1011)
             for (idx, mw) in middlewares.iter().enumerate() {
@@ -582,10 +599,28 @@ pub fn compile_with_manifest(
                 }
             }
 
-            let middlewares = op
-                .middlewares
-                .clone()
-                .unwrap_or_else(|| spec.global_middlewares.clone());
+            // Resolve middleware chain:
+            // - None: use global middlewares only
+            // - Some([]): explicit opt-out, no middlewares at all
+            // - Some([items]): global middlewares (excluding any overridden by name) + operation-level
+            let middlewares = match &op.middlewares {
+                None => spec.global_middlewares.clone(),
+                Some(op_mw) if op_mw.is_empty() => Vec::new(),
+                Some(op_mw) => {
+                    // Collect operation middleware names for deduplication
+                    let op_names: std::collections::HashSet<_> =
+                        op_mw.iter().map(|m| m.name.as_str()).collect();
+                    // Include global middlewares except those overridden by operation
+                    let mut merged: Vec<_> = spec
+                        .global_middlewares
+                        .iter()
+                        .filter(|m| !op_names.contains(m.name.as_str()))
+                        .cloned()
+                        .collect();
+                    merged.extend(op_mw.clone());
+                    merged
+                }
+            };
 
             // Validate middleware names (E1011)
             for (idx, mw) in middlewares.iter().enumerate() {
@@ -987,10 +1022,28 @@ pub fn compile_with_plugins(
                 ))
             })?;
 
-            let middlewares = op
-                .middlewares
-                .clone()
-                .unwrap_or_else(|| spec.global_middlewares.clone());
+            // Resolve middleware chain:
+            // - None: use global middlewares only
+            // - Some([]): explicit opt-out, no middlewares at all
+            // - Some([items]): global middlewares (excluding any overridden by name) + operation-level
+            let middlewares = match &op.middlewares {
+                None => spec.global_middlewares.clone(),
+                Some(op_mw) if op_mw.is_empty() => Vec::new(),
+                Some(op_mw) => {
+                    // Collect operation middleware names for deduplication
+                    let op_names: std::collections::HashSet<_> =
+                        op_mw.iter().map(|m| m.name.as_str()).collect();
+                    // Include global middlewares except those overridden by operation
+                    let mut merged: Vec<_> = spec
+                        .global_middlewares
+                        .iter()
+                        .filter(|m| !op_names.contains(m.name.as_str()))
+                        .cloned()
+                        .collect();
+                    merged.extend(op_mw.clone());
+                    merged
+                }
+            };
 
             // Validate middleware names (E1011)
             for (idx, mw) in middlewares.iter().enumerate() {


### PR DESCRIPTION
Previously, operation-level x-barbacane-middlewares completely replaced global middlewares. This fix changes the behavior to:

- None: use global middlewares only
- []: explicit opt-out, no middlewares at all
- [items]: global middlewares + items (same-name items override global)

When an operation defines a middleware with the same name as a global one, the operation-level config replaces the global one (deduplication by name).