### PR TITLE
refactor: deduplicate compiler, validator, WASM, and gateway code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml"><img src="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://docs.barbacane.dev"><img src="https://img.shields.io/badge/docs-docs.barbacane.dev-blue" alt="Documentation"></a>
-  <img src="https://img.shields.io/badge/tests-367%20passing-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-374%20passing-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rust-1.75%2B-orange" alt="Rust Version">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml"><img src="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://docs.barbacane.dev"><img src="https://img.shields.io/badge/docs-docs.barbacane.dev-blue" alt="Documentation"></a>
-  <img src="https://img.shields.io/badge/tests-374%20passing-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-378%20passing-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rust-1.75%2B-orange" alt="Rust Version">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 <p align="center">
   <a href="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml"><img src="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://docs.barbacane.dev"><img src="https://img.shields.io/badge/docs-docs.barbacane.dev-blue" alt="Documentation"></a>
-  <img src="https://img.shields.io/badge/tests-378%20passing-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/unit%20tests-250%20passing-brightgreen" alt="Unit Tests">
+  <img src="https://img.shields.io/badge/integration%20tests-125%20passing-brightgreen" alt="Integration Tests">
   <img src="https://img.shields.io/badge/rust-1.75%2B-orange" alt="Rust Version">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
 </p>

--- a/crates/barbacane-compiler/src/manifest.rs
+++ b/crates/barbacane-compiler/src/manifest.rs
@@ -32,6 +32,72 @@ fn read_plugin_metadata(wasm_path: &Path) -> Option<(String, String)> {
     Some((parsed.plugin.version, parsed.plugin.plugin_type))
 }
 
+/// Resolve a WASM path from a plugin source, relative to a base path.
+fn resolve_wasm_path(path_source: &PathSource, base_path: &Path) -> std::path::PathBuf {
+    if Path::new(&path_source.path).is_absolute() {
+        Path::new(&path_source.path).to_path_buf()
+    } else {
+        base_path.join(&path_source.path)
+    }
+}
+
+/// Resolve a single plugin: read WASM bytes, validate, and extract metadata.
+fn resolve_plugin(
+    name: &str,
+    source: &PluginSource,
+    base_path: &Path,
+) -> Result<ResolvedPlugin, CompileError> {
+    let wasm_bytes = match source {
+        PluginSource::Path(path_source) => {
+            let wasm_path = resolve_wasm_path(path_source, base_path);
+            std::fs::read(&wasm_path).map_err(|e| {
+                CompileError::PluginResolution(format!(
+                    "failed to read plugin '{}' from {}: {}",
+                    name,
+                    wasm_path.display(),
+                    e
+                ))
+            })?
+        }
+        PluginSource::Url(url_source) => {
+            return Err(CompileError::PluginResolution(format!(
+                "URL plugin sources not yet implemented: {} -> {}",
+                name, url_source.url
+            )));
+        }
+    };
+
+    // Validate WASM magic number
+    if wasm_bytes.len() < 8
+        || wasm_bytes[0..4] != [0x00, 0x61, 0x73, 0x6d]
+        || wasm_bytes[4..8] != [0x01, 0x00, 0x00, 0x00]
+    {
+        return Err(CompileError::PluginResolution(format!(
+            "plugin '{}' is not a valid WASM file (invalid magic number)",
+            name
+        )));
+    }
+
+    // Try to read plugin metadata from plugin.toml
+    let (version, plugin_type) = match source {
+        PluginSource::Path(path_source) => {
+            let wasm_path = resolve_wasm_path(path_source, base_path);
+            read_plugin_metadata(&wasm_path)
+                .map(|(v, t)| (Some(v), Some(t)))
+                .unwrap_or((None, None))
+        }
+        PluginSource::Url(_) => (None, None),
+    };
+
+    Ok(ResolvedPlugin {
+        name: name.to_string(),
+        source: source.description(),
+        wasm_bytes,
+        version,
+        plugin_type,
+    })
+}
+
 /// A project manifest (`barbacane.yaml`).
 ///
 /// Declares the plugins available for use in OpenAPI specs.
@@ -122,72 +188,10 @@ impl ProjectManifest {
     ///
     /// The `base_path` is used to resolve relative paths in `path:` sources.
     pub fn resolve_plugins(&self, base_path: &Path) -> Result<Vec<ResolvedPlugin>, CompileError> {
-        let mut resolved = Vec::new();
-
-        for (name, source) in &self.plugins {
-            let wasm_bytes = match source {
-                PluginSource::Path(path_source) => {
-                    let wasm_path = if Path::new(&path_source.path).is_absolute() {
-                        Path::new(&path_source.path).to_path_buf()
-                    } else {
-                        base_path.join(&path_source.path)
-                    };
-
-                    std::fs::read(&wasm_path).map_err(|e| {
-                        CompileError::PluginResolution(format!(
-                            "failed to read plugin '{}' from {}: {}",
-                            name,
-                            wasm_path.display(),
-                            e
-                        ))
-                    })?
-                }
-                PluginSource::Url(url_source) => {
-                    // For now, URL resolution is not implemented
-                    // This will be added when we need remote plugin fetching
-                    return Err(CompileError::PluginResolution(format!(
-                        "URL plugin sources not yet implemented: {} -> {}",
-                        name, url_source.url
-                    )));
-                }
-            };
-
-            // Validate it looks like a WASM file (magic number)
-            if wasm_bytes.len() < 8
-                || wasm_bytes[0..4] != [0x00, 0x61, 0x73, 0x6d]
-                || wasm_bytes[4..8] != [0x01, 0x00, 0x00, 0x00]
-            {
-                return Err(CompileError::PluginResolution(format!(
-                    "plugin '{}' is not a valid WASM file (invalid magic number)",
-                    name
-                )));
-            }
-
-            // Try to read plugin metadata from plugin.toml
-            let (version, plugin_type) = match source {
-                PluginSource::Path(path_source) => {
-                    let wasm_path = if Path::new(&path_source.path).is_absolute() {
-                        Path::new(&path_source.path).to_path_buf()
-                    } else {
-                        base_path.join(&path_source.path)
-                    };
-                    read_plugin_metadata(&wasm_path)
-                        .map(|(v, t)| (Some(v), Some(t)))
-                        .unwrap_or((None, None))
-                }
-                PluginSource::Url(_) => (None, None),
-            };
-
-            resolved.push(ResolvedPlugin {
-                name: name.clone(),
-                source: source.description(),
-                wasm_bytes,
-                version,
-                plugin_type,
-            });
-        }
-
-        Ok(resolved)
+        self.plugins
+            .iter()
+            .map(|(name, source)| resolve_plugin(name, source, base_path))
+            .collect()
     }
 
     /// Validate that all plugins used in specs are declared in the manifest.
@@ -217,7 +221,6 @@ impl ProjectManifest {
         specs: &[ApiSpec],
         base_path: &Path,
     ) -> Result<Vec<ResolvedPlugin>, CompileError> {
-        // First validate all plugins are declared
         self.validate_specs(specs)?;
 
         let used = extract_plugin_names(specs);
@@ -228,65 +231,7 @@ impl ProjectManifest {
                 Some(s) => s,
                 None => continue, // Already validated, shouldn't happen
             };
-
-            let wasm_bytes = match source {
-                PluginSource::Path(path_source) => {
-                    let wasm_path = if Path::new(&path_source.path).is_absolute() {
-                        Path::new(&path_source.path).to_path_buf()
-                    } else {
-                        base_path.join(&path_source.path)
-                    };
-
-                    std::fs::read(&wasm_path).map_err(|e| {
-                        CompileError::PluginResolution(format!(
-                            "failed to read plugin '{}' from {}: {}",
-                            name,
-                            wasm_path.display(),
-                            e
-                        ))
-                    })?
-                }
-                PluginSource::Url(url_source) => {
-                    return Err(CompileError::PluginResolution(format!(
-                        "URL plugin sources not yet implemented: {} -> {}",
-                        name, url_source.url
-                    )));
-                }
-            };
-
-            // Validate WASM magic number
-            if wasm_bytes.len() < 8
-                || wasm_bytes[0..4] != [0x00, 0x61, 0x73, 0x6d]
-                || wasm_bytes[4..8] != [0x01, 0x00, 0x00, 0x00]
-            {
-                return Err(CompileError::PluginResolution(format!(
-                    "plugin '{}' is not a valid WASM file (invalid magic number)",
-                    name
-                )));
-            }
-
-            // Try to read plugin metadata from plugin.toml
-            let (version, plugin_type) = match source {
-                PluginSource::Path(path_source) => {
-                    let wasm_path = if Path::new(&path_source.path).is_absolute() {
-                        Path::new(&path_source.path).to_path_buf()
-                    } else {
-                        base_path.join(&path_source.path)
-                    };
-                    read_plugin_metadata(&wasm_path)
-                        .map(|(v, t)| (Some(v), Some(t)))
-                        .unwrap_or((None, None))
-                }
-                PluginSource::Url(_) => (None, None),
-            };
-
-            resolved.push(ResolvedPlugin {
-                name: name.clone(),
-                source: source.description(),
-                wasm_bytes,
-                version,
-                plugin_type,
-            });
+            resolved.push(resolve_plugin(&name, source, base_path)?);
         }
 
         Ok(resolved)
@@ -611,5 +556,200 @@ plugins:
         let err = result.unwrap_err().to_string();
         assert!(err.contains("E1040"));
         assert!(err.contains("http-upstream"));
+    }
+
+    fn make_spec_using_plugin(plugin_name: &str) -> ApiSpec {
+        use barbacane_spec_parser::{DispatchConfig, Operation, SpecFormat};
+        use std::collections::BTreeMap;
+
+        ApiSpec {
+            filename: Some("test.yaml".to_string()),
+            format: SpecFormat::OpenApi,
+            version: "3.1.0".to_string(),
+            title: "Test".to_string(),
+            api_version: "1.0.0".to_string(),
+            global_middlewares: vec![],
+            extensions: BTreeMap::new(),
+            operations: vec![Operation {
+                path: "/health".to_string(),
+                method: "GET".to_string(),
+                operation_id: None,
+                parameters: vec![],
+                request_body: None,
+                dispatch: Some(DispatchConfig {
+                    name: plugin_name.to_string(),
+                    config: serde_json::json!({}),
+                }),
+                middlewares: None,
+                deprecated: false,
+                sunset: None,
+                extensions: BTreeMap::new(),
+                messages: vec![],
+                bindings: BTreeMap::new(),
+            }],
+        }
+    }
+
+    fn write_valid_wasm(dir: &Path, name: &str) -> Vec<u8> {
+        let wasm_content = vec![
+            0x00, 0x61, 0x73, 0x6d, // magic
+            0x01, 0x00, 0x00, 0x00, // version
+        ];
+        let path = dir.join(name);
+        std::fs::write(&path, &wasm_content).unwrap();
+        wasm_content
+    }
+
+    #[test]
+    fn resolve_used_plugins_from_path() {
+        let temp = TempDir::new().unwrap();
+        let plugin_dir = temp.path().join("plugins");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        let wasm_content = write_valid_wasm(&plugin_dir, "mock.wasm");
+
+        let content = r#"
+plugins:
+  mock:
+    path: ./plugins/mock.wasm
+"#;
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+        let spec = make_spec_using_plugin("mock");
+
+        let resolved = manifest.resolve_used_plugins(&[spec], temp.path()).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name, "mock");
+        assert_eq!(resolved[0].wasm_bytes, wasm_content);
+    }
+
+    #[test]
+    fn resolve_used_plugins_skips_unused() {
+        let temp = TempDir::new().unwrap();
+        let plugin_dir = temp.path().join("plugins");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        write_valid_wasm(&plugin_dir, "mock.wasm");
+        write_valid_wasm(&plugin_dir, "unused.wasm");
+
+        let content = r#"
+plugins:
+  mock:
+    path: ./plugins/mock.wasm
+  unused:
+    path: ./plugins/unused.wasm
+"#;
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+        let spec = make_spec_using_plugin("mock");
+
+        let resolved = manifest.resolve_used_plugins(&[spec], temp.path()).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name, "mock");
+    }
+
+    #[test]
+    fn resolve_used_plugins_invalid_wasm() {
+        let temp = TempDir::new().unwrap();
+        let plugin_dir = temp.path().join("plugins");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        std::fs::write(plugin_dir.join("bad.wasm"), b"not a wasm file").unwrap();
+
+        let content = r#"
+plugins:
+  bad:
+    path: ./plugins/bad.wasm
+"#;
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+        let spec = make_spec_using_plugin("bad");
+
+        let result = manifest.resolve_used_plugins(&[spec], temp.path());
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid magic number"));
+    }
+
+    #[test]
+    fn resolve_used_plugins_missing_file() {
+        let temp = TempDir::new().unwrap();
+
+        let content = r#"
+plugins:
+  missing:
+    path: ./plugins/missing.wasm
+"#;
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+        let spec = make_spec_using_plugin("missing");
+
+        let result = manifest.resolve_used_plugins(&[spec], temp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("failed to read"));
+    }
+
+    #[test]
+    fn resolve_used_plugins_rejects_undeclared() {
+        let temp = TempDir::new().unwrap();
+
+        let content = "plugins: {}";
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+        let spec = make_spec_using_plugin("unknown");
+
+        let result = manifest.resolve_used_plugins(&[spec], temp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("E1040"));
+    }
+
+    #[test]
+    fn resolve_plugins_reads_metadata() {
+        let temp = TempDir::new().unwrap();
+        let plugin_dir = temp.path().join("plugins");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        write_valid_wasm(&plugin_dir, "mock.wasm");
+
+        // Create plugin.toml next to the wasm file
+        let plugin_toml = r#"
+[plugin]
+name = "mock"
+version = "1.2.3"
+type = "dispatcher"
+"#;
+        std::fs::write(plugin_dir.join("plugin.toml"), plugin_toml).unwrap();
+
+        let content = r#"
+plugins:
+  mock:
+    path: ./plugins/mock.wasm
+"#;
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+
+        let resolved = manifest.resolve_plugins(temp.path()).unwrap();
+        assert_eq!(resolved[0].version, Some("1.2.3".to_string()));
+        assert_eq!(resolved[0].plugin_type, Some("dispatcher".to_string()));
+    }
+
+    #[test]
+    fn resolve_used_plugins_reads_metadata() {
+        let temp = TempDir::new().unwrap();
+        let plugin_dir = temp.path().join("plugins");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        write_valid_wasm(&plugin_dir, "mock.wasm");
+
+        let plugin_toml = r#"
+[plugin]
+name = "mock"
+version = "2.0.0"
+type = "middleware"
+"#;
+        std::fs::write(plugin_dir.join("plugin.toml"), plugin_toml).unwrap();
+
+        let content = r#"
+plugins:
+  mock:
+    path: ./plugins/mock.wasm
+"#;
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+        let spec = make_spec_using_plugin("mock");
+
+        let resolved = manifest.resolve_used_plugins(&[spec], temp.path()).unwrap();
+        assert_eq!(resolved[0].version, Some("2.0.0".to_string()));
+        assert_eq!(resolved[0].plugin_type, Some("middleware".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

- **manifest.rs**: Extract `resolve_wasm_path` and `resolve_plugin` helpers — `resolve_plugins` and `resolve_used_plugins` now share a single implementation instead of duplicating WASM reading, magic validation, and metadata extraction
- **validator lib.rs**: Extract `validate_params` shared loop — `validate_path_params`, `validate_query_params`, and `validate_headers` now delegate to a single validation function with a lookup closure
- **main.rs**: Extract `dev_error_response` helper — replaces 10 identical `if self.dev_mode { Some(format!(...)) } else { None }` blocks with one-liner calls
- **instance.rs**: Extract `add_read_result_fn` — replaces 7 identical WASM host function closures (each ~25 lines) with a single reusable registration function
- **README.md**: Split single test badge into separate unit tests (250) and integration tests (125) badges for accurate tracking

## Test plan

- [x] 7 new tests for `resolve_used_plugins` in manifest.rs
- [x] 4 new tests for `validate_headers` (required, optional, schema, case-insensitive)
- [x] All 250 unit tests passing
- [x] `cargo clippy --all-targets` clean
- [x] `cargo audit` clean (3 allowed warnings only)