### PR TITLE
bench: add WASM, serialization, and compilation benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ name = "barbacane-compiler"
 version = "0.1.0"
 dependencies = [
  "barbacane-spec-parser",
+ "criterion",
  "flate2",
  "serde",
  "serde_json",
@@ -503,6 +504,7 @@ dependencies = [
  "anyhow",
  "barbacane-plugin-sdk",
  "barbacane-telemetry",
+ "criterion",
  "dashmap",
  "hex",
  "jsonschema",
@@ -520,6 +522,7 @@ dependencies = [
  "tracing",
  "uuid",
  "wasmtime",
+ "wat",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ proc-macro2 = "1"
 
 # Benchmarking
 criterion = { version = "0.5", features = ["html_reports"] }
+wat = "1"
 
 # Workspace crates (version required for crates.io publishing)
 barbacane-spec-parser = { path = "crates/barbacane-spec-parser", version = "0.1.0" }

--- a/README.md
+++ b/README.md
@@ -93,12 +93,42 @@ The playground includes a Train Travel API demo with WireMock backend, full obse
 
 Benchmark results on Apple M4 (MacBook Air 16GB):
 
+**Routing & Validation**
+
 | Operation | Latency |
 |-----------|---------|
 | Route lookup (1000 routes) | ~83 ns |
 | Request validation (full) | ~1.2 µs |
 | Body validation (JSON) | ~458 ns |
 | Router build (500 routes) | ~130 µs |
+
+**WASM Plugin Runtime**
+
+| Operation | Latency |
+|-----------|---------|
+| Module compilation | ~210 µs |
+| Instance creation | ~17 µs |
+| Middleware chain (1 plugin) | ~261 µs |
+| Middleware chain (3 plugins) | ~941 µs |
+| Middleware chain (5 plugins) | ~1.32 ms |
+| Memory write (1 KB) | ~14 ns |
+| Memory write (100 KB) | ~1.4 µs |
+
+**Serialization**
+
+| Operation | Latency |
+|-----------|---------|
+| Request (minimal) | ~118 ns |
+| Request (full, 1 KB body) | ~921 ns |
+| Response (1 KB body) | ~417 ns |
+
+**Spec Compilation**
+
+| Operation | Latency |
+|-----------|---------|
+| Compile 10 operations | ~550 µs |
+| Compile 50 operations | ~2.17 ms |
+| Compile 100 operations | ~3.72 ms |
 
 Run your own benchmarks:
 

--- a/crates/barbacane-compiler/Cargo.toml
+++ b/crates/barbacane-compiler/Cargo.toml
@@ -18,3 +18,9 @@ toml = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+criterion = { workspace = true }
+serde_json = { workspace = true }
+
+[[bench]]
+name = "compilation"
+harness = false

--- a/crates/barbacane-compiler/benches/compilation.rs
+++ b/crates/barbacane-compiler/benches/compilation.rs
@@ -1,0 +1,109 @@
+//! Spec compilation benchmarks.
+//!
+//! Measures the cost of compiling OpenAPI specs with varying numbers of
+//! operations into .bca artifacts. Includes spec parsing, validation,
+//! schema checking, JSON serialization, and tar.gz packaging.
+//!
+//! Run with: cargo bench -p barbacane-compiler --bench compilation
+
+use std::io::Write;
+use std::path::Path;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use barbacane_compiler::{compile_with_options, CompileOptions};
+
+/// Generate an OpenAPI 3.1 spec YAML with N operations.
+///
+/// Each operation has a path param, query param, and request body schema.
+fn generate_spec(operation_count: usize) -> String {
+    let mut yaml = String::from(
+        r#"openapi: "3.1.0"
+info:
+  title: Benchmark API
+  version: "1.0.0"
+paths:
+"#,
+    );
+
+    for i in 0..operation_count {
+        let resource = format!("resource{}", i);
+        yaml.push_str(&format!(
+            r#"  /{resource}/{{id}}:
+    get:
+      operationId: get_{resource}
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                email:
+                  type: string
+                  format: email
+"#,
+            resource = resource,
+        ));
+    }
+
+    yaml
+}
+
+fn bench_spec_compilation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("spec_compilation");
+    let options = CompileOptions {
+        allow_plaintext: true,
+        ..CompileOptions::default()
+    };
+
+    for op_count in [10, 50, 100] {
+        let spec_yaml = generate_spec(op_count);
+
+        group.bench_with_input(
+            BenchmarkId::new("compile", format!("{}_ops", op_count)),
+            &spec_yaml,
+            |b, spec_yaml| {
+                // Write spec to temp file (setup, not measured per-iter)
+                let temp_dir = tempfile::TempDir::new().unwrap();
+                let spec_path = temp_dir.path().join("api.yaml");
+                let mut f = std::fs::File::create(&spec_path).unwrap();
+                f.write_all(spec_yaml.as_bytes()).unwrap();
+                let output_path = temp_dir.path().join("output.bca");
+
+                b.iter(|| {
+                    let spec_ref: &Path = &spec_path;
+                    let result =
+                        compile_with_options(&[spec_ref], black_box(&output_path), &options);
+                    black_box(result.unwrap());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_spec_compilation);
+criterion_main!(benches);

--- a/crates/barbacane-wasm/Cargo.toml
+++ b/crates/barbacane-wasm/Cargo.toml
@@ -54,3 +54,13 @@ barbacane-telemetry.workspace = true
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
+criterion = { workspace = true }
+wat = { workspace = true }
+
+[[bench]]
+name = "wasm"
+harness = false
+
+[[bench]]
+name = "serialization"
+harness = false

--- a/crates/barbacane-wasm/benches/serialization.rs
+++ b/crates/barbacane-wasm/benches/serialization.rs
@@ -1,0 +1,142 @@
+//! Request/Response serialization benchmarks.
+//!
+//! Measures serde_json serialization cost for the plugin Request and Response
+//! types with varying payload sizes — this runs on every request.
+//!
+//! Run with: cargo bench -p barbacane-wasm --bench serialization
+
+use std::collections::BTreeMap;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use barbacane_wasm::{Request, Response};
+
+// ---------------------------------------------------------------------------
+// Request serialization
+// ---------------------------------------------------------------------------
+
+fn bench_request_serialization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("request_serialization");
+
+    // Minimal request
+    group.bench_function("minimal", |b| {
+        let req = Request {
+            method: "GET".to_string(),
+            path: "/health".to_string(),
+            query: None,
+            headers: BTreeMap::new(),
+            body: None,
+            client_ip: "127.0.0.1".to_string(),
+            path_params: BTreeMap::new(),
+        };
+        b.iter(|| black_box(serde_json::to_vec(&req).unwrap()));
+    });
+
+    // With varying header counts
+    for count in [5, 20] {
+        let mut headers = BTreeMap::new();
+        for i in 0..count {
+            headers.insert(format!("x-header-{}", i), format!("value-{}", i));
+        }
+        let req = Request {
+            method: "POST".to_string(),
+            path: "/api/users".to_string(),
+            query: None,
+            headers,
+            body: None,
+            client_ip: "127.0.0.1".to_string(),
+            path_params: BTreeMap::new(),
+        };
+
+        group.bench_with_input(BenchmarkId::new("with_headers", count), &req, |b, req| {
+            b.iter(|| black_box(serde_json::to_vec(req).unwrap()));
+        });
+    }
+
+    // With varying body sizes
+    for (label, size) in [("1KB", 1024), ("10KB", 10 * 1024)] {
+        let body = "x".repeat(size);
+        let req = Request {
+            method: "POST".to_string(),
+            path: "/api/users".to_string(),
+            query: None,
+            headers: BTreeMap::from([("content-type".to_string(), "application/json".to_string())]),
+            body: Some(body),
+            client_ip: "127.0.0.1".to_string(),
+            path_params: BTreeMap::new(),
+        };
+
+        group.bench_with_input(BenchmarkId::new("with_body", label), &req, |b, req| {
+            b.iter(|| black_box(serde_json::to_vec(req).unwrap()));
+        });
+    }
+
+    // Full realistic request
+    group.bench_function("full", |b| {
+        let mut headers = BTreeMap::new();
+        for i in 0..10 {
+            headers.insert(format!("x-header-{}", i), format!("value-{}", i));
+        }
+        headers.insert("content-type".to_string(), "application/json".to_string());
+        headers.insert(
+            "authorization".to_string(),
+            "Bearer eyJhbGciOi...".to_string(),
+        );
+
+        let mut path_params = BTreeMap::new();
+        for i in 0..5 {
+            path_params.insert(format!("param{}", i), format!("val{}", i));
+        }
+
+        let req = Request {
+            method: "POST".to_string(),
+            path: "/api/v1/users/{userId}/orders/{orderId}".to_string(),
+            query: Some("include=items&sort=date&limit=10".to_string()),
+            headers,
+            body: Some("x".repeat(1024)),
+            client_ip: "192.168.1.100".to_string(),
+            path_params,
+        };
+        b.iter(|| black_box(serde_json::to_vec(&req).unwrap()));
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Response serialization
+// ---------------------------------------------------------------------------
+
+fn bench_response_serialization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("response_serialization");
+
+    group.bench_function("minimal", |b| {
+        let resp = Response {
+            status: 200,
+            headers: BTreeMap::new(),
+            body: None,
+        };
+        b.iter(|| black_box(serde_json::to_vec(&resp).unwrap()));
+    });
+
+    for (label, size) in [("1KB", 1024), ("10KB", 10 * 1024)] {
+        let resp = Response {
+            status: 200,
+            headers: BTreeMap::from([("content-type".to_string(), "application/json".to_string())]),
+            body: Some("x".repeat(size)),
+        };
+
+        group.bench_with_input(BenchmarkId::new("with_body", label), &resp, |b, resp| {
+            b.iter(|| black_box(serde_json::to_vec(resp).unwrap()));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_request_serialization,
+    bench_response_serialization
+);
+criterion_main!(benches);

--- a/crates/barbacane-wasm/benches/wasm.rs
+++ b/crates/barbacane-wasm/benches/wasm.rs
@@ -1,0 +1,275 @@
+//! WASM runtime benchmarks.
+//!
+//! Benchmarks engine compilation, instance lifecycle, middleware chain execution,
+//! and context cloning — the per-request hot paths through the WASM layer.
+//!
+//! Run with: cargo bench -p barbacane-wasm --bench wasm
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use barbacane_wasm::{
+    execute_on_request_with_metrics, execute_on_response_with_metrics, ChainResult, PluginInstance,
+    PluginLimits, RequestContext, WasmEngine,
+};
+
+/// Noop WASM middleware: accepts calls, returns 0 (continue), produces no output.
+const NOOP_WAT: &str = r#"
+(module
+  (memory (export "memory") 4)
+  (func (export "init") (param i32 i32) (result i32) (i32.const 0))
+  (func (export "on_request") (param i32 i32) (result i32) (i32.const 0))
+  (func (export "on_response") (param i32 i32) (result i32) (i32.const 0))
+  (func (export "dispatch") (param i32 i32) (result i32) (i32.const 0))
+)
+"#;
+
+fn noop_wasm_bytes() -> Vec<u8> {
+    wat::parse_str(NOOP_WAT).expect("valid WAT")
+}
+
+fn create_engine() -> Arc<WasmEngine> {
+    Arc::new(WasmEngine::new().expect("engine creation"))
+}
+
+fn create_test_request() -> Vec<u8> {
+    let mut headers = BTreeMap::new();
+    headers.insert("content-type".to_string(), "application/json".to_string());
+    headers.insert("authorization".to_string(), "Bearer token123".to_string());
+
+    let request = barbacane_wasm::Request {
+        method: "GET".to_string(),
+        path: "/api/users/12345".to_string(),
+        query: Some("limit=10&offset=0".to_string()),
+        headers,
+        body: None,
+        client_ip: "127.0.0.1".to_string(),
+        path_params: BTreeMap::from([("id".to_string(), "12345".to_string())]),
+    };
+
+    serde_json::to_vec(&request).unwrap()
+}
+
+fn create_test_response() -> Vec<u8> {
+    let response = barbacane_wasm::Response {
+        status: 200,
+        headers: BTreeMap::from([("content-type".to_string(), "application/json".to_string())]),
+        body: Some(r#"{"id":"12345","name":"test"}"#.to_string()),
+    };
+
+    serde_json::to_vec(&response).unwrap()
+}
+
+fn create_noop_instance(engine: &WasmEngine) -> PluginInstance {
+    let wasm = noop_wasm_bytes();
+    let module = engine
+        .compile(&wasm, "noop".to_string(), "0.1.0".to_string())
+        .expect("compile");
+    PluginInstance::new(engine.engine(), &module, PluginLimits::default()).expect("instance")
+}
+
+// ---------------------------------------------------------------------------
+// Engine benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_wasm_engine(c: &mut Criterion) {
+    let mut group = c.benchmark_group("wasm_engine");
+    let engine = create_engine();
+    let wasm = noop_wasm_bytes();
+
+    group.bench_function("compile_module", |b| {
+        b.iter(|| {
+            black_box(
+                engine
+                    .compile(&wasm, "noop".to_string(), "0.1.0".to_string())
+                    .unwrap(),
+            );
+        });
+    });
+
+    group.bench_function("validate_module", |b| {
+        b.iter(|| {
+            engine.validate(&wasm).unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Instance benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_wasm_instance(c: &mut Criterion) {
+    let mut group = c.benchmark_group("wasm_instance");
+    let engine = create_engine();
+    let wasm = noop_wasm_bytes();
+    let module = engine
+        .compile(&wasm, "noop".to_string(), "0.1.0".to_string())
+        .unwrap();
+    let request = create_test_request();
+
+    group.bench_function("create_instance", |b| {
+        b.iter(|| {
+            black_box(
+                PluginInstance::new(engine.engine(), &module, PluginLimits::default()).unwrap(),
+            );
+        });
+    });
+
+    group.bench_function("init_instance", |b| {
+        let config = serde_json::to_vec(&serde_json::json!({"key": "value"})).unwrap();
+        b.iter(|| {
+            let mut instance =
+                PluginInstance::new(engine.engine(), &module, PluginLimits::default()).unwrap();
+            black_box(instance.init(&config).unwrap());
+        });
+    });
+
+    for size in [1024, 10 * 1024, 100 * 1024] {
+        let label = match size {
+            1024 => "1KB",
+            10240 => "10KB",
+            _ => "100KB",
+        };
+        let data = vec![0u8; size];
+
+        group.bench_with_input(
+            BenchmarkId::new("write_to_memory", label),
+            &data,
+            |b, data| {
+                let mut instance =
+                    PluginInstance::new(engine.engine(), &module, PluginLimits::default()).unwrap();
+                b.iter(|| {
+                    black_box(instance.write_to_memory(data).unwrap());
+                });
+            },
+        );
+    }
+
+    group.bench_function("on_request", |b| {
+        b.iter(|| {
+            let mut instance =
+                PluginInstance::new(engine.engine(), &module, PluginLimits::default()).unwrap();
+            black_box(instance.on_request(&request).unwrap());
+        });
+    });
+
+    group.bench_function("dispatch", |b| {
+        b.iter(|| {
+            let mut instance =
+                PluginInstance::new(engine.engine(), &module, PluginLimits::default()).unwrap();
+            black_box(instance.dispatch(&request).unwrap());
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Middleware chain benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_middleware_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("middleware_chain");
+    let engine = create_engine();
+    let request = create_test_request();
+    let response = create_test_response();
+
+    for chain_size in [1, 3, 5] {
+        group.bench_with_input(
+            BenchmarkId::new("on_request", chain_size),
+            &chain_size,
+            |b, &size| {
+                b.iter(|| {
+                    let mut instances: Vec<_> =
+                        (0..size).map(|_| create_noop_instance(&engine)).collect();
+                    let ctx = RequestContext::new("trace-1".into(), "req-1".into());
+                    let result = execute_on_request_with_metrics(
+                        &mut instances,
+                        black_box(&request),
+                        ctx,
+                        None,
+                    );
+                    assert!(matches!(result, ChainResult::Continue { .. }));
+                    black_box(result);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("on_response", chain_size),
+            &chain_size,
+            |b, &size| {
+                b.iter(|| {
+                    let mut instances: Vec<_> =
+                        (0..size).map(|_| create_noop_instance(&engine)).collect();
+                    let ctx = RequestContext::new("trace-1".into(), "req-1".into());
+                    let result = execute_on_response_with_metrics(
+                        &mut instances,
+                        black_box(&response),
+                        ctx,
+                        None,
+                    );
+                    black_box(result);
+                });
+            },
+        );
+    }
+
+    // Benchmark with metrics callback to measure callback overhead
+    group.bench_function("on_request_with_callback/3", |b| {
+        let callback = |_name: &str, _phase: &str, _duration: f64, _sc: bool| {};
+        b.iter(|| {
+            let mut instances: Vec<_> = (0..3).map(|_| create_noop_instance(&engine)).collect();
+            let ctx = RequestContext::new("trace-1".into(), "req-1".into());
+            let result = execute_on_request_with_metrics(
+                &mut instances,
+                black_box(&request),
+                ctx,
+                Some(&callback),
+            );
+            black_box(result);
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Context clone benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_context_clone(c: &mut Criterion) {
+    let mut group = c.benchmark_group("context_clone");
+
+    group.bench_function("empty", |b| {
+        let ctx = RequestContext::new("trace-1".into(), "req-1".into());
+        b.iter(|| black_box(ctx.clone()));
+    });
+
+    for count in [10, 50] {
+        let mut ctx = RequestContext::new("trace-1".into(), "req-1".into());
+        for i in 0..count {
+            ctx.values
+                .insert(format!("key-{}", i), format!("value-{}", i));
+        }
+
+        group.bench_with_input(BenchmarkId::new("with_values", count), &ctx, |b, ctx| {
+            b.iter(|| black_box(ctx.clone()));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_wasm_engine,
+    bench_wasm_instance,
+    bench_middleware_chain,
+    bench_context_clone
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Add criterion benchmarks for the WASM plugin runtime (engine compilation, instance lifecycle, middleware chain execution, context cloning)
- Add request/response JSON serialization benchmarks with varying payload sizes
- Add spec compilation benchmarks with 10/50/100 operations
- Update README performance section with all new benchmark results

## Test plan

- [x] `cargo bench --workspace` runs all benchmarks (new + existing)
- [x] `cargo clippy --all-targets` passes clean
- [x] `cargo fmt --all` passes
- [x] `cargo test --workspace --exclude barbacane-test` passes