### PR TITLE
feat: implement real NATS and Kafka dispatchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Protocol bindings extraction for Kafka, NATS, MQTT, AMQP, WebSocket
 - Message schema validation for AsyncAPI payloads
 - Host functions: `host_kafka_publish`, `host_nats_publish`
-- `kafka` dispatcher plugin with topic routing, key expressions, and header forwarding
-- `nats` dispatcher plugin with subject routing
+- `kafka` dispatcher plugin with `brokers` config, topic routing, key expressions, and header forwarding
+- `nats` dispatcher plugin with `url` config and subject routing
 - Sync-to-async bridge: HTTP request in, broker publish out, 202 ack response
+- `KafkaPublisher` — real Kafka publishing via `rskafka` (pure-Rust, no C deps) with connection caching and dedicated runtime
+- `NatsPublisher` — real NATS publishing via `async-nats` with connection caching and dedicated runtime
+- Integration tests for NATS and Kafka dispatchers (spec compilation, broker-unavailable 502, payload validation)
 
 #### Data Plane Connection (M12)
 - WebSocket-based connection between data planes and control plane
@@ -51,7 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New Web UI guide (`docs/guide/web-ui.md`)
 - Updated Control Plane guide with Projects, Data Planes, Deploy sections
 - Updated Development guide with Makefile targets and UI setup
-- Updated Dispatchers guide with AsyncAPI support
+- Updated Dispatchers guide with Kafka `brokers` and NATS `url` configuration
+- Updated Extensions reference with Kafka and NATS dispatcher schemas
 - Updated CLI Reference with `seed-plugins` command documentation
 - Added Interactive API Documentation section (Scalar at `/api/docs`)
 
@@ -89,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `compile_with_plugins` now enforces the plaintext HTTP URL check (E1031), previously missing from this code path
 
 ### Removed
+- `MessageBroker` trait, `BrokerRegistry`, and placeholder `KafkaBroker`/`NatsBroker` implementations — replaced by concrete `KafkaPublisher` and `NatsPublisher` with real broker connections
 - `x-barbacane-observability` extension (dead code - was parsed but never used at runtime)
   - Per-operation observability should be achieved via the middleware plugin system
   - Global trace sampling remains configurable via `--trace-sampling` CLI flag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "barbacane-plugin-sdk",
  "barbacane-telemetry",
  "bytes",
+ "chrono",
  "criterion",
  "dashmap",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "ar_archive_writer"
@@ -153,14 +153,50 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.37"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10e4f991a553474232bc0a31799f6d24b034a84c0971d80d2e2f78b2e576e40"
+checksum = "68650b7df54f0293fd061972a0fb05aaf4fc0879d3b3d21a638a182c5c543b9f"
 dependencies = [
  "compression-codecs",
  "compression-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-nats"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.8.5",
+ "regex",
+ "ring",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
 ]
 
 [[package]]
@@ -502,8 +538,10 @@ name = "barbacane-wasm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-nats",
  "barbacane-plugin-sdk",
  "barbacane-telemetry",
+ "bytes",
  "criterion",
  "dashmap",
  "hex",
@@ -511,6 +549,7 @@ dependencies = [
  "parking_lot",
  "regex-lite",
  "reqwest",
+ "rskafka",
  "semver",
  "serde",
  "serde_json",
@@ -618,6 +657,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cast"
@@ -627,9 +669,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -692,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.55"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e34525d5bbbd55da2bb745d34b36121baac88d07619a9a09cfcf4a6c0832785"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -702,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.55"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a20016a20a3da95bef50ec7238dbd09baeef4311dcdd38ec15aba69812fb61"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -787,10 +829,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpp_demangle"
@@ -933,6 +1004,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1108,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1155,6 +1262,28 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "signature",
+ "subtle",
+]
 
 [[package]]
 name = "either"
@@ -1257,6 +1386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,15 +1404,15 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1717,7 +1852,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1735,14 +1870,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1912,6 +2046,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,6 +2098,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2127,6 +2276,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memfd"
@@ -2226,12 +2394,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.5",
+ "signatory",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2386,6 +2578,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "opentelemetry"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,6 +2710,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,6 +2831,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,7 +2921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2710,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa96cb91275ed31d6da3e983447320c4eb219ac180fa1679a0889ff32861e2d"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -2969,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2981,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2992,15 +3211,15 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -3041,7 +3260,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3076,6 +3295,48 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rsasl"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8b534a23662bb559c5c73213be63ecd6524e774d291f3618c2b04b723d184eb"
+dependencies = [
+ "base64 0.22.1",
+ "core2",
+ "digest",
+ "hmac",
+ "pbkdf2",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "stringprep",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rskafka"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "849b87417a191e37e16b8893eba8928bbd10e1989e6b57c4f8531549eaa29bdc"
+dependencies = [
+ "bytes",
+ "chrono",
+ "crc32c",
+ "flate2",
+ "futures",
+ "integer-encoding",
+ "lz4",
+ "parking_lot",
+ "rand 0.8.5",
+ "rsasl",
+ "snap",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -3125,6 +3386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3161,9 +3431,34 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -3187,6 +3482,17 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
@@ -3205,9 +3511,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3229,10 +3535,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3288,6 +3639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,6 +3656,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3380,6 +3751,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3397,9 +3780,9 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -3409,6 +3792,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -3806,10 +4195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3817,6 +4208,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -3929,6 +4330,27 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "httparse",
+ "rand 0.8.5",
+ "ring",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4156,6 +4578,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4188,9 +4620,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-normalization"
@@ -4766,14 +5198,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5232,18 +5664,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.35"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.35"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5312,9 +5744,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,12 @@ tar = "0.4"
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "stream"] }
 
+# NATS client
+async-nats = "0.38"
+
+# Kafka client
+rskafka = "0.6"
+
 # TLS
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tokio-rustls = "0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ tower-http = { version = "0.6", features = ["trace", "cors", "set-header"] }
 
 # Database (control plane)
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono", "json"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde", "clock"] }
 base64 = "0.22"
 tempfile = "3"
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 <p align="center">
   <a href="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml"><img src="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://docs.barbacane.dev"><img src="https://img.shields.io/badge/docs-docs.barbacane.dev-blue" alt="Documentation"></a>
-  <img src="https://img.shields.io/badge/unit%20tests-250%20passing-brightgreen" alt="Unit Tests">
-  <img src="https://img.shields.io/badge/integration%20tests-125%20passing-brightgreen" alt="Integration Tests">
+  <img src="https://img.shields.io/badge/unit%20tests-271%20passing-brightgreen" alt="Unit Tests">
+  <img src="https://img.shields.io/badge/integration%20tests-131%20passing-brightgreen" alt="Integration Tests">
   <img src="https://img.shields.io/badge/rust-1.75%2B-orange" alt="Rust Version">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
 </p>

--- a/crates/barbacane-wasm/Cargo.toml
+++ b/crates/barbacane-wasm/Cargo.toml
@@ -34,6 +34,13 @@ tracing.workspace = true
 # HTTP client (for host_http_call)
 reqwest.workspace = true
 
+# NATS client (for host_nats_publish)
+async-nats.workspace = true
+bytes.workspace = true
+
+# Kafka client (for host_kafka_publish)
+rskafka.workspace = true
+
 # Sync primitives (for circuit breaker)
 parking_lot.workspace = true
 

--- a/crates/barbacane-wasm/Cargo.toml
+++ b/crates/barbacane-wasm/Cargo.toml
@@ -40,6 +40,7 @@ bytes.workspace = true
 
 # Kafka client (for host_kafka_publish)
 rskafka.workspace = true
+chrono.workspace = true
 
 # Sync primitives (for circuit breaker)
 parking_lot.workspace = true

--- a/crates/barbacane-wasm/src/kafka_client.rs
+++ b/crates/barbacane-wasm/src/kafka_client.rs
@@ -5,7 +5,7 @@
 //! A dedicated tokio runtime keeps Kafka background tasks alive between publishes.
 
 use crate::broker::{BrokerError, PublishResult};
-use rskafka::chrono::Utc;
+use chrono::Utc;
 use rskafka::client::partition::{Compression, UnknownTopicHandling};
 use rskafka::client::{Client, ClientBuilder};
 use rskafka::record::Record;

--- a/crates/barbacane-wasm/src/kafka_client.rs
+++ b/crates/barbacane-wasm/src/kafka_client.rs
@@ -1,0 +1,225 @@
+//! Kafka publisher for the Barbacane gateway.
+//!
+//! Provides a connection-caching Kafka client for the `host_kafka_publish` host function.
+//! Connections are lazily established on first publish and cached by broker URL.
+//! A dedicated tokio runtime keeps Kafka background tasks alive between publishes.
+
+use crate::broker::{BrokerError, PublishResult};
+use rskafka::chrono::Utc;
+use rskafka::client::partition::{Compression, UnknownTopicHandling};
+use rskafka::client::{Client, ClientBuilder};
+use rskafka::record::Record;
+use rskafka::BackoffConfig;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Kafka publisher with connection caching.
+///
+/// Owns a dedicated tokio runtime so that `rskafka::Client` background tasks
+/// stay alive between publish calls. Connections are created lazily on first
+/// publish and reused for subsequent messages to the same broker.
+pub struct KafkaPublisher {
+    runtime: tokio::runtime::Runtime,
+    clients: Mutex<HashMap<String, Arc<Client>>>,
+}
+
+impl Default for KafkaPublisher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KafkaPublisher {
+    /// Create a new Kafka publisher with its own background runtime.
+    pub fn new() -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("kafka-runtime")
+            .enable_all()
+            .build()
+            .expect("failed to create Kafka runtime");
+        Self {
+            runtime,
+            clients: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Blocking publish for use from sync WASM host functions.
+    ///
+    /// Must be called from a thread that is NOT inside a tokio runtime context
+    /// (e.g. from within `std::thread::scope`).
+    pub fn publish_blocking(
+        &self,
+        brokers: &str,
+        topic: &str,
+        key: Option<String>,
+        payload: &str,
+        headers: BTreeMap<String, String>,
+    ) -> Result<PublishResult, BrokerError> {
+        self.runtime
+            .block_on(self.publish(brokers, topic, key, payload, headers))
+    }
+
+    /// Publish a message to a Kafka topic (async).
+    async fn publish(
+        &self,
+        brokers: &str,
+        topic: &str,
+        key: Option<String>,
+        payload: &str,
+        headers: BTreeMap<String, String>,
+    ) -> Result<PublishResult, BrokerError> {
+        let client = self.get_or_connect(brokers).await?;
+
+        let partition_client = client
+            .partition_client(topic.to_string(), 0, UnknownTopicHandling::Retry)
+            .await
+            .map_err(|e| BrokerError::ConnectionFailed(e.to_string()))?;
+
+        let record = Record {
+            key: key.map(|k| k.into_bytes()),
+            value: Some(payload.as_bytes().to_vec()),
+            headers: headers
+                .into_iter()
+                .map(|(k, v)| (k, v.into_bytes()))
+                .collect(),
+            timestamp: Utc::now(),
+        };
+
+        let offsets = partition_client
+            .produce(vec![record], Compression::NoCompression)
+            .await
+            .map_err(|e| BrokerError::PublishFailed(e.to_string()))?;
+
+        let offset = offsets.first().copied();
+
+        Ok(PublishResult {
+            success: true,
+            error: None,
+            topic: topic.to_string(),
+            partition: Some(0),
+            offset,
+        })
+    }
+
+    /// Get a cached client or establish a new one.
+    async fn get_or_connect(&self, brokers: &str) -> Result<Arc<Client>, BrokerError> {
+        // Check cache (lock is held briefly, no await while locked)
+        {
+            let clients = self.clients.lock().unwrap();
+            if let Some(client) = clients.get(brokers) {
+                return Ok(client.clone());
+            }
+        }
+
+        // Parse broker addresses (comma-separated)
+        let broker_list: Vec<String> = brokers.split(',').map(|s| s.trim().to_string()).collect();
+
+        // Connect (outside the lock) with a 5s deadline to avoid blocking the host function
+        let backoff = BackoffConfig {
+            deadline: Some(Duration::from_secs(5)),
+            ..Default::default()
+        };
+        let client = ClientBuilder::new(broker_list)
+            .backoff_config(backoff)
+            .build()
+            .await
+            .map_err(|e| BrokerError::ConnectionFailed(e.to_string()))?;
+
+        let client = Arc::new(client);
+        tracing::info!(brokers = %brokers, "established Kafka connection");
+
+        // Cache the new connection
+        {
+            let mut clients = self.clients.lock().unwrap();
+            clients.insert(brokers.to_string(), client.clone());
+        }
+
+        Ok(client)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publisher_starts_empty() {
+        let publisher = KafkaPublisher::new();
+        let clients = publisher.clients.lock().unwrap();
+        assert!(clients.is_empty());
+    }
+
+    #[test]
+    fn default_impl() {
+        let publisher = KafkaPublisher::default();
+        let clients = publisher.clients.lock().unwrap();
+        assert!(clients.is_empty());
+    }
+
+    #[test]
+    fn publish_blocking_connection_refused() {
+        let publisher = KafkaPublisher::new();
+        let result = publisher.publish_blocking(
+            "127.0.0.1:19092",
+            "test-topic",
+            None,
+            "hello",
+            BTreeMap::new(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, BrokerError::ConnectionFailed(_)));
+    }
+
+    #[test]
+    fn publish_blocking_from_thread_scope() {
+        let publisher = KafkaPublisher::new();
+        let result = std::thread::scope(|s| {
+            s.spawn(|| {
+                publisher.publish_blocking(
+                    "127.0.0.1:19092",
+                    "test-topic",
+                    None,
+                    "hello",
+                    BTreeMap::new(),
+                )
+            })
+            .join()
+            .unwrap()
+        });
+        assert!(matches!(result, Err(BrokerError::ConnectionFailed(_))));
+    }
+
+    #[test]
+    fn publish_blocking_with_key_and_headers() {
+        let publisher = KafkaPublisher::new();
+        let mut headers = BTreeMap::new();
+        headers.insert("x-request-id".to_string(), "req-123".to_string());
+
+        let result = publisher.publish_blocking(
+            "127.0.0.1:19092",
+            "test-topic",
+            Some("order-456".to_string()),
+            r#"{"orderId":"456"}"#,
+            headers,
+        );
+        // Connection refused, but validates the key/headers path compiles and runs
+        assert!(matches!(result, Err(BrokerError::ConnectionFailed(_))));
+    }
+
+    #[test]
+    fn publish_blocking_comma_separated_brokers() {
+        let publisher = KafkaPublisher::new();
+        let result = publisher.publish_blocking(
+            "127.0.0.1:19092, 127.0.0.1:19093",
+            "test-topic",
+            None,
+            "hello",
+            BTreeMap::new(),
+        );
+        // Connection refused, but validates comma-separated broker parsing
+        assert!(matches!(result, Err(BrokerError::ConnectionFailed(_))));
+    }
+}

--- a/crates/barbacane-wasm/src/lib.rs
+++ b/crates/barbacane-wasm/src/lib.rs
@@ -15,8 +15,10 @@ mod error;
 mod host;
 mod http_client;
 mod instance;
+pub mod kafka_client;
 mod limits;
 mod manifest;
+pub mod nats_client;
 mod pool;
 pub mod rate_limiter;
 mod schema;
@@ -57,11 +59,14 @@ pub use http_client::{
     TlsConfigError,
 };
 
-// Message brokers for event dispatch (M10)
-pub use broker::{
-    BrokerError, BrokerMessage, BrokerRegistry, KafkaBroker, MessageBroker, MockBroker, NatsBroker,
-    PublishResult,
-};
+// Message broker types for event dispatch
+pub use broker::{BrokerError, BrokerMessage, PublishResult};
+
+// Kafka publisher for host_kafka_publish
+pub use kafka_client::KafkaPublisher;
+
+// NATS publisher for host_nats_publish
+pub use nats_client::NatsPublisher;
 
 /// Re-export plugin SDK types for convenience.
 pub use barbacane_plugin_sdk::prelude::{Action, Request, Response};

--- a/crates/barbacane-wasm/src/nats_client.rs
+++ b/crates/barbacane-wasm/src/nats_client.rs
@@ -1,0 +1,180 @@
+//! NATS publisher for the Barbacane gateway.
+//!
+//! Provides a connection-caching NATS client for the `host_nats_publish` host function.
+//! Connections are lazily established on first publish and cached by server URL.
+//! A dedicated tokio runtime keeps NATS background tasks alive between publishes.
+
+use crate::broker::{BrokerError, PublishResult};
+use bytes::Bytes;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Mutex;
+
+/// NATS publisher with connection caching.
+///
+/// Owns a dedicated tokio runtime so that `async_nats::Client` background tasks
+/// (heartbeats, reconnection) stay alive between publish calls. Connections are
+/// created lazily on first publish and reused for subsequent messages to the same server.
+pub struct NatsPublisher {
+    runtime: tokio::runtime::Runtime,
+    connections: Mutex<HashMap<String, async_nats::Client>>,
+}
+
+impl Default for NatsPublisher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NatsPublisher {
+    /// Create a new NATS publisher with its own background runtime.
+    pub fn new() -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("nats-runtime")
+            .enable_all()
+            .build()
+            .expect("failed to create NATS runtime");
+        Self {
+            runtime,
+            connections: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Blocking publish for use from sync WASM host functions.
+    ///
+    /// Must be called from a thread that is NOT inside a tokio runtime context
+    /// (e.g. from within `std::thread::scope`).
+    pub fn publish_blocking(
+        &self,
+        url: &str,
+        subject: &str,
+        payload: Bytes,
+        headers: BTreeMap<String, String>,
+    ) -> Result<PublishResult, BrokerError> {
+        self.runtime
+            .block_on(self.publish(url, subject, payload, headers))
+    }
+
+    /// Publish a message to a NATS subject (async).
+    async fn publish(
+        &self,
+        url: &str,
+        subject: &str,
+        payload: Bytes,
+        headers: BTreeMap<String, String>,
+    ) -> Result<PublishResult, BrokerError> {
+        let client = self.get_or_connect(url).await?;
+
+        if headers.is_empty() {
+            client
+                .publish(subject.to_string(), payload)
+                .await
+                .map_err(|e| BrokerError::PublishFailed(e.to_string()))?;
+        } else {
+            let mut header_map = async_nats::HeaderMap::new();
+            for (k, v) in &headers {
+                header_map.insert(k.as_str(), v.as_str());
+            }
+            client
+                .publish_with_headers(subject.to_string(), header_map, payload)
+                .await
+                .map_err(|e| BrokerError::PublishFailed(e.to_string()))?;
+        }
+
+        Ok(PublishResult::success(subject.to_string()))
+    }
+
+    /// Get a cached connection or establish a new one.
+    async fn get_or_connect(&self, url: &str) -> Result<async_nats::Client, BrokerError> {
+        // Check cache (lock is held briefly, no await while locked)
+        {
+            let conns = self.connections.lock().unwrap();
+            if let Some(client) = conns.get(url) {
+                return Ok(client.clone());
+            }
+        }
+
+        // Connect (outside the lock)
+        let client = async_nats::connect(url)
+            .await
+            .map_err(|e| BrokerError::ConnectionFailed(e.to_string()))?;
+
+        tracing::info!(url = %url, "established NATS connection");
+
+        // Cache the new connection
+        {
+            let mut conns = self.connections.lock().unwrap();
+            conns.insert(url.to_string(), client.clone());
+        }
+
+        Ok(client)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publisher_starts_empty() {
+        let publisher = NatsPublisher::new();
+        let conns = publisher.connections.lock().unwrap();
+        assert!(conns.is_empty());
+    }
+
+    #[test]
+    fn default_impl() {
+        let publisher = NatsPublisher::default();
+        let conns = publisher.connections.lock().unwrap();
+        assert!(conns.is_empty());
+    }
+
+    #[test]
+    fn publish_blocking_connection_refused() {
+        let publisher = NatsPublisher::new();
+        let result = publisher.publish_blocking(
+            "nats://127.0.0.1:19999",
+            "test.subject",
+            Bytes::from_static(b"hello"),
+            BTreeMap::new(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, BrokerError::ConnectionFailed(_)));
+    }
+
+    #[test]
+    fn publish_blocking_from_thread_scope() {
+        let publisher = NatsPublisher::new();
+        let result = std::thread::scope(|s| {
+            s.spawn(|| {
+                publisher.publish_blocking(
+                    "nats://127.0.0.1:19999",
+                    "test.subject",
+                    Bytes::from_static(b"hello"),
+                    BTreeMap::new(),
+                )
+            })
+            .join()
+            .unwrap()
+        });
+        assert!(matches!(result, Err(BrokerError::ConnectionFailed(_))));
+    }
+
+    #[test]
+    fn publish_blocking_with_headers() {
+        let publisher = NatsPublisher::new();
+        let mut headers = BTreeMap::new();
+        headers.insert("x-request-id".to_string(), "req-123".to_string());
+        headers.insert("x-trace-id".to_string(), "trace-456".to_string());
+
+        let result = publisher.publish_blocking(
+            "nats://127.0.0.1:19999",
+            "events.orders",
+            Bytes::from_static(b"hello"),
+            headers,
+        );
+        // Connection refused, but validates the headers code path
+        assert!(matches!(result, Err(BrokerError::ConnectionFailed(_))));
+    }
+}

--- a/crates/barbacane-wasm/src/pool.rs
+++ b/crates/barbacane-wasm/src/pool.rs
@@ -84,6 +84,12 @@ pub struct InstancePool {
     /// Response cache (shared across all instances).
     response_cache: Option<ResponseCache>,
 
+    /// NATS publisher (shared across all instances).
+    nats_publisher: Option<Arc<crate::nats_client::NatsPublisher>>,
+
+    /// Kafka publisher (shared across all instances).
+    kafka_publisher: Option<Arc<crate::kafka_client::KafkaPublisher>>,
+
     /// Cache of compiled modules by plugin name.
     modules: DashMap<String, CompiledModule>,
 
@@ -106,6 +112,8 @@ impl InstancePool {
             secrets: None,
             rate_limiter: None,
             response_cache: None,
+            nats_publisher: None,
+            kafka_publisher: None,
             modules: DashMap::new(),
             instances: DashMap::new(),
             configs: DashMap::new(),
@@ -125,6 +133,8 @@ impl InstancePool {
             secrets: None,
             rate_limiter: None,
             response_cache: None,
+            nats_publisher: None,
+            kafka_publisher: None,
             modules: DashMap::new(),
             instances: DashMap::new(),
             configs: DashMap::new(),
@@ -145,6 +155,8 @@ impl InstancePool {
             secrets: Some(secrets),
             rate_limiter: None,
             response_cache: None,
+            nats_publisher: None,
+            kafka_publisher: None,
             modules: DashMap::new(),
             instances: DashMap::new(),
             configs: DashMap::new(),
@@ -152,6 +164,7 @@ impl InstancePool {
     }
 
     /// Create a new instance pool with all options.
+    #[allow(clippy::too_many_arguments)]
     pub fn with_all_options(
         engine: Arc<WasmEngine>,
         limits: PluginLimits,
@@ -159,6 +172,8 @@ impl InstancePool {
         secrets: Option<SecretsStore>,
         rate_limiter: Option<RateLimiter>,
         response_cache: Option<ResponseCache>,
+        nats_publisher: Option<Arc<crate::nats_client::NatsPublisher>>,
+        kafka_publisher: Option<Arc<crate::kafka_client::KafkaPublisher>>,
     ) -> Self {
         Self {
             engine,
@@ -167,6 +182,8 @@ impl InstancePool {
             secrets,
             rate_limiter,
             response_cache,
+            nats_publisher,
+            kafka_publisher,
             modules: DashMap::new(),
             instances: DashMap::new(),
             configs: DashMap::new(),
@@ -207,6 +224,8 @@ impl InstancePool {
             self.secrets.clone(),
             self.rate_limiter.clone(),
             self.response_cache.clone(),
+            self.nats_publisher.clone(),
+            self.kafka_publisher.clone(),
         )?;
 
         // Initialize with config

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -692,7 +692,13 @@ impl Gateway {
         // Create response cache for host_cache_get/set calls
         let response_cache = ResponseCache::new();
 
-        // Create pool with all options: HTTP client, secrets, rate limiter, and cache
+        // Create NATS publisher for host_nats_publish calls
+        let nats_publisher = barbacane_wasm::NatsPublisher::new();
+
+        // Create Kafka publisher for host_kafka_publish calls
+        let kafka_publisher = barbacane_wasm::KafkaPublisher::new();
+
+        // Create pool with all options: HTTP client, secrets, rate limiter, cache, NATS, and Kafka
         let plugin_pool = InstancePool::with_all_options(
             wasm_engine.clone(),
             plugin_limits.clone(),
@@ -700,6 +706,8 @@ impl Gateway {
             Some(secrets_store),
             Some(rate_limiter),
             Some(response_cache),
+            Some(Arc::new(nats_publisher)),
+            Some(Arc::new(kafka_publisher)),
         );
 
         // Register all compiled modules in the pool

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -93,7 +93,7 @@ Parses OpenAPI and AsyncAPI specifications and extracts Barbacane extensions.
 - OpenAPI 3.0.x
 - OpenAPI 3.1.x
 - OpenAPI 3.2.x (draft)
-- AsyncAPI 3.x (parsing supported, dispatchers planned)
+- AsyncAPI 3.x (with Kafka and NATS dispatchers)
 
 ### barbacane-router
 
@@ -183,6 +183,12 @@ WASM plugin runtime built on wasmtime.
 - `host_http_read_result` - Read HTTP response data
 - `host_get_secret` - Get a resolved secret by reference
 - `host_secret_read_result` - Read secret value into plugin memory
+- `host_kafka_publish` - Publish messages to Kafka topics
+- `host_nats_publish` - Publish messages to NATS subjects
+- `host_rate_limit_check` - Check rate limits
+- `host_cache_read/write` - Read/write response cache
+- `host_metric_counter_inc` - Increment Prometheus counter
+- `host_metric_histogram_observe` - Record histogram observation
 
 **Resource limits:**
 - 16 MB linear memory
@@ -372,4 +378,3 @@ cargo test --workspace
 - **gRPC passthrough**: Transparent proxying for gRPC services
 - **Hot reload**: Reload artifacts without restart via control plane notifications
 - **Cluster mode**: Distributed configuration across multiple nodes
-- **AsyncAPI dispatchers**: Event-driven APIs with Kafka/NATS dispatch (parsing already supported)

--- a/docs/contributing/plugins.md
+++ b/docs/contributing/plugins.md
@@ -370,12 +370,18 @@ Barbacane includes these official plugins in the `plugins/` directory:
 | `mock` | Dispatcher | Return static responses |
 | `http-upstream` | Dispatcher | Reverse proxy to HTTP backends |
 | `lambda` | Dispatcher | Invoke AWS Lambda functions |
+| `kafka` | Dispatcher | Publish messages to Kafka |
+| `nats` | Dispatcher | Publish messages to NATS |
 | `jwt-auth` | Middleware | JWT token validation |
 | `apikey-auth` | Middleware | API key authentication |
 | `oauth2-auth` | Middleware | OAuth2 token introspection |
 | `rate-limit` | Middleware | Sliding window rate limiting |
 | `cache` | Middleware | Response caching |
 | `cors` | Middleware | CORS header management |
+| `correlation-id` | Middleware | Request correlation ID propagation |
+| `request-size-limit` | Middleware | Request body size limits |
+| `ip-restriction` | Middleware | IP allowlist/blocklist |
+| `observability` | Middleware | SLO monitoring and detailed logging |
 
 Use these as references for your own plugins.
 

--- a/docs/guide/dispatchers.md
+++ b/docs/guide/dispatchers.md
@@ -300,12 +300,13 @@ Lambda response format:
 
 ### kafka
 
-Publishes messages to Apache Kafka topics. Designed for AsyncAPI specs using the sync-to-async bridge pattern: HTTP POST requests publish messages and return 202 Accepted.
+Publishes messages to Apache Kafka topics. Designed for AsyncAPI specs using the sync-to-async bridge pattern: HTTP POST requests publish messages and return 202 Accepted. Uses a pure-Rust Kafka client with connection caching and a dedicated runtime.
 
 ```yaml
 x-barbacane-dispatch:
   name: kafka
   config:
+    brokers: "kafka.internal:9092"
     topic: "user-events"
 ```
 
@@ -313,6 +314,7 @@ x-barbacane-dispatch:
 
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
+| `brokers` | string | Yes | - | Comma-separated Kafka broker addresses (e.g. `"kafka:9092"` or `"broker1:9092, broker2:9092"`) |
 | `topic` | string | Yes | - | Kafka topic to publish to |
 | `key` | string | No | - | Message key expression (see below) |
 | `ack_response` | object | No | - | Custom acknowledgment response |
@@ -337,6 +339,7 @@ Override the default 202 Accepted response:
 x-barbacane-dispatch:
   name: kafka
   config:
+    brokers: "kafka.internal:9092"
     topic: "orders"
     ack_response:
       body: {"queued": true, "estimatedDelivery": "5s"}
@@ -371,6 +374,7 @@ operations:
     x-barbacane-dispatch:
       name: kafka
       config:
+        brokers: "kafka.internal:9092"
         topic: "order-events"
         key: "$request.header.X-Order-Id"
         include_metadata: true
@@ -381,6 +385,7 @@ operations:
 x-barbacane-dispatch:
   name: kafka
   config:
+    brokers: "kafka.internal:9092"
     topic: "audit-events"
     headers_from_request:
       - "x-correlation-id"
@@ -410,12 +415,13 @@ On successful publish, returns 202 Accepted:
 
 ### nats
 
-Publishes messages to NATS subjects. Designed for AsyncAPI specs using the sync-to-async bridge pattern.
+Publishes messages to NATS subjects. Designed for AsyncAPI specs using the sync-to-async bridge pattern. Uses a pure-Rust NATS client with connection caching and a dedicated runtime.
 
 ```yaml
 x-barbacane-dispatch:
   name: nats
   config:
+    url: "nats://nats.internal:4222"
     subject: "notifications.user"
 ```
 
@@ -423,6 +429,7 @@ x-barbacane-dispatch:
 
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
+| `url` | string | Yes | - | NATS server URL (e.g. `"nats://localhost:4222"`) |
 | `subject` | string | Yes | - | NATS subject to publish to (supports wildcards) |
 | `ack_response` | object | No | - | Custom acknowledgment response |
 | `headers_from_request` | array | No | `[]` | Request headers to forward as message headers |
@@ -461,6 +468,7 @@ operations:
     x-barbacane-dispatch:
       name: nats
       config:
+        url: "nats://nats.internal:4222"
         subject: "notifications"
         headers_from_request:
           - "x-request-id"
@@ -471,6 +479,7 @@ operations:
 x-barbacane-dispatch:
   name: nats
   config:
+    url: "nats://nats.internal:4222"
     subject: "events.user.signup"
     ack_response:
       body: {"accepted": true}
@@ -504,28 +513,6 @@ Custom dispatchers can be implemented as WASM plugins using the Plugin SDK. The 
 ### Planned Dispatchers
 
 The following dispatchers are planned for future releases:
-
-#### AsyncAPI Dispatchers (Kafka, NATS)
-
-Barbacane supports parsing AsyncAPI 3.x specifications. Message broker dispatchers are planned:
-
-```yaml
-# Planned Kafka dispatcher
-x-barbacane-dispatch:
-  name: kafka
-  config:
-    broker: "kafka.internal:9092"
-    topic: "orders"
-```
-
-```yaml
-# Planned NATS dispatcher
-x-barbacane-dispatch:
-  name: nats
-  config:
-    url: "nats://nats.internal:4222"
-    subject: "events.orders"
-```
 
 #### gRPC Dispatcher
 

--- a/docs/guide/spec-configuration.md
+++ b/docs/guide/spec-configuration.md
@@ -318,6 +318,7 @@ operations:
     x-barbacane-dispatch:
       name: kafka
       config:
+        brokers: "kafka.internal:9092"
         topic: "user-events"
 ```
 
@@ -368,6 +369,7 @@ operations:
     x-barbacane-dispatch:
       name: kafka
       config:
+        brokers: "kafka.internal:9092"
         topic: "events"
 ```
 

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -59,6 +59,30 @@ x-barbacane-dispatch:
     timeout: number   # Optional. Timeout in seconds (default: 30.0)
 ```
 
+### Dispatcher: `kafka`
+
+Publish messages to Apache Kafka topics.
+
+```yaml
+x-barbacane-dispatch:
+  name: kafka
+  config:
+    brokers: string   # Required. Comma-separated broker addresses
+    topic: string     # Required. Kafka topic
+```
+
+### Dispatcher: `nats`
+
+Publish messages to NATS subjects.
+
+```yaml
+x-barbacane-dispatch:
+  name: nats
+  config:
+    url: string       # Required. NATS server URL (e.g. "nats://localhost:4222")
+    subject: string   # Required. NATS subject
+```
+
 ### Examples
 
 **Mock response:**

--- a/playground/barbacane.yaml
+++ b/playground/barbacane.yaml
@@ -19,5 +19,7 @@ plugins:
     path: /plugins/correlation-id/correlation-id.wasm
   request-size-limit:
     path: /plugins/request-size-limit/request-size-limit.wasm
+  nats:
+    path: /plugins/nats/nats.wasm
   observability:
     path: /plugins/observability/observability.wasm

--- a/playground/docker-compose.yml
+++ b/playground/docker-compose.yml
@@ -10,6 +10,7 @@
 #   - Control Plane UI: http://localhost:3001
 #   - Grafana: http://localhost:3000 (admin/admin)
 #   - Prometheus: http://localhost:9090
+#   - NATS: nats://localhost:4222
 #   - WireMock: http://localhost:8081/__admin
 
 services:
@@ -50,6 +51,8 @@ services:
       compiler:
         condition: service_completed_successfully
       wiremock:
+        condition: service_healthy
+      nats:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/__barbacane/health"]
@@ -95,6 +98,20 @@ services:
       test: ["CMD-SHELL", "pg_isready -U barbacane"]
       interval: 5s
       timeout: 5s
+      retries: 5
+
+  # ==========================================================================
+  # Message Broker (NATS)
+  # ==========================================================================
+  nats:
+    image: nats:2-alpine
+    ports:
+      - "4222:4222"   # Client connections
+      - "8222:8222"   # HTTP monitoring
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8222/healthz"]
+      interval: 5s
+      timeout: 3s
       retries: 5
 
   # ==========================================================================

--- a/playground/specs/train-events.yaml
+++ b/playground/specs/train-events.yaml
@@ -262,11 +262,10 @@ operations:
       $ref: '#/channels/tripDelayEvents'
     summary: Publish train delay event
     x-barbacane-dispatch:
-      name: mock
+      name: nats
       config:
-        status: 202
-        body: '{"status":"accepted","event_type":"trip.delayed"}'
-        content_type: application/json
+        url: nats://nats:4222
+        subject: trains.trips.delayed
     x-barbacane-middlewares:
       - name: rate-limit
         config:
@@ -283,11 +282,10 @@ operations:
       $ref: '#/channels/tripCancelledEvents'
     summary: Publish train cancellation event
     x-barbacane-dispatch:
-      name: mock
+      name: nats
       config:
-        status: 202
-        body: '{"status":"accepted","event_type":"trip.cancelled"}'
-        content_type: application/json
+        url: nats://nats:4222
+        subject: trains.trips.cancelled
 
   publishPlatformChange:
     action: send
@@ -295,11 +293,10 @@ operations:
       $ref: '#/channels/platformChangeEvents'
     summary: Publish platform change event
     x-barbacane-dispatch:
-      name: mock
+      name: nats
       config:
-        status: 202
-        body: '{"status":"accepted","event_type":"platform.changed"}'
-        content_type: application/json
+        url: nats://nats:4222
+        subject: trains.stations.platform-changed
 
   publishBookingConfirmed:
     action: send
@@ -307,11 +304,10 @@ operations:
       $ref: '#/channels/bookingConfirmedEvents'
     summary: Publish booking confirmation event
     x-barbacane-dispatch:
-      name: mock
+      name: nats
       config:
-        status: 202
-        body: '{"status":"accepted","event_type":"booking.confirmed"}'
-        content_type: application/json
+        url: nats://nats:4222
+        subject: trains.bookings.confirmed
     x-barbacane-middlewares:
       - name: observability
         config:
@@ -323,11 +319,10 @@ operations:
       $ref: '#/channels/bookingCancelledEvents'
     summary: Publish booking cancellation event
     x-barbacane-dispatch:
-      name: mock
+      name: nats
       config:
-        status: 202
-        body: '{"status":"accepted","event_type":"booking.cancelled"}'
-        content_type: application/json
+        url: nats://nats:4222
+        subject: trains.bookings.cancelled
 
   publishPaymentSucceeded:
     action: send
@@ -335,11 +330,10 @@ operations:
       $ref: '#/channels/paymentSucceededEvents'
     summary: Publish payment success event
     x-barbacane-dispatch:
-      name: mock
+      name: nats
       config:
-        status: 202
-        body: '{"status":"accepted","event_type":"payment.succeeded"}'
-        content_type: application/json
+        url: nats://nats:4222
+        subject: trains.payments.succeeded
 
   publishPaymentFailed:
     action: send
@@ -347,8 +341,7 @@ operations:
       $ref: '#/channels/paymentFailedEvents'
     summary: Publish payment failure event
     x-barbacane-dispatch:
-      name: mock
+      name: nats
       config:
-        status: 202
-        body: '{"status":"accepted","event_type":"payment.failed"}'
-        content_type: application/json
+        url: nats://nats:4222
+        subject: trains.payments.failed

--- a/plugins/kafka/Cargo.lock
+++ b/plugins/kafka/Cargo.lock
@@ -15,7 +15,6 @@ dependencies = [
 name = "barbacane-plugin-macros"
 version = "0.1.0"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn",
 ]
@@ -26,7 +25,6 @@ version = "0.1.0"
 dependencies = [
  "barbacane-plugin-macros",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/plugins/nats/Cargo.lock
+++ b/plugins/nats/Cargo.lock
@@ -15,7 +15,6 @@ dependencies = [
 name = "barbacane-plugin-macros"
 version = "0.1.0"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn",
 ]
@@ -26,7 +25,6 @@ version = "0.1.0"
 dependencies = [
  "barbacane-plugin-macros",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/plugins/nats/src/lib.rs
+++ b/plugins/nats/src/lib.rs
@@ -11,6 +11,9 @@ use std::collections::BTreeMap;
 #[barbacane_dispatcher]
 #[derive(Deserialize)]
 pub struct NatsDispatcher {
+    /// NATS server URL (e.g., nats://localhost:4222).
+    url: String,
+
     /// NATS subject to publish messages to.
     subject: String,
 
@@ -33,6 +36,7 @@ struct AckResponse {
 /// Message to send to host_nats_publish.
 #[derive(Serialize)]
 struct BrokerMessage {
+    url: String,
     topic: String, // "topic" field is used for subject in NATS
     payload: String,
     headers: BTreeMap<String, String>,
@@ -68,6 +72,7 @@ impl NatsDispatcher {
 
         // Build the broker message
         let message = BrokerMessage {
+            url: self.url.clone(),
             topic: self.subject.clone(),
             payload: req.body.clone().unwrap_or_default(),
             headers: msg_headers,

--- a/tests/fixtures/barbacane.yaml
+++ b/tests/fixtures/barbacane.yaml
@@ -24,3 +24,7 @@ plugins:
     path: ../../plugins/request-size-limit/request-size-limit.wasm
   ip-restriction:
     path: ../../plugins/ip-restriction/ip-restriction.wasm
+  nats:
+    path: ../../plugins/nats/nats.wasm
+  kafka:
+    path: ../../plugins/kafka/kafka.wasm

--- a/tests/fixtures/kafka-dispatch.yaml
+++ b/tests/fixtures/kafka-dispatch.yaml
@@ -1,0 +1,35 @@
+asyncapi: "3.0.0"
+info:
+  title: Kafka Dispatch Test API
+  version: "1.0.0"
+  description: Tests real Kafka dispatcher publishing via sync-to-async bridge
+
+channels:
+  orderEvents:
+    address: /events/orders
+    messages:
+      OrderPlaced:
+        contentType: application/json
+        payload:
+          type: object
+          required:
+            - orderId
+            - total
+          properties:
+            orderId:
+              type: string
+              format: uuid
+            total:
+              type: number
+
+operations:
+  publishOrderPlaced:
+    action: send
+    channel:
+      $ref: '#/channels/orderEvents'
+    x-barbacane-dispatch:
+      name: kafka
+      config:
+        brokers: "127.0.0.1:19092"
+        topic: "orders.placed"
+        include_metadata: true

--- a/tests/fixtures/nats-dispatch.yaml
+++ b/tests/fixtures/nats-dispatch.yaml
@@ -1,0 +1,35 @@
+asyncapi: "3.0.0"
+info:
+  title: NATS Dispatch Test API
+  version: "1.0.0"
+  description: Tests real NATS dispatcher publishing via sync-to-async bridge
+
+channels:
+  userEvents:
+    address: /events/users
+    messages:
+      UserCreated:
+        contentType: application/json
+        payload:
+          type: object
+          required:
+            - userId
+            - email
+          properties:
+            userId:
+              type: string
+              format: uuid
+            email:
+              type: string
+              format: email
+
+operations:
+  publishUserCreated:
+    action: send
+    channel:
+      $ref: '#/channels/userEvents'
+    x-barbacane-dispatch:
+      name: nats
+      config:
+        url: "nats://127.0.0.1:14222"
+        subject: "events.users"


### PR DESCRIPTION
## Summary

- **KafkaPublisher**: real Kafka publishing via rskafka (pure-Rust, no C deps) with connection caching and a dedicated tokio runtime
- **NatsPublisher**: real NATS publishing via async-nats with connection caching and a dedicated tokio runtime
- Removed placeholder MessageBroker trait, BrokerRegistry, KafkaBroker, and NatsBroker — replaced by concrete publishers with actual broker connections
- Added brokers config to the Kafka plugin and url config to the NATS plugin
- Updated all documentation (dispatchers guide, spec-configuration, extensions reference, architecture, plugins guide, changelog)

## Test plan

- [x] 6 new unit tests for KafkaPublisher (connection refused, thread scope, key/headers, comma-separated brokers)
- [x] 1 new unit test for NatsPublisher (headers path)
- [x] 8 new unit tests for broker.rs shared types (serialization, constructors, error display)
- [x] 2 new unit tests for PluginState (kafka_publisher field, with_all_options wiring)
- [x] 6 new integration tests: spec compilation, broker-unavailable 502, payload validation for both NATS and Kafka
- [x] All 275 unit + 131 integration tests passing
- [x] cargo fmt, cargo clippy, cargo audit clean