### PR TITLE
adding spec-to-run roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,6 +146,16 @@ Near-term items ready to be picked up:
 | Homebrew formula | macOS package manager support | P3 |
 | APT/RPM packages | Linux package manager support | P3 |
 
+### Security & Config provenance: Trusted Spec-to-Run Pipeline
+
+To guarantee that the running gateway is executing the exact specification intended, we will implement a verifiable spec-to-run trust chain. This ensures no unauthorized configuration drift can occur between the source repository and the production edge.
+
+- [ ] **Artifact fingerprinting:** Automatically calculate and embed a cryptographic hash (along with optional metadata like Git commit SHA or S3 Object ID) into the `.bca` artifact during the `barbacane compile` step.
+- [ ] **Provenance API endpoint:** Add a dedicated, authenticated endpoint to the Data Plane to interrogate the currently loaded configuration fingerprint.
+- [ ] **Control Plane drift detection:** Implement a background worker in `barbacane-control` that periodically polls connected Data Planes to ensure the running artifact hash matches the authorized version, triggering alerts upon drift.
+- [ ] **OCI / SBOM integration:** Surface the specification fingerprint in the software bill of materials (SBOM) and container labels when packaging the Data Plane as an OCI image, completing the end-to-end supply chain verification.
+
+
 ---
 
 ## Technical Debt

--- a/adr/0021-config-provenance.md
+++ b/adr/0021-config-provenance.md
@@ -1,0 +1,70 @@
+# ADR-0021: Spec-to-Run configuration provenance and drift detection
+
+**Status:** Proposed
+**Date:** 2026-02-20
+
+## Context
+
+Barbacane’s architecture compiles human-readable configuration files (OpenAPI specs, routing rules) into an optimized binary artifact (`.bca`) which is then loaded by the Data Plane (`barbacane serve`). 
+
+Currently, once a Data Plane is running, there is no cryptographic guarantee or programmatic way to verify exactly *which* specification it is executing. In highly regulated enterprise environments (Zero Trust, SOC2, PCI-DSS compliance), operators require a verifiable "Trust Chain". They need to answer:
+1. Is the gateway running the exact configuration that was approved in Git?
+2. Has the configuration drifted or been tampered with?
+
+We need a standardized way to fingerprint configurations at build time and verify them at runtime.
+
+## Decision
+
+We will implement an end-to-end configuration provenance system. This will be broken down into four architectural pillars:
+
+### 1. Build-Time Artifact Fingerprinting
+
+The `barbacane compile` command will be updated to automatically calculate a SHA-256 hash of all input configuration files before compiling. 
+
+**Embedded Metadata:** The resulting `.bca` file format will be updated to include a metadata header containing:
+- `spec_hash`: The SHA-256 hash of the input configuration files.
+- `build_timestamp`: UTC timestamp of the compilation.
+- Optional injected metadata via CLI flags (e.g., `--provenance-commit=a1b2c3d`, `--provenance-source=s3://bucket/config.zip`).
+
+### 2. Runtime Provenance API (Data Plane)
+
+The Data Plane (`barbacane`) will expose a new internal administration endpoint to query this metadata.
+- **Endpoint:** `GET /_admin/provenance` 
+- **Binding:** Available only on the dedicated admin port/interface (not exposed to the public internet alongside user traffic).
+- **Response:** JSON payload containing the metadata extracted from the currently loaded `.bca` artifact's header.
+
+### 3. Drift Detection (Control Plane)
+
+The Control Plane (`barbacane-control`) will act as the source of truth for the *desired state*.
+- A background worker will periodically poll the `/_admin/provenance` endpoint of all registered Data Plane nodes.
+- If the `actual_hash` from the Data Plane does not match the `desired_hash` known to the Control Plane, the Control Plane will flag the node with a `ConfigurationDrift` status.
+- This status will trigger native alerts (via logs, metrics, or webhooks) to notify operators.
+
+### 4. OCI Image & SBOM Supply Chain Integration
+
+When Barbacane artifacts are packaged into container images, the build tooling will extract the `spec_hash` and provenance metadata to:
+- Inject them as standard OCI image labels (e.g., `org.opencontainers.image.revision`).
+- Include the configuration artifact as a verified component in the container's SBOM (Software Bill of Materials).
+
+## Consequences
+
+### Positive
+
+- **Compliance & Auditability:** Provides cryptographic proof of what is running, satisfying strict audit requirements.
+- **Observability:** Operators can instantly see if a deployment failed to roll out properly (e.g., half the fleet running the old config).
+- **Security:** Detects unauthorized out-of-band changes or tampering with the `.bca` file directly on the server.
+
+### Negative
+
+- **Artifact Format Change:** This requires a breaking change to the internal `.bca` binary format to support a metadata header. We must ensure backward compatibility or bump the artifact version.
+- **Admin Port Security:** Exposing the `/_admin/provenance` endpoint requires strict network binding (e.g., `127.0.0.1` or a dedicated internal network) to prevent exposing internal infrastructure details.
+- **Control Plane Overhead:** The Control Plane now needs an active polling mechanism (worker loop) to monitor Data Plane nodes, increasing its CPU and network footprint slightly.
+
+### Alternatives Considered
+
+- **Hashing the `.bca` file directly instead of the input files:** Rejected. The compilation process might introduce non-deterministic byte ordering depending on the OS/Architecture where `barbacane compile` is run. Hashing the *source* files provides a true, reproducible representation of the user's intent.
+
+## Related ADRs
+
+- [ADR-0007: Control Plane / Data Plane Separation](0007-control-data-plane-separation.md) — Reaffirms the need for the control plane to actively monitor the isolated data planes.
+- [ADR-0019: Packaging and Release Strategy](0019-packaging-and-release-strategy.md) — Aligns with the supply chain security goals (SBOMs, SLSA).

--- a/adr/0022-admin-api.md
+++ b/adr/0022-admin-api.md
@@ -1,0 +1,45 @@
+# ADR-022: Dedicated listening server for the admin API
+
+**Status:** Proposed
+**Date:** 2026-02-25
+
+## Context
+
+Currently, the Barbacane data plane (`barbacane serve`) only opens a single network port, which is intended to receive public user traffic. 
+
+However, we have an increasing need to expose internal endpoints for observability and maintenance. For example:
+- Health checks and readiness probes.
+- Prometheus metrics (`/metrics`).
+- Configuration provenance data (`/_admin/provenance`, see ADR-0024).
+- Profiling or debugging tools (pprof).
+
+Exposing these sensitive routes on the same port as public traffic represents a major security risk. Even with strict routing rules, a simple configuration error could expose metrics or internal gateway data to the internet.
+
+## Decision
+
+We will introduce a dedicated listening server (a separate listener) solely for administration and observability requests on the data plane.
+
+1. **Default port and interface:** The admin API will listen on `127.0.0.1:8081` by default. Restricting it to `localhost` ensures it is not accidentally exposed during local tests or basic deployments.
+
+2. **CLI configuration:** We will add a new explicit parameter to configure this interface. For example: `--admin-bind 0.0.0.0:8081`. 
+
+3. **Strict routing separation:**
+   The main router (which processes user traffic based on OpenAPI specs) will completely ignore administration routes. The admin server will have its own minimalist, hardcoded router, independent of the dynamic configuration lifecycle.
+
+## Consequences
+
+### Positive
+
+- **Security by default:** Internal APIs are physically isolated (at the network socket level) from public traffic. No OpenAPI specification error can accidentally expose `/metrics` or `/_admin/provenance`.
+- **Foundation for the future:** This unblocks the implementation of essential features (like the provenance verification in ADR-0024) without compromising security.
+- **Kubernetes best practice:** This allows operators to configure their probes (liveness/readiness) and metrics scrapers on a distinct internal port, which is the industry standard (similar to Envoy or Traefik).
+
+### Negative
+
+- **Deployment complexity:** Users deploying Barbacane in containers (Docker/Kubernetes) will need to remember to expose an additional port if they want to access metrics from outside the container.
+- **Resources:** Running a second HTTP server consumes slightly more memory and system resources, although the impact is negligible in Rust.
+
+## Alternatives considered
+
+- **IP-based filtering on the main port:** Rejected. Filtering requests to `/metrics` by checking the source IP on the public port is fragile, complex to maintain, and vulnerable to IP spoofing or upstream proxy misconfigurations.
+- **Dynamic admin configuration via the spec:** Rejected. The admin API must remain available even if the user-provided specification is invalid or corrupted. It must therefore be configured via the CLI or environment variables, not via the `.bca` file.


### PR DESCRIPTION
## Description

This PR updates the `ROADMAP.md` to include a new major security and compliance feature: **Trusted Spec-to-Run Pipeline**.

As Barbacane targets enterprise and highly regulated environments, users need cryptographically verifiable guarantees that the running Data Plane is executing the exact configuration/spec they approved, with zero drift.

### The feature covers:
1. **Build-time Fingerprinting**: Injecting a cryptographic hash (and Git commit / S3 object-id) into the `.bca` artifact during compilation.
2. **Runtime Verification**: Exposing an API endpoint on the Data Plane to query the current config fingerprint.
3. **Control Plane Drift Detection**: The Control Plane will periodically verify the running instances against the expected source of truth and alert on anomalies.
4. **Supply Chain Security**: Exporting this provenance data into the SBOM when running as an OCI container.
