### PR TITLE
feat: wildcard path parameters ({param+})

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 <p align="center">
   <a href="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml"><img src="https://github.com/barbacane-dev/barbacane/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://docs.barbacane.dev"><img src="https://img.shields.io/badge/docs-docs.barbacane.dev-blue" alt="Documentation"></a>
-  <img src="https://img.shields.io/badge/unit%20tests-323%20passing-brightgreen" alt="Unit Tests">
+  <img src="https://img.shields.io/badge/unit%20tests-334%20passing-brightgreen" alt="Unit Tests">
   <img src="https://img.shields.io/badge/plugin%20tests-495%20passing-brightgreen" alt="Plugin Tests">
-  <img src="https://img.shields.io/badge/integration%20tests-181%20passing-brightgreen" alt="Integration Tests">
+  <img src="https://img.shields.io/badge/integration%20tests-186%20passing-brightgreen" alt="Integration Tests">
   <img src="https://img.shields.io/badge/cli%20tests-17%20passing-brightgreen" alt="CLI Tests">
   <img src="https://img.shields.io/badge/rust-1.75%2B-orange" alt="Rust Version">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>

--- a/crates/barbacane-test/src/gateway.rs
+++ b/crates/barbacane-test/src/gateway.rs
@@ -506,6 +506,67 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn test_wildcard_path_single_segment() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/wildcard-path.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Single segment captured by {path+}
+        let resp = gateway.get("/files/readme.txt").await.unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_path_multi_segment() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/wildcard-path.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Multi-segment path captured as a single value
+        let resp = gateway.get("/files/docs/2024/report.pdf").await.unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_path_static_takes_precedence() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/wildcard-path.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // Static route /files/special must win over /files/{path+}
+        let resp = gateway.get("/files/special").await.unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["route"], "static");
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_path_with_prefix_param() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/wildcard-path.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // S3-style: {bucket} is a regular param, {key+} captures the rest
+        let resp = gateway
+            .get("/storage/my-bucket/folder/sub/file.txt")
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_path_missing_key_segment() {
+        let gateway = TestGateway::from_spec("../../tests/fixtures/wildcard-path.yaml")
+            .await
+            .expect("failed to start gateway");
+
+        // /storage/{bucket} with no key — {key+} requires at least one segment
+        let resp = gateway.get("/storage/my-bucket").await.unwrap();
+        assert_eq!(resp.status().as_u16(), 404);
+    }
+
     // ========================
     // M2: Validation Tests
     // ========================

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -109,15 +109,16 @@ paths:
           path: "/api/v2/users/{id}"
 ```
 
-**Wildcard proxy:**
+**Wildcard proxy** (multi-segment path capture with `{param+}`):
 ```yaml
 paths:
-  /proxy/{path}:
+  /proxy/{path+}:
     get:
       parameters:
         - name: path
           in: path
           required: true
+          allowReserved: true  # value may contain unencoded '/'
           schema:
             type: string
       x-barbacane-dispatch:
@@ -127,6 +128,8 @@ paths:
           path: "/{path}"
           timeout: 10.0
 ```
+
+A request to `/proxy/api/v2/users/123` captures `path=api/v2/users/123` and forwards to `https://backend.internal/api/v2/users/123`. See [Path Parameters](../guide/spec-configuration.md#path-parameters) for details.
 
 ### Secret References
 

--- a/tests/fixtures/wildcard-path.yaml
+++ b/tests/fixtures/wildcard-path.yaml
@@ -1,0 +1,84 @@
+openapi: "3.1.0"
+info:
+  title: Wildcard Path Parameter Test API
+  version: "1.0.0"
+paths:
+  # Static route — must take precedence over the wildcard below
+  /files/special:
+    get:
+      operationId: getSpecialFile
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"route":"static"}'
+      responses:
+        "200":
+          description: OK
+
+  # Wildcard route — captures any single or multi-segment path under /files/
+  /files/{path+}:
+    get:
+      operationId: getFile
+      parameters:
+        - name: path
+          in: path
+          required: true
+          allowReserved: true
+          schema:
+            type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"route":"wildcard"}'
+      responses:
+        "200":
+          description: OK
+
+  # Wildcard with a regular prefix param — S3-style bucket + key
+  /storage/{bucket}/{key+}:
+    get:
+      operationId: getObject
+      parameters:
+        - name: bucket
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: key
+          in: path
+          required: true
+          allowReserved: true
+          schema:
+            type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"route":"storage"}'
+      responses:
+        "200":
+          description: OK
+    put:
+      operationId: putObject
+      parameters:
+        - name: bucket
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: key
+          in: path
+          required: true
+          allowReserved: true
+          schema:
+            type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"route":"storage"}'
+      responses:
+        "200":
+          description: OK


### PR DESCRIPTION
## Summary

- Adds `{param+}` catch-all path parameter syntax to the compiler and router, enabling routes like `/files/{bucket}/{key+}` where the wildcard captures all remaining segments (including `/`) as a single value
- Enforces constraints at compile time: wildcard must be the last segment, at most one per path
- Precedence order: static > regular param > wildcard (consistent with trie matching)

## Changes

**Compiler** (`artifact.rs`): validates `{param+}` syntax and preserves the `+` modifier in normalized form for ambiguity detection.

**Router** (`trie.rs`): new `Segment::Wildcard`, `WildcardNode`, and `wildcard_child` on `Node`; `traverse_and_match` joins remaining segments with `/` when matching a wildcard node.

**Tests**: 5 new router unit tests + `tests/fixtures/wildcard-path.yaml` + 5 new integration tests covering single-segment, multi-segment, S3-style prefix+wildcard, static precedence, and missing-key 404.

**Docs**: new "Path Parameters" section in `spec-configuration.md`; updated wildcard proxy example in `extensions.md` to use `{path+}`.

## Test plan

- [x] `cargo test --workspace --exclude barbacane-test` — all 334 unit tests pass
- [x] `cargo test -p barbacane-test` — 5 new wildcard integration tests pass alongside existing 181
- [x] Verify `GET /files/docs/2024/report.pdf` → 200 with wildcard fixture
- [x] Verify `GET /files/special` → 200 with `{"route":"static"}` (static precedence)
- [x] Verify `GET /storage/my-bucket` → 404 (wildcard requires at least one key segment)