### PR TITLE
docs: add FIPS 140-3 compliance guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Documentation
+- **FIPS 140-3 compliance guide**: step-by-step instructions for enabling FIPS mode via the `rustls` `fips` feature flag and `aws-lc-fips-sys`
+
 #### Config Provenance & Drift Detection (ADR-0021)
 - **Artifact fingerprinting**: combined SHA-256 hash of all artifact inputs (`artifact_hash`) embedded in manifest at compile time; hash-of-hashes approach using sorted source spec hashes and BTreeMap checksums
 - **Build provenance metadata**: optional `--provenance-commit` and `--provenance-source` CLI flags on `barbacane compile` to embed Git commit SHA and build source (e.g., `ci/github-actions`) into the artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Documentation
 - **FIPS 140-3 compliance guide**: step-by-step instructions for enabling FIPS mode via the `rustls` `fips` feature flag and `aws-lc-fips-sys`
+- **`fips` Cargo feature flag**: `cargo build -p barbacane --features fips` enables FIPS 140-3 compliant cryptography without manual `Cargo.toml` edits
 
 #### Config Provenance & Drift Detection (ADR-0021)
 - **Artifact fingerprinting**: combined SHA-256 hash of all artifact inputs (`artifact_hash`) embedded in manifest at compile time; hash-of-hashes approach using sorted source spec hashes and BTreeMap checksums

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,11 +269,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.13.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed8cd42adddefbdb8507fb7443fa9b666631078616b78f70ed22117b5c27d90"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "regex",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
+ "aws-lc-fips-sys",
  "aws-lc-sys",
  "zeroize",
 ]
@@ -597,6 +612,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +730,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +789,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -2252,6 +2307,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,6 +2463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,6 +2519,16 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "signatory",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]

--- a/crates/barbacane/Cargo.toml
+++ b/crates/barbacane/Cargo.toml
@@ -44,6 +44,9 @@ arc-swap = "1.7"
 sha2 = { workspace = true }
 hex = { workspace = true }
 
+[features]
+fips = ["rustls/fips"]
+
 [lints]
 workspace = true
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -12,6 +12,7 @@
 - [Observability](guide/observability.md)
 - [Control Plane](guide/control-plane.md)
 - [Web UI](guide/web-ui.md)
+- [FIPS 140-3 Compliance](guide/fips.md)
 
 # Reference
 

--- a/docs/guide/fips.md
+++ b/docs/guide/fips.md
@@ -1,0 +1,150 @@
+# FIPS 140-3 Compliance
+
+FIPS 140-3 is a US federal standard for cryptographic modules. Government agencies and their contractors are required to use FIPS-validated cryptography. Many large enterprises — especially in finance, healthcare, and defense — enforce FIPS compliance as a baseline security requirement.
+
+Barbacane uses [rustls](https://github.com/rustls/rustls) with the [aws-lc-rs](https://github.com/aws/aws-lc-rs) cryptographic backend — no OpenSSL dependency. AWS-LC has received [FIPS 140-3 Level 1 certification](https://aws.amazon.com/blogs/security/aws-lc-is-now-fips-140-3-certified/) from NIST, making it straightforward to run Barbacane in FIPS-compliant mode.
+
+## How It Works
+
+By default, Barbacane links against `aws-lc-sys` (the non-FIPS build of AWS-LC). Enabling the `fips` feature switches the entire TLS stack to `aws-lc-fips-sys`, which is the FIPS-validated module.
+
+When FIPS mode is enabled:
+
+- Only FIPS-approved cipher suites and key exchange algorithms are available
+- TLS Extended Master Secret (EMS) is **required** for TLS 1.2 connections
+- The aws-lc-fips-sys crate performs a power-on self-test at startup to verify cryptographic integrity
+
+## Enabling FIPS Mode
+
+### 1. Install Additional Build Dependencies
+
+The FIPS build of AWS-LC requires **Go** in addition to the standard build tools:
+
+| Tool | Standard Build | FIPS Build |
+|------|---------------|------------|
+| cmake | Required | Required |
+| clang | Required | Required |
+| Go 1.18+ | Not required | **Required** |
+
+On Debian/Ubuntu:
+
+```bash
+apt-get install -y cmake clang golang
+```
+
+On macOS:
+
+```bash
+brew install cmake go
+```
+
+### 2. Enable the Feature Flag
+
+In the workspace root `Cargo.toml`, replace the `aws-lc-rs` feature with `fips`:
+
+```toml
+# Before (default)
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
+
+# After (FIPS-compliant)
+rustls = { version = "0.23", features = ["fips"] }
+```
+
+That's it for dependencies. The `fips` feature on rustls transitively pulls in `aws-lc-fips-sys` instead of `aws-lc-sys`.
+
+### 3. Use the FIPS Crypto Provider
+
+No code change is needed — the startup code in `main.rs` already installs the aws-lc-rs default provider:
+
+```rust
+let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+```
+
+When built with the `fips` feature, this provider automatically uses the FIPS-validated module.
+
+### 4. Verify FIPS Mode (Optional)
+
+You can assert FIPS compliance at runtime using `ServerConfig::fips()`:
+
+```rust
+let tls_config = load_tls_config(&config)?;
+assert!(tls_config.fips(), "TLS config is not FIPS-compliant");
+```
+
+In production, prefer a health-check or log message over panicking:
+
+```rust
+if !tls_config.fips() {
+    tracing::warn!("TLS configuration is NOT FIPS-compliant");
+}
+```
+
+### 5. Build
+
+```bash
+cargo build --release
+```
+
+The first FIPS build takes longer because `aws-lc-fips-sys` compiles AWS-LC from source with FIPS self-tests enabled.
+
+## Docker
+
+Update the Dockerfile to install Go for the FIPS build:
+
+```dockerfile
+FROM rust:1.93-slim-bookworm AS builder
+
+# Build dependencies — Go required for aws-lc-fips-sys
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake \
+    clang \
+    golang \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+The runtime image (`distroless/cc-debian12`) does not need changes — the FIPS module is statically linked.
+
+## FIPS Cipher Suites
+
+When FIPS mode is active, rustls restricts the available cipher suites to FIPS-approved algorithms:
+
+**TLS 1.3:**
+- `TLS_AES_256_GCM_SHA384`
+- `TLS_AES_128_GCM_SHA256`
+
+**TLS 1.2:**
+- `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
+- `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
+
+> **Note:** ChaCha20-Poly1305 cipher suites are **not** available in FIPS mode, as ChaCha20 is not FIPS-approved.
+
+## Platform Support
+
+| Platform | FIPS Build | Notes |
+|----------|-----------|-------|
+| Linux (glibc) | Supported | Primary target |
+| Linux (musl) | Supported | Requires `cross-rs` (same as non-FIPS) |
+| macOS | Supported | Development only — not FIPS-certified |
+| Windows | Supported | Static build used automatically |
+
+> **Important:** FIPS 140-3 validation only covers the specific certified platforms. For production FIPS compliance, deploy on Linux. macOS and Windows builds use the same code but are not covered by the NIST certificate.
+
+## Downstream Dependencies
+
+The `reqwest` and `tokio-tungstenite` crates also use rustls for outbound TLS. Since they share the same workspace-level rustls dependency, enabling the `fips` feature applies to **all** TLS connections — both ingress and egress.
+
+| Crate | TLS Usage | FIPS Coverage |
+|-------|-----------|---------------|
+| `barbacane` | Ingress TLS termination | Covered |
+| `barbacane-wasm` | Outbound HTTP (plugin `host_http_call`) | Covered via `reqwest` |
+| `barbacane-control` | WebSocket to data plane | Covered via `tokio-tungstenite` |
+
+## References
+
+- [rustls FIPS documentation](https://rustls.dev/docs/manual/_06_fips/index.html)
+- [aws-lc-rs GitHub](https://github.com/aws/aws-lc-rs)
+- [AWS-LC FIPS 140-3 certification announcement](https://aws.amazon.com/blogs/security/aws-lc-is-now-fips-140-3-certified/)
+- [ADR-0019: Packaging and Release Strategy](../../adr/0019-packaging-and-release-strategy.md) — documents the aws-lc-rs backend choice

--- a/docs/guide/fips.md
+++ b/docs/guide/fips.md
@@ -38,19 +38,15 @@ On macOS:
 brew install cmake go
 ```
 
-### 2. Enable the Feature Flag
+### 2. Build with the FIPS Feature Flag
 
-In the workspace root `Cargo.toml`, replace the `aws-lc-rs` feature with `fips`:
+The `barbacane` crate exposes a `fips` Cargo feature. Pass it at build time:
 
-```toml
-# Before (default)
-rustls = { version = "0.23", features = ["aws-lc-rs"] }
-
-# After (FIPS-compliant)
-rustls = { version = "0.23", features = ["fips"] }
+```bash
+cargo build -p barbacane --release --features fips
 ```
 
-That's it for dependencies. The `fips` feature on rustls transitively pulls in `aws-lc-fips-sys` instead of `aws-lc-sys`.
+This enables `rustls/fips`, which transitively pulls in `aws-lc-fips-sys` instead of `aws-lc-sys`. No source edits required.
 
 ### 3. Use the FIPS Crypto Provider
 
@@ -82,7 +78,7 @@ if !tls_config.fips() {
 ### 5. Build
 
 ```bash
-cargo build --release
+cargo build -p barbacane --release --features fips
 ```
 
 The first FIPS build takes longer because `aws-lc-fips-sys` compiles AWS-LC from source with FIPS self-tests enabled.


### PR DESCRIPTION
## Summary
- Add step-by-step guide for enabling FIPS 140-3 mode via the rustls `fips` feature flag
- Covers build dependencies (Go required), Cargo.toml change, Docker updates, cipher suites, and platform matrix
- Added to docs navigation and CHANGELOG

## Context
A potential user flagged FIPS compliance documentation as a requirement for adoption in enterprise environments.

## Test plan
- [x] Verify `mdbook build` renders the new page correctly
- [x] Verify FIPS build works: change `features = ["aws-lc-rs"]` to `features = ["fips"]` and run `cargo build`