### PR TITLE
feat(rulesets): add ws-upstream, ai-proxy, response-transformer to vacuum ruleset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,8 +118,8 @@ Plugins are not part of the workspace. Run `cargo check`, `cargo test`, and `car
 After adding or modifying a plugin's `config-schema.json`, regenerate the vacuum ruleset validators:
 
 ```bash
-node docs/rulesets/generate.mjs
-bash docs/rulesets/tests/run-tests.sh
+docs/rulesets/generate.mjs
+docs/rulesets/tests/run-tests.sh
 ```
 
 ## Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,13 @@ cargo build --target wasm32-unknown-unknown --release
 
 Plugins are not part of the workspace. Run `cargo check`, `cargo test`, and `cargo clippy` from within the plugin directory.
 
+After adding or modifying a plugin's `config-schema.json`, regenerate the vacuum ruleset validators:
+
+```bash
+node docs/rulesets/generate.mjs
+bash docs/rulesets/tests/run-tests.sh
+```
+
 ## Testing
 
 - **Workspace unit tests**: `cargo test --workspace --exclude barbacane-test`

--- a/docs/rulesets/barbacane.yaml
+++ b/docs/rulesets/barbacane.yaml
@@ -28,7 +28,7 @@ rules:
       function: truthy
 
   barbacane-dispatch-known-plugin:
-    description: "Dispatcher plugin must be one of: mock, http-upstream, kafka, nats, s3, lambda."
+    description: "Dispatcher plugin must be one of: ai-proxy, http-upstream, kafka, lambda, mock, nats, s3, ws-upstream."
     documentationUrl: https://docs.barbacane.dev/guide/dispatchers.html
     severity: error
     given: "$.paths[*][*]['x-barbacane-dispatch'].name"
@@ -36,12 +36,14 @@ rules:
       function: enumeration
       functionOptions:
         values:
-          - mock
+          - ai-proxy
           - http-upstream
           - kafka
+          - lambda
+          - mock
           - nats
           - s3
-          - lambda
+          - ws-upstream
 
   barbacane-dispatch-has-config:
     description: x-barbacane-dispatch must include a "config" object.
@@ -100,6 +102,7 @@ rules:
           - rate-limit
           - request-size-limit
           - request-transformer
+          - response-transformer
 
   barbacane-middleware-config-valid:
     description: Middleware config must validate against the plugin's JSON Schema.
@@ -155,6 +158,7 @@ rules:
           - rate-limit
           - request-size-limit
           - request-transformer
+          - response-transformer
 
   barbacane-op-middleware-config-valid:
     description: Operation-level middleware config must validate against the plugin's JSON Schema.
@@ -189,7 +193,7 @@ rules:
   # ---------------------------------------------------------------------------
 
   barbacane-no-plaintext-upstream:
-    description: "http-upstream URLs should use HTTPS; plaintext HTTP is insecure."
+    description: "Upstream URLs should use HTTPS/WSS; plaintext HTTP/WS is insecure."
     documentationUrl: https://docs.barbacane.dev/guide/dispatchers.html#http-upstream
     severity: warn
     given: "$.paths[*][*]['x-barbacane-dispatch']"

--- a/docs/rulesets/functions/barbacane-no-plaintext-upstream.js
+++ b/docs/rulesets/functions/barbacane-no-plaintext-upstream.js
@@ -1,16 +1,16 @@
-// Returns a result when http-upstream dispatcher uses plaintext HTTP instead of HTTPS.
+// Returns a result when upstream dispatchers use plaintext protocols (HTTP, WS)
+// instead of their secure counterparts (HTTPS, WSS).
 // Severity is defined in the ruleset that references this function.
 
 function getSchema() {
   return {
     name: "barbacane-no-plaintext-upstream",
-    description: "Warns when http-upstream uses http:// instead of https://",
+    description: "Warns when upstream dispatchers use plaintext protocols instead of HTTPS/WSS",
   };
 }
 
 function runRule(input) {
   if (!input || typeof input !== "object") return [];
-  if (input.name !== "http-upstream") return [];
   if (!input.config || !input.config.url) return [];
 
   const url = input.config.url;
@@ -20,8 +20,12 @@ function runRule(input) {
     return [];
   }
 
-  if (typeof url === "string" && url.startsWith("http://")) {
+  if (input.name === "http-upstream" && typeof url === "string" && url.startsWith("http://")) {
     return [{ message: `Upstream URL "${url}" uses plaintext HTTP. Use HTTPS for production.` }];
+  }
+
+  if (input.name === "ws-upstream" && typeof url === "string" && url.startsWith("ws://")) {
+    return [{ message: `Upstream URL "${url}" uses plaintext WebSocket. Use WSS for production.` }];
   }
 
   return [];

--- a/docs/rulesets/functions/barbacane-validate-dispatch-config.js
+++ b/docs/rulesets/functions/barbacane-validate-dispatch-config.js
@@ -115,19 +115,26 @@ function runRule(input) {
   const pluginName = input.name;
   const config = input.config;
 
-  if (!pluginName || !config) return [];
+  if (!pluginName) return [];
 
   const schema = schemas[pluginName];
   if (!schema) return []; // unknown plugin handled by enumeration rule
 
+  if (!config && schema.required.length === 0) return [];
+  if (!config && schema.required.length > 0) {
+    return [{
+      message: `Dispatcher "${pluginName}" requires a config object with fields: ${schema.required.join(", ")}.`,
+    }];
+  }
+
+  if (!config) return [];
+
   const results = [];
-  if (schema.required) {
-    for (const field of schema.required) {
-      if (config[field] === undefined || config[field] === null) {
-        results.push({
-          message: `Dispatcher "${pluginName}" requires config field "${field}".`,
-        });
-      }
+  for (const field of schema.required) {
+    if (config[field] === undefined || config[field] === null) {
+      results.push({
+        message: `Dispatcher "${pluginName}" requires config field "${field}".`,
+      });
     }
   }
 

--- a/docs/rulesets/functions/barbacane-validate-dispatch-config.js
+++ b/docs/rulesets/functions/barbacane-validate-dispatch-config.js
@@ -1,23 +1,24 @@
-// Validates x-barbacane-dispatch.config against the plugin's JSON Schema.
-//
-// Each dispatcher plugin ships a config-schema.json that defines required
-// fields, types, and constraints.  This function loads the matching schema
-// by plugin name and checks the config object against it.
+// AUTO-GENERATED from plugins/*/config-schema.json — do not edit by hand.
+// Regenerate: node docs/rulesets/generate.mjs
 
 const schemas = {
-  mock: {
-    type: "object",
+  "ai-proxy": {
     required: [],
     properties: {
-      status: { type: "integer", minimum: 100, maximum: 599 },
-      body: { type: "string" },
-      headers: { type: "object" },
-      content_type: { type: "string" },
+      provider: { type: "string" },
+      model: { type: "string" },
+      api_key: { type: "string" },
+      base_url: { type: "string" },
+      timeout: { type: "integer", minimum: 1 },
+      max_tokens: { type: "integer", minimum: 1 },
+      fallback: { type: "array" },
+      targets: { type: "object" },
+      default_target: { type: "string" },
     },
     additionalProperties: false,
   },
+
   "http-upstream": {
-    type: "object",
     required: ["url"],
     properties: {
       url: { type: "string" },
@@ -26,9 +27,9 @@ const schemas = {
     },
     additionalProperties: false,
   },
-  kafka: {
-    type: "object",
-    required: ["brokers", "topic"],
+
+  "kafka": {
+    required: ["brokers","topic"],
     properties: {
       brokers: { type: "string" },
       topic: { type: "string" },
@@ -39,9 +40,30 @@ const schemas = {
     },
     additionalProperties: false,
   },
-  nats: {
-    type: "object",
-    required: ["url", "subject"],
+
+  "lambda": {
+    required: ["url"],
+    properties: {
+      url: { type: "string" },
+      timeout: { type: "number", minimum: 1, maximum: 900 },
+      pass_through_headers: { type: "boolean" },
+    },
+    additionalProperties: false,
+  },
+
+  "mock": {
+    required: [],
+    properties: {
+      status: { type: "integer", minimum: 100, maximum: 599 },
+      body: { type: "string" },
+      headers: { type: "object" },
+      content_type: { type: "string" },
+    },
+    additionalProperties: false,
+  },
+
+  "nats": {
+    required: ["url","subject"],
     properties: {
       url: { type: "string" },
       subject: { type: "string" },
@@ -50,9 +72,9 @@ const schemas = {
     },
     additionalProperties: false,
   },
-  s3: {
-    type: "object",
-    required: ["access_key_id", "secret_access_key", "region"],
+
+  "s3": {
+    required: ["access_key_id","secret_access_key","region"],
     properties: {
       access_key_id: { type: "string" },
       secret_access_key: { type: "string" },
@@ -67,13 +89,13 @@ const schemas = {
     },
     additionalProperties: false,
   },
-  lambda: {
-    type: "object",
+
+  "ws-upstream": {
     required: ["url"],
     properties: {
       url: { type: "string" },
-      timeout: { type: "number", minimum: 1, maximum: 900 },
-      pass_through_headers: { type: "boolean" },
+      connect_timeout: { type: "number", minimum: 0.1, maximum: 300 },
+      path: { type: "string" },
     },
     additionalProperties: false,
   },
@@ -99,7 +121,6 @@ function runRule(input) {
   if (!schema) return []; // unknown plugin handled by enumeration rule
 
   const results = [];
-  // Check required fields
   if (schema.required) {
     for (const field of schema.required) {
       if (config[field] === undefined || config[field] === null) {
@@ -110,7 +131,6 @@ function runRule(input) {
     }
   }
 
-  // Check for unknown fields
   if (schema.additionalProperties === false && schema.properties) {
     const allowed = Object.keys(schema.properties);
     for (const key of Object.keys(config)) {
@@ -122,11 +142,14 @@ function runRule(input) {
     }
   }
 
-  // Check field types
   if (schema.properties) {
     for (const [key, prop] of Object.entries(schema.properties)) {
       const value = config[key];
       if (value === undefined || value === null) continue;
+
+      if (typeof value === "string" && (value.startsWith("env://") || value.startsWith("file://"))) {
+        continue;
+      }
 
       if (!checkType(value, prop.type)) {
         results.push({
@@ -167,6 +190,6 @@ function checkType(value, expectedType) {
     case "array":
       return Array.isArray(value);
     default:
-      return false; // unknown type: fail explicitly rather than silently pass
+      return false;
   }
 }

--- a/docs/rulesets/functions/barbacane-validate-middleware-config.js
+++ b/docs/rulesets/functions/barbacane-validate-middleware-config.js
@@ -1,10 +1,8 @@
-// Validates middleware config against the plugin's JSON Schema.
-//
-// Each middleware plugin ships a config-schema.json.  This function loads the
-// matching schema by plugin name and checks the config object against it.
+// AUTO-GENERATED from plugins/*/config-schema.json — do not edit by hand.
+// Regenerate: node docs/rulesets/generate.mjs
 
 const schemas = {
-  acl: {
+  "acl": {
     required: [],
     properties: {
       allow: { type: "array" },
@@ -17,6 +15,7 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "apikey-auth": {
     required: [],
     properties: {
@@ -27,6 +26,7 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "basic-auth": {
     required: [],
     properties: {
@@ -36,6 +36,7 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "bot-detection": {
     required: [],
     properties: {
@@ -47,7 +48,8 @@ const schemas = {
     },
     additionalProperties: false,
   },
-  cache: {
+
+  "cache": {
     required: [],
     properties: {
       ttl: { type: "integer", minimum: 1, maximum: 86400 },
@@ -57,14 +59,17 @@ const schemas = {
     },
     additionalProperties: false,
   },
-  cel: {
+
+  "cel": {
     required: ["expression"],
     properties: {
       expression: { type: "string" },
       deny_message: { type: "string" },
+      on_match: { type: "object" },
     },
     additionalProperties: false,
   },
+
   "correlation-id": {
     required: [],
     properties: {
@@ -75,7 +80,8 @@ const schemas = {
     },
     additionalProperties: false,
   },
-  cors: {
+
+  "cors": {
     required: ["allowed_origins"],
     properties: {
       allowed_origins: { type: "array" },
@@ -87,6 +93,7 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "http-log": {
     required: ["endpoint"],
     properties: {
@@ -100,6 +107,7 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "ip-restriction": {
     required: [],
     properties: {
@@ -110,6 +118,7 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "jwt-auth": {
     required: [],
     properties: {
@@ -123,8 +132,9 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "oauth2-auth": {
-    required: ["introspection_endpoint", "client_id", "client_secret"],
+    required: ["introspection_endpoint","client_id","client_secret"],
     properties: {
       introspection_endpoint: { type: "string" },
       client_id: { type: "string" },
@@ -134,7 +144,8 @@ const schemas = {
     },
     additionalProperties: false,
   },
-  observability: {
+
+  "observability": {
     required: [],
     properties: {
       latency_slo_ms: { type: "integer", minimum: 1 },
@@ -144,6 +155,7 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "oidc-auth": {
     required: ["issuer_url"],
     properties: {
@@ -157,6 +169,7 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "opa-authz": {
     required: ["opa_url"],
     properties: {
@@ -168,8 +181,9 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "rate-limit": {
-    required: ["quota", "window"],
+    required: ["quota","window"],
     properties: {
       quota: { type: "integer", minimum: 1 },
       window: { type: "integer", minimum: 1 },
@@ -178,6 +192,7 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "request-size-limit": {
     required: [],
     properties: {
@@ -186,12 +201,23 @@ const schemas = {
     },
     additionalProperties: false,
   },
+
   "request-transformer": {
     required: [],
     properties: {
       headers: { type: "object" },
       querystring: { type: "object" },
       path: { type: "object" },
+      body: { type: "object" },
+    },
+    additionalProperties: false,
+  },
+
+  "response-transformer": {
+    required: [],
+    properties: {
+      status: { type: "object" },
+      headers: { type: "object" },
       body: { type: "object" },
     },
     additionalProperties: false,
@@ -217,7 +243,6 @@ function runRule(input) {
   const schema = schemas[pluginName];
   if (!schema) return []; // unknown plugin handled by enumeration rule
 
-  // config is optional for plugins with no required fields
   if (!config && schema.required.length === 0) return [];
   if (!config && schema.required.length > 0) {
     return [{
@@ -228,7 +253,6 @@ function runRule(input) {
   if (!config) return [];
 
   const results = [];
-  // Check required fields
   for (const field of schema.required) {
     if (config[field] === undefined || config[field] === null) {
       results.push({
@@ -237,7 +261,6 @@ function runRule(input) {
     }
   }
 
-  // Check for unknown fields
   if (schema.additionalProperties === false && schema.properties) {
     const allowed = Object.keys(schema.properties);
     for (const key of Object.keys(config)) {
@@ -249,13 +272,11 @@ function runRule(input) {
     }
   }
 
-  // Check field types
   if (schema.properties) {
     for (const [key, prop] of Object.entries(schema.properties)) {
       const value = config[key];
       if (value === undefined || value === null) continue;
 
-      // Skip type checking for secret references (env://, file://)
       if (typeof value === "string" && (value.startsWith("env://") || value.startsWith("file://"))) {
         continue;
       }
@@ -299,6 +320,6 @@ function checkType(value, expectedType) {
     case "array":
       return Array.isArray(value);
     default:
-      return false; // unknown type: fail explicitly rather than silently pass
+      return false;
   }
 }

--- a/docs/rulesets/generate.mjs
+++ b/docs/rulesets/generate.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+// Generates vacuum validator JS files from plugins/*/config-schema.json.
+// Usage: node docs/rulesets/generate.mjs
+
+import { readFileSync, writeFileSync, readdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const PLUGINS = join(ROOT, "plugins");
+const FUNCTIONS = join(dirname(fileURLToPath(import.meta.url)), "functions");
+
+const dispatchers = {};
+const middlewares = {};
+
+for (const name of readdirSync(PLUGINS).sort()) {
+  const dir = join(PLUGINS, name);
+  let toml, schema;
+  try {
+    toml = readFileSync(join(dir, "plugin.toml"), "utf8");
+    schema = JSON.parse(readFileSync(join(dir, "config-schema.json"), "utf8"));
+  } catch { continue; }
+
+  const type = toml.match(/^type\s*=\s*"(\w+)"/m)?.[1];
+  if (!type) continue;
+
+  // Simplify: keep only top-level properties with type + min/max
+  const simplified = {
+    required: schema.required || [],
+    properties: {},
+    additionalProperties: schema.additionalProperties === false ? false : true,
+  };
+  for (const [k, v] of Object.entries(schema.properties || {})) {
+    const prop = { type: v.type };
+    if (v.minimum !== undefined) prop.minimum = v.minimum;
+    if (v.maximum !== undefined) prop.maximum = v.maximum;
+    simplified.properties[k] = prop;
+  }
+
+  if (type === "dispatcher") dispatchers[name] = simplified;
+  else if (type === "middleware") middlewares[name] = simplified;
+}
+
+function formatSchemas(schemas) {
+  const entries = Object.entries(schemas).map(([name, s]) => {
+    const props = Object.entries(s.properties)
+      .map(([k, v]) => {
+        const parts = [`type: "${v.type}"`];
+        if (v.minimum !== undefined) parts.push(`minimum: ${v.minimum}`);
+        if (v.maximum !== undefined) parts.push(`maximum: ${v.maximum}`);
+        return `      ${k}: { ${parts.join(", ")} },`;
+      })
+      .join("\n");
+    return [
+      `  "${name}": {`,
+      `    required: ${JSON.stringify(s.required)},`,
+      `    properties: {`,
+      props,
+      `    },`,
+      `    additionalProperties: ${s.additionalProperties},`,
+      `  },`,
+    ].join("\n");
+  });
+  return entries.join("\n\n");
+}
+
+// --- Dispatch validator ---
+const dispatchJS = `// AUTO-GENERATED from plugins/*/config-schema.json — do not edit by hand.
+// Regenerate: node docs/rulesets/generate.mjs
+
+const schemas = {
+${formatSchemas(dispatchers)}
+};
+
+function getSchema() {
+  return {
+    name: "barbacane-validate-dispatch-config",
+    description:
+      "Validates x-barbacane-dispatch.config against the dispatcher plugin schema",
+  };
+}
+
+function runRule(input) {
+  if (!input || typeof input !== "object") return [];
+
+  const pluginName = input.name;
+  const config = input.config;
+
+  if (!pluginName || !config) return [];
+
+  const schema = schemas[pluginName];
+  if (!schema) return []; // unknown plugin handled by enumeration rule
+
+  const results = [];
+  if (schema.required) {
+    for (const field of schema.required) {
+      if (config[field] === undefined || config[field] === null) {
+        results.push({
+          message: \`Dispatcher "\${pluginName}" requires config field "\${field}".\`,
+        });
+      }
+    }
+  }
+
+  if (schema.additionalProperties === false && schema.properties) {
+    const allowed = Object.keys(schema.properties);
+    for (const key of Object.keys(config)) {
+      if (!allowed.includes(key)) {
+        results.push({
+          message: \`Unknown config field "\${key}" for dispatcher "\${pluginName}". Allowed fields: \${allowed.join(", ")}.\`,
+        });
+      }
+    }
+  }
+
+  if (schema.properties) {
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      const value = config[key];
+      if (value === undefined || value === null) continue;
+
+      if (typeof value === "string" && (value.startsWith("env://") || value.startsWith("file://"))) {
+        continue;
+      }
+
+      if (!checkType(value, prop.type)) {
+        results.push({
+          message: \`Config field "\${key}" for dispatcher "\${pluginName}" must be of type "\${prop.type}", got "\${typeof value}".\`,
+        });
+        continue;
+      }
+
+      if (prop.minimum !== undefined && typeof value === "number" && value < prop.minimum) {
+        results.push({
+          message: \`Config field "\${key}" for dispatcher "\${pluginName}" must be >= \${prop.minimum}.\`,
+        });
+      }
+
+      if (prop.maximum !== undefined && typeof value === "number" && value > prop.maximum) {
+        results.push({
+          message: \`Config field "\${key}" for dispatcher "\${pluginName}" must be <= \${prop.maximum}.\`,
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+function checkType(value, expectedType) {
+  switch (expectedType) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number";
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "object":
+      return typeof value === "object" && !Array.isArray(value);
+    case "array":
+      return Array.isArray(value);
+    default:
+      return false;
+  }
+}
+`;
+
+// --- Middleware validator ---
+const middlewareJS = `// AUTO-GENERATED from plugins/*/config-schema.json — do not edit by hand.
+// Regenerate: node docs/rulesets/generate.mjs
+
+const schemas = {
+${formatSchemas(middlewares)}
+};
+
+function getSchema() {
+  return {
+    name: "barbacane-validate-middleware-config",
+    description:
+      "Validates middleware config against the plugin's JSON Schema",
+  };
+}
+
+function runRule(input) {
+  if (!input || typeof input !== "object") return [];
+
+  const pluginName = input.name;
+  const config = input.config;
+
+  if (!pluginName) return [];
+
+  const schema = schemas[pluginName];
+  if (!schema) return []; // unknown plugin handled by enumeration rule
+
+  if (!config && schema.required.length === 0) return [];
+  if (!config && schema.required.length > 0) {
+    return [{
+      message: \`Middleware "\${pluginName}" requires a config object with fields: \${schema.required.join(", ")}.\`,
+    }];
+  }
+
+  if (!config) return [];
+
+  const results = [];
+  for (const field of schema.required) {
+    if (config[field] === undefined || config[field] === null) {
+      results.push({
+        message: \`Middleware "\${pluginName}" requires config field "\${field}".\`,
+      });
+    }
+  }
+
+  if (schema.additionalProperties === false && schema.properties) {
+    const allowed = Object.keys(schema.properties);
+    for (const key of Object.keys(config)) {
+      if (!allowed.includes(key)) {
+        results.push({
+          message: \`Unknown config field "\${key}" for middleware "\${pluginName}". Allowed fields: \${allowed.join(", ")}.\`,
+        });
+      }
+    }
+  }
+
+  if (schema.properties) {
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      const value = config[key];
+      if (value === undefined || value === null) continue;
+
+      if (typeof value === "string" && (value.startsWith("env://") || value.startsWith("file://"))) {
+        continue;
+      }
+
+      if (!checkType(value, prop.type)) {
+        results.push({
+          message: \`Config field "\${key}" for middleware "\${pluginName}" must be of type "\${prop.type}", got "\${typeof value}".\`,
+        });
+        continue;
+      }
+
+      if (prop.minimum !== undefined && typeof value === "number" && value < prop.minimum) {
+        results.push({
+          message: \`Config field "\${key}" for middleware "\${pluginName}" must be >= \${prop.minimum}.\`,
+        });
+      }
+
+      if (prop.maximum !== undefined && typeof value === "number" && value > prop.maximum) {
+        results.push({
+          message: \`Config field "\${key}" for middleware "\${pluginName}" must be <= \${prop.maximum}.\`,
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+function checkType(value, expectedType) {
+  switch (expectedType) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number";
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "object":
+      return typeof value === "object" && !Array.isArray(value);
+    case "array":
+      return Array.isArray(value);
+    default:
+      return false;
+  }
+}
+`;
+
+writeFileSync(join(FUNCTIONS, "barbacane-validate-dispatch-config.js"), dispatchJS);
+writeFileSync(join(FUNCTIONS, "barbacane-validate-middleware-config.js"), middlewareJS);
+
+// --- Update barbacane.yaml enums ---
+let ruleset = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "barbacane.yaml"), "utf8");
+
+const dispatchNames = Object.keys(dispatchers);
+const middlewareNames = Object.keys(middlewares);
+
+// Update dispatch description
+const dispatchList = dispatchNames.join(", ");
+ruleset = ruleset.replace(
+  /Dispatcher plugin must be one of: [^"]+/,
+  `Dispatcher plugin must be one of: ${dispatchList}.`
+);
+
+// Update enum blocks — match "values:\n          - ...\n" sequences after known-plugin rules
+function replaceEnum(yaml, rulePattern, names) {
+  const enumBlock = names.map((n) => `          - ${n}`).join("\n");
+  // Find the rule, then replace the values block that follows
+  const re = new RegExp(
+    `(${rulePattern}[\\s\\S]*?values:\\n)((?:          - .+\\n)+)`,
+    "g"
+  );
+  return yaml.replace(re, `$1${enumBlock}\n`);
+}
+
+ruleset = replaceEnum(ruleset, "barbacane-dispatch-known-plugin:", dispatchNames);
+ruleset = replaceEnum(ruleset, "barbacane-middleware-known-plugin:", middlewareNames);
+ruleset = replaceEnum(ruleset, "barbacane-op-middleware-known-plugin:", middlewareNames);
+
+writeFileSync(join(dirname(fileURLToPath(import.meta.url)), "barbacane.yaml"), ruleset);
+
+console.log(`Generated dispatch validator (${dispatchNames.length} dispatchers: ${dispatchList})`);
+console.log(`Generated middleware validator (${middlewareNames.length} middlewares: ${middlewareNames.join(", ")})`);
+console.log("Updated barbacane.yaml enums");

--- a/docs/rulesets/generate.mjs
+++ b/docs/rulesets/generate.mjs
@@ -6,40 +6,9 @@ import { readFileSync, writeFileSync, readdirSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
-const PLUGINS = join(ROOT, "plugins");
-const FUNCTIONS = join(dirname(fileURLToPath(import.meta.url)), "functions");
-
-const dispatchers = {};
-const middlewares = {};
-
-for (const name of readdirSync(PLUGINS).sort()) {
-  const dir = join(PLUGINS, name);
-  let toml, schema;
-  try {
-    toml = readFileSync(join(dir, "plugin.toml"), "utf8");
-    schema = JSON.parse(readFileSync(join(dir, "config-schema.json"), "utf8"));
-  } catch { continue; }
-
-  const type = toml.match(/^type\s*=\s*"(\w+)"/m)?.[1];
-  if (!type) continue;
-
-  // Simplify: keep only top-level properties with type + min/max
-  const simplified = {
-    required: schema.required || [],
-    properties: {},
-    additionalProperties: schema.additionalProperties === false ? false : true,
-  };
-  for (const [k, v] of Object.entries(schema.properties || {})) {
-    const prop = { type: v.type };
-    if (v.minimum !== undefined) prop.minimum = v.minimum;
-    if (v.maximum !== undefined) prop.maximum = v.maximum;
-    simplified.properties[k] = prop;
-  }
-
-  if (type === "dispatcher") dispatchers[name] = simplified;
-  else if (type === "middleware") middlewares[name] = simplified;
-}
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
 
 function formatSchemas(schemas) {
   const entries = Object.entries(schemas).map(([name, s]) => {
@@ -64,121 +33,19 @@ function formatSchemas(schemas) {
   return entries.join("\n\n");
 }
 
-// --- Dispatch validator ---
-const dispatchJS = `// AUTO-GENERATED from plugins/*/config-schema.json — do not edit by hand.
+function buildValidatorJS(kind, ruleName, description, schemas) {
+  return `// AUTO-GENERATED from plugins/*/config-schema.json — do not edit by hand.
 // Regenerate: node docs/rulesets/generate.mjs
 
 const schemas = {
-${formatSchemas(dispatchers)}
+${formatSchemas(schemas)}
 };
 
 function getSchema() {
   return {
-    name: "barbacane-validate-dispatch-config",
+    name: "${ruleName}",
     description:
-      "Validates x-barbacane-dispatch.config against the dispatcher plugin schema",
-  };
-}
-
-function runRule(input) {
-  if (!input || typeof input !== "object") return [];
-
-  const pluginName = input.name;
-  const config = input.config;
-
-  if (!pluginName || !config) return [];
-
-  const schema = schemas[pluginName];
-  if (!schema) return []; // unknown plugin handled by enumeration rule
-
-  const results = [];
-  if (schema.required) {
-    for (const field of schema.required) {
-      if (config[field] === undefined || config[field] === null) {
-        results.push({
-          message: \`Dispatcher "\${pluginName}" requires config field "\${field}".\`,
-        });
-      }
-    }
-  }
-
-  if (schema.additionalProperties === false && schema.properties) {
-    const allowed = Object.keys(schema.properties);
-    for (const key of Object.keys(config)) {
-      if (!allowed.includes(key)) {
-        results.push({
-          message: \`Unknown config field "\${key}" for dispatcher "\${pluginName}". Allowed fields: \${allowed.join(", ")}.\`,
-        });
-      }
-    }
-  }
-
-  if (schema.properties) {
-    for (const [key, prop] of Object.entries(schema.properties)) {
-      const value = config[key];
-      if (value === undefined || value === null) continue;
-
-      if (typeof value === "string" && (value.startsWith("env://") || value.startsWith("file://"))) {
-        continue;
-      }
-
-      if (!checkType(value, prop.type)) {
-        results.push({
-          message: \`Config field "\${key}" for dispatcher "\${pluginName}" must be of type "\${prop.type}", got "\${typeof value}".\`,
-        });
-        continue;
-      }
-
-      if (prop.minimum !== undefined && typeof value === "number" && value < prop.minimum) {
-        results.push({
-          message: \`Config field "\${key}" for dispatcher "\${pluginName}" must be >= \${prop.minimum}.\`,
-        });
-      }
-
-      if (prop.maximum !== undefined && typeof value === "number" && value > prop.maximum) {
-        results.push({
-          message: \`Config field "\${key}" for dispatcher "\${pluginName}" must be <= \${prop.maximum}.\`,
-        });
-      }
-    }
-  }
-
-  return results;
-}
-
-function checkType(value, expectedType) {
-  switch (expectedType) {
-    case "string":
-      return typeof value === "string";
-    case "number":
-      return typeof value === "number";
-    case "integer":
-      return typeof value === "number" && Number.isInteger(value);
-    case "boolean":
-      return typeof value === "boolean";
-    case "object":
-      return typeof value === "object" && !Array.isArray(value);
-    case "array":
-      return Array.isArray(value);
-    default:
-      return false;
-  }
-}
-`;
-
-// --- Middleware validator ---
-const middlewareJS = `// AUTO-GENERATED from plugins/*/config-schema.json — do not edit by hand.
-// Regenerate: node docs/rulesets/generate.mjs
-
-const schemas = {
-${formatSchemas(middlewares)}
-};
-
-function getSchema() {
-  return {
-    name: "barbacane-validate-middleware-config",
-    description:
-      "Validates middleware config against the plugin's JSON Schema",
+      "${description}",
   };
 }
 
@@ -196,7 +63,7 @@ function runRule(input) {
   if (!config && schema.required.length === 0) return [];
   if (!config && schema.required.length > 0) {
     return [{
-      message: \`Middleware "\${pluginName}" requires a config object with fields: \${schema.required.join(", ")}.\`,
+      message: \`${kind} "\${pluginName}" requires a config object with fields: \${schema.required.join(", ")}.\`,
     }];
   }
 
@@ -206,7 +73,7 @@ function runRule(input) {
   for (const field of schema.required) {
     if (config[field] === undefined || config[field] === null) {
       results.push({
-        message: \`Middleware "\${pluginName}" requires config field "\${field}".\`,
+        message: \`${kind} "\${pluginName}" requires config field "\${field}".\`,
       });
     }
   }
@@ -216,7 +83,7 @@ function runRule(input) {
     for (const key of Object.keys(config)) {
       if (!allowed.includes(key)) {
         results.push({
-          message: \`Unknown config field "\${key}" for middleware "\${pluginName}". Allowed fields: \${allowed.join(", ")}.\`,
+          message: \`Unknown config field "\${key}" for ${kind.toLowerCase()} "\${pluginName}". Allowed fields: \${allowed.join(", ")}.\`,
         });
       }
     }
@@ -233,20 +100,20 @@ function runRule(input) {
 
       if (!checkType(value, prop.type)) {
         results.push({
-          message: \`Config field "\${key}" for middleware "\${pluginName}" must be of type "\${prop.type}", got "\${typeof value}".\`,
+          message: \`Config field "\${key}" for ${kind.toLowerCase()} "\${pluginName}" must be of type "\${prop.type}", got "\${typeof value}".\`,
         });
         continue;
       }
 
       if (prop.minimum !== undefined && typeof value === "number" && value < prop.minimum) {
         results.push({
-          message: \`Config field "\${key}" for middleware "\${pluginName}" must be >= \${prop.minimum}.\`,
+          message: \`Config field "\${key}" for ${kind.toLowerCase()} "\${pluginName}" must be >= \${prop.minimum}.\`,
         });
       }
 
       if (prop.maximum !== undefined && typeof value === "number" && value > prop.maximum) {
         results.push({
-          message: \`Config field "\${key}" for middleware "\${pluginName}" must be <= \${prop.maximum}.\`,
+          message: \`Config field "\${key}" for ${kind.toLowerCase()} "\${pluginName}" must be <= \${prop.maximum}.\`,
         });
       }
     }
@@ -274,33 +141,90 @@ function checkType(value, expectedType) {
   }
 }
 `;
+}
+
+function replaceEnum(yaml, rulePattern, names) {
+  const enumBlock = names.map((n) => `          - ${n}`).join("\n");
+  const re = new RegExp(
+    `(${rulePattern}[\\s\\S]*?values:\\n)((?: {10}- .+\\n)+)`,
+    "g"
+  );
+  return yaml.replace(re, `$1${enumBlock}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Scan plugins
+// ---------------------------------------------------------------------------
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const PLUGINS = join(ROOT, "plugins");
+const FUNCTIONS = join(dirname(fileURLToPath(import.meta.url)), "functions");
+
+const dispatchers = {};
+const middlewares = {};
+
+for (const name of readdirSync(PLUGINS).sort()) {
+  const dir = join(PLUGINS, name);
+  let toml, schema;
+  try {
+    toml = readFileSync(join(dir, "plugin.toml"), "utf8");
+    schema = JSON.parse(readFileSync(join(dir, "config-schema.json"), "utf8"));
+  } catch { continue; }
+
+  const type = toml.match(/^type\s*=\s*"(\w+)"/m)?.[1];
+  if (!type) continue;
+
+  const simplified = {
+    required: schema.required || [],
+    properties: {},
+    additionalProperties: schema.additionalProperties !== false,
+  };
+  for (const [k, v] of Object.entries(schema.properties || {})) {
+    const prop = { type: v.type };
+    if (v.minimum !== undefined) prop.minimum = v.minimum;
+    if (v.maximum !== undefined) prop.maximum = v.maximum;
+    simplified.properties[k] = prop;
+  }
+
+  if (type === "dispatcher") dispatchers[name] = simplified;
+  else if (type === "middleware") middlewares[name] = simplified;
+}
+
+// ---------------------------------------------------------------------------
+// Generate validator JS files
+// ---------------------------------------------------------------------------
+
+const dispatchJS = buildValidatorJS(
+  "Dispatcher",
+  "barbacane-validate-dispatch-config",
+  "Validates x-barbacane-dispatch.config against the dispatcher plugin schema",
+  dispatchers,
+);
+
+const middlewareJS = buildValidatorJS(
+  "Middleware",
+  "barbacane-validate-middleware-config",
+  "Validates middleware config against the plugin's JSON Schema",
+  middlewares,
+);
 
 writeFileSync(join(FUNCTIONS, "barbacane-validate-dispatch-config.js"), dispatchJS);
 writeFileSync(join(FUNCTIONS, "barbacane-validate-middleware-config.js"), middlewareJS);
 
-// --- Update barbacane.yaml enums ---
+// ---------------------------------------------------------------------------
+// Update barbacane.yaml enums
+// ---------------------------------------------------------------------------
+
 let ruleset = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "barbacane.yaml"), "utf8");
 
 const dispatchNames = Object.keys(dispatchers);
 const middlewareNames = Object.keys(middlewares);
 
-// Update dispatch description
 const dispatchList = dispatchNames.join(", ");
 ruleset = ruleset.replace(
   /Dispatcher plugin must be one of: [^"]+/,
   `Dispatcher plugin must be one of: ${dispatchList}.`
 );
-
-// Update enum blocks — match "values:\n          - ...\n" sequences after known-plugin rules
-function replaceEnum(yaml, rulePattern, names) {
-  const enumBlock = names.map((n) => `          - ${n}`).join("\n");
-  // Find the rule, then replace the values block that follows
-  const re = new RegExp(
-    `(${rulePattern}[\\s\\S]*?values:\\n)((?:          - .+\\n)+)`,
-    "g"
-  );
-  return yaml.replace(re, `$1${enumBlock}\n`);
-}
 
 ruleset = replaceEnum(ruleset, "barbacane-dispatch-known-plugin:", dispatchNames);
 ruleset = replaceEnum(ruleset, "barbacane-middleware-known-plugin:", middlewareNames);

--- a/docs/rulesets/tests/invalid-dispatch.yaml
+++ b/docs/rulesets/tests/invalid-dispatch.yaml
@@ -72,3 +72,48 @@ paths:
       responses:
         "200":
           description: OK
+
+  /ws-missing-url:
+    get:
+      operationId: wsMissingUrl
+      summary: ws-upstream missing required url
+      description: ws-upstream without the required url field.
+      tags: [test]
+      x-barbacane-dispatch:
+        name: ws-upstream
+        config:
+          connect_timeout: 5
+      responses:
+        "101":
+          description: Switching Protocols
+
+  /ws-bad-field:
+    get:
+      operationId: wsBadField
+      summary: ws-upstream unknown field
+      description: ws-upstream with unknown config field.
+      tags: [test]
+      x-barbacane-dispatch:
+        name: ws-upstream
+        config:
+          url: "wss://example.com"
+          unknown_option: true
+      responses:
+        "101":
+          description: Switching Protocols
+
+  /ai-bad-field:
+    post:
+      operationId: aiBadField
+      summary: ai-proxy unknown field
+      description: ai-proxy with unknown config field.
+      tags: [test]
+      x-barbacane-dispatch:
+        name: ai-proxy
+        config:
+          provider: "openai"
+          model: "gpt-4o"
+          unknown_option: true
+      responses:
+        "200":
+          description: OK

--- a/docs/rulesets/tests/invalid-middleware.yaml
+++ b/docs/rulesets/tests/invalid-middleware.yaml
@@ -53,3 +53,24 @@ paths:
       responses:
         "200":
           description: OK
+
+  /bad-response-transformer:
+    get:
+      operationId: badResponseTransformer
+      summary: Bad response-transformer config
+      description: Operation with unknown field in response-transformer config.
+      tags: [test]
+      x-barbacane-middlewares:
+        - name: response-transformer
+          config:
+            headers:
+              add:
+                x-foo: "bar"
+            unknown_field: true
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+      responses:
+        "200":
+          description: OK

--- a/docs/rulesets/tests/invalid-upstream-secrets.yaml
+++ b/docs/rulesets/tests/invalid-upstream-secrets.yaml
@@ -53,3 +53,17 @@ paths:
       responses:
         "200":
           description: OK
+
+  /plaintext-ws:
+    get:
+      operationId: plaintextWs
+      summary: Plaintext WebSocket upstream
+      description: Uses ws instead of wss.
+      tags: [test]
+      x-barbacane-dispatch:
+        name: ws-upstream
+        config:
+          url: "ws://insecure.example.com"
+      responses:
+        "101":
+          description: Switching Protocols

--- a/docs/rulesets/tests/valid-complete.yaml
+++ b/docs/rulesets/tests/valid-complete.yaml
@@ -16,6 +16,13 @@ x-barbacane-middlewares:
     config:
       quota: 100
       window: 60
+  - name: response-transformer
+    config:
+      headers:
+        add:
+          x-request-id: "abc"
+        remove:
+          - x-internal-trace
 
 paths:
   /health:
@@ -49,3 +56,39 @@ paths:
       responses:
         "200":
           description: User list
+
+  /ws:
+    get:
+      operationId: wsProxy
+      summary: WebSocket proxy
+      description: Proxies WebSocket connections to upstream.
+      tags: [websocket]
+      x-barbacane-middlewares: []
+      x-barbacane-dispatch:
+        name: ws-upstream
+        config:
+          url: "wss://ws.internal.example.com"
+          connect_timeout: 10
+          path: "/v1/stream"
+      responses:
+        "101":
+          description: Switching Protocols
+
+  /chat/completions:
+    post:
+      operationId: chatCompletions
+      summary: AI chat completions
+      description: Proxies chat completion requests to LLM providers.
+      tags: [ai]
+      x-barbacane-middlewares: []
+      x-barbacane-dispatch:
+        name: ai-proxy
+        config:
+          provider: "openai"
+          model: "gpt-4o"
+          api_key: "env://OPENAI_API_KEY"
+          timeout: 120
+          max_tokens: 4096
+      responses:
+        "200":
+          description: Chat completion response


### PR DESCRIPTION
## Summary
- Add **ws-upstream** and **ai-proxy** dispatchers + **response-transformer** middleware to the vacuum ruleset (enums, config validators, plaintext upstream check)
- Add `generate.mjs` script that sources validator schemas from `plugins/*/config-schema.json` — eliminates hand-maintained duplicates and prevents drift
- Extend `barbacane-no-plaintext-upstream` to warn on `ws://` URLs for ws-upstream
- Add test fixtures covering all three new plugins (valid + invalid cases)
- Document the generate workflow in CLAUDE.md

## Test plan
- [x] `bash docs/rulesets/tests/run-tests.sh` — 11/11 pass
- [ ] Review generated JS output matches plugin config-schema.json
- [ ] Verify `node docs/rulesets/generate.mjs` is idempotent (running twice produces no diff)