### PR TITLE
feat: remote plugin loading via HTTPS URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -556,9 +556,14 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts/release
-          # Checksums for binaries only (plugins have their own file)
-          sha256sum barbacane-* barbacane-control-* > checksums.txt
-          cat checksums.txt
+          # Checksums for binaries (plugins have their own file)
+          binaries=$(ls barbacane-* barbacane-control-* 2>/dev/null || true)
+          if [ -n "$binaries" ]; then
+            sha256sum $binaries > checksums.txt
+            cat checksums.txt
+          else
+            echo "::warning::No binary files found for checksums"
+          fi
 
       - name: Extract release notes from changelog
         id: changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -451,10 +451,73 @@ jobs:
           echo ""
           echo "All crates published successfully!"
 
+  # Build WASM plugins and collect artifacts for release
+  build-plugins:
+    name: Build Plugins
+    needs: [validate-version, validate-changelog]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-plugins-${{ hashFiles('plugins/**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-plugins-
+
+      - name: Build all plugins
+        run: |
+          mkdir -p dist/plugins
+          for plugin_dir in plugins/*/; do
+            if [ -f "$plugin_dir/Cargo.toml" ]; then
+              name=$(basename "$plugin_dir")
+              echo "::group::Building $name"
+              (cd "$plugin_dir" && cargo build --release --target wasm32-unknown-unknown)
+
+              # Find the .wasm output (exclude deps)
+              wasm_file=$(ls "$plugin_dir/target/wasm32-unknown-unknown/release/"*.wasm 2>/dev/null | grep -v deps | head -1)
+              if [ -n "$wasm_file" ]; then
+                cp "$wasm_file" "dist/plugins/$name.wasm"
+                echo "  -> $name.wasm ($(du -h "dist/plugins/$name.wasm" | cut -f1))"
+              else
+                echo "::warning::No .wasm output found for $name"
+              fi
+
+              # Copy plugin.toml if present
+              if [ -f "$plugin_dir/plugin.toml" ]; then
+                cp "$plugin_dir/plugin.toml" "dist/plugins/$name.plugin.toml"
+              fi
+
+              echo "::endgroup::"
+            fi
+          done
+
+      - name: Generate plugin checksums
+        run: |
+          cd dist/plugins
+          sha256sum *.wasm > plugin-checksums.txt
+          cat plugin-checksums.txt
+
+      - name: Upload plugin artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: plugins
+          path: dist/plugins/
+          retention-days: 1
+
   # Create GitHub Release with all artifacts
   create-release:
     name: Create Release
-    needs: [build-binaries, create-manifests, scan-containers, publish-crates]
+    needs: [build-binaries, build-plugins, create-manifests, scan-containers, publish-crates]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -465,17 +528,36 @@ jobs:
         id: tag
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Download all artifacts
+      - name: Download binary artifacts
         uses: actions/download-artifact@v8
         with:
-          path: artifacts
+          path: artifacts/binaries
           pattern: binaries-*
           merge-multiple: true
 
+      - name: Download plugin artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: plugins
+          path: artifacts/plugins
+
+      - name: Prepare release artifacts
+        run: |
+          mkdir -p artifacts/release
+
+          # Binaries
+          cp artifacts/binaries/* artifacts/release/
+
+          # Plugins (.wasm and .plugin.toml files)
+          cp artifacts/plugins/*.wasm artifacts/release/
+          cp artifacts/plugins/*.plugin.toml artifacts/release/
+          cp artifacts/plugins/plugin-checksums.txt artifacts/release/
+
       - name: Generate checksums
         run: |
-          cd artifacts
-          sha256sum * > checksums.txt
+          cd artifacts/release
+          # Checksums for binaries only (plugins have their own file)
+          sha256sum barbacane-* barbacane-control-* > checksums.txt
           cat checksums.txt
 
       - name: Extract release notes from changelog
@@ -496,6 +578,6 @@ jobs:
           name: Barbacane v${{ steps.tag.outputs.version }}
           body_path: release-notes.md
           files: |
-            artifacts/*
+            artifacts/release/*
           draft: false
           prerelease: ${{ contains(steps.tag.outputs.version, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **compiler**: remote plugin loading — `url:` sources in `barbacane.yaml` now download WASM plugins over HTTPS at compile time (ADR-0029)
+- **compiler**: optional `sha256` field on URL plugin sources for integrity verification
+- **compiler**: local plugin download cache at `~/.barbacane/cache/plugins/` with checksum-based invalidation
+- **compiler**: automatic `plugin.toml` metadata discovery from sibling URLs
+- **cli**: `--no-cache` flag on `barbacane compile` to force re-download of remote plugins
+- **ci**: release workflow now builds and publishes all 27 plugin `.wasm` files + checksums as GitHub release assets
+
 ## [0.4.1] - 2026-03-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **compiler**: optional `sha256` field on URL plugin sources for integrity verification
 - **compiler**: local plugin download cache at `~/.barbacane/cache/plugins/` with checksum-based invalidation
 - **compiler**: automatic `plugin.toml` metadata discovery from sibling URLs
-- **cli**: `--no-cache` flag on `barbacane compile` to force re-download of remote plugins
+- **cli**: `--no-cache` flag on `barbacane compile` to bypass the plugin download cache entirely
 - **ci**: release workflow now builds and publishes all 27 plugin `.wasm` files + checksums as GitHub release assets
 
 ## [0.4.1] - 2026-03-17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,8 @@ dependencies = [
  "criterion",
  "flate2",
  "hex",
+ "home",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -457,6 +459,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ flate2 = "1"
 tar = "0.4"
 
 # HTTP client
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "stream", "blocking"] }
 
 # NATS client
 async-nats = "0.38"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,7 +116,7 @@ Near-term items ready to be picked up:
 |---------|-------------|----------|
 | Rollback support | One-click rollback to previous artifact version | P1 |
 | Artifact signing | GPG/private-key signing + verification on load | P2 |
-| URL plugin source | Load WASM plugins from `url:` in manifests (in addition to `path:`) | P2 |
+| ~~URL plugin source~~ | ~~Load WASM plugins from `url:` in manifests (in addition to `path:`)~~ — **done** (ADR-0029) | ~~P2~~ |
 | ~~Admin introspection endpoints~~ | ~~Dedicated admin port with `/health`, `/metrics`, `/provenance`~~ — **done** (ADR-0022) | ~~P3~~ |
 | Data plane groups | Deploy to specific subsets of data planes | P2 |
 | Audit log | Track all spec/artifact/deployment changes | P2 |

--- a/adr/0029-remote-plugin-distribution.md
+++ b/adr/0029-remote-plugin-distribution.md
@@ -1,0 +1,86 @@
+# ADR-0029: Remote Plugin Distribution via HTTPS
+
+**Status:** Accepted
+**Date:** 2026-03-17
+
+## Context
+
+Barbacane plugins are WASM modules declared in `barbacane.yaml` and resolved at compile time (ADR-0006, ADR-0011). Until now, only local `path:` sources were implemented — `url:` sources returned a hard error despite being part of the original schema.
+
+This forced users to either vendor plugin `.wasm` files in their repository or build them from source locally. For teams consuming official or third-party plugins, this adds unnecessary friction: they must download files manually, track versions by hand, and cannot point their manifest at a canonical release URL.
+
+The existing GitHub release workflow already publishes platform binaries and container images but not plugin `.wasm` files. Adding plugin assets to releases would complete the distribution story — users could reference plugins by URL and get reproducible, version-pinned builds.
+
+## Decision
+
+### URL Plugin Sources with HTTPS Download
+
+The compiler resolves `url:` plugin sources by downloading `.wasm` files over HTTPS at compile time. Downloads are cached locally to avoid redundant network requests.
+
+```yaml
+# barbacane.yaml
+plugins:
+  jwt-auth:
+    url: https://github.com/barbacane-dev/barbacane/releases/download/v0.5.0/jwt-auth.wasm
+    sha256: abc123def456...  # optional integrity check
+  mock:
+    path: ./plugins/mock.wasm  # local sources still work
+```
+
+### Integrity Verification
+
+An optional `sha256` field on URL sources enables checksum verification. When provided, the compiler computes SHA-256 of the downloaded bytes and rejects mismatches. This defends against CDN corruption and supply-chain tampering without requiring a separate lockfile.
+
+### Local File Cache
+
+Downloaded plugins are cached at `~/.barbacane/cache/plugins/<sha256-of-url>/` containing:
+- `plugin.wasm` — the WASM binary
+- `plugin.toml` — plugin metadata (if available from remote)
+- `metadata.json` — cache metadata (URL, checksum, download timestamp)
+
+Cache behavior:
+- If `sha256` is specified, the cache validates against it — mismatches trigger re-download
+- If `sha256` is not specified, cached files are used if present
+- `--no-cache` flag on `barbacane compile` forces re-download
+
+### Plugin Metadata Resolution
+
+The compiler attempts to fetch `plugin.toml` from the remote source to extract version, type, and capability metadata. Two URL conventions are tried:
+1. `<name>.plugin.toml` — sibling file (GitHub release assets are flat)
+2. `plugin.toml` — directory convention (self-hosted / structured URLs)
+
+If neither is found, the plugin resolves without metadata (defaults apply).
+
+### CI/CD: Plugin Assets in GitHub Releases
+
+The release workflow (`release.yml`) now includes a `build-plugins` job that:
+1. Builds all plugins in `plugins/` to `wasm32-unknown-unknown`
+2. Uploads `<name>.wasm` + `<name>.plugin.toml` as release assets
+3. Generates `plugin-checksums.txt` with SHA-256 for every `.wasm`
+
+### What we are NOT doing
+
+- **No OCI registry for plugins** — GitHub Releases provides versioned URLs, checksums, and CDN distribution for free. OCI adds complexity (ORAS tooling, registry auth) without solving a real problem at current scale. ADR-0027 already covers OCI for `.bca` artifacts if the need arises.
+- **No plugin registry service** — discovery and versioning are handled by GitHub releases and manifest URLs. A registry may be added when a third-party plugin ecosystem emerges.
+- **No lockfile** — the `sha256` field in `barbacane.yaml` serves the same purpose with less tooling overhead. A `barbacane lock` command may be added later to auto-populate checksums.
+
+## Consequences
+
+### Easier
+
+- **Zero-friction plugin consumption** — users reference a URL instead of building from source
+- **Reproducible builds** — pinning `sha256` ensures identical plugin bytes across environments
+- **Official plugin distribution** — every release ships pre-built `.wasm` files with checksums
+- **Caching** — repeated compiles don't re-download plugins
+
+### Harder
+
+- **Network dependency at compile time** — first compile requires internet access (cached afterward)
+- **Cache management** — users must manually clear `~/.barbacane/cache/` if it grows; no automatic eviction yet
+- **URL stability** — if a release is deleted or a URL changes, cached copies still work but new environments fail
+
+## Related ADRs
+
+- [ADR-0006: WASM Plugin Architecture](0006-wasm-plugin-architecture.md) — plugin model and manifest schema
+- [ADR-0011: Spec Compilation Model](0011-spec-compilation-model.md) — compile-time plugin resolution
+- [ADR-0027: OCI Artifact Distribution](0027-oci-artifact-distribution.md) — OCI distribution for `.bca` artifacts (not plugins)

--- a/adr/0029-remote-plugin-distribution.md
+++ b/adr/0029-remote-plugin-distribution.md
@@ -41,7 +41,7 @@ Downloaded plugins are cached at `~/.barbacane/cache/plugins/<sha256-of-url>/` c
 Cache behavior:
 - If `sha256` is specified, the cache validates against it — mismatches trigger re-download
 - If `sha256` is not specified, cached files are used if present
-- `--no-cache` flag on `barbacane compile` forces re-download
+- `--no-cache` flag on `barbacane compile` bypasses the cache entirely (no read, no write)
 
 ### Plugin Metadata Resolution
 

--- a/crates/barbacane-compiler/Cargo.toml
+++ b/crates/barbacane-compiler/Cargo.toml
@@ -12,6 +12,8 @@ categories.workspace = true
 [dependencies]
 chrono = { workspace = true }
 hex = { workspace = true }
+home = "0.5"
+reqwest = { workspace = true, features = ["blocking"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
@@ -20,6 +22,7 @@ flate2 = { workspace = true }
 tar = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -36,6 +36,8 @@ pub struct CompileOptions {
     pub provenance_commit: Option<String>,
     /// Source identifier for build provenance (e.g., "ci/github-actions").
     pub provenance_source: Option<String>,
+    /// Disable plugin download cache (force re-download of remote plugins).
+    pub no_cache: bool,
 }
 
 impl Default for CompileOptions {
@@ -46,6 +48,7 @@ impl Default for CompileOptions {
             max_schema_properties: 256,
             provenance_commit: None,
             provenance_source: None,
+            no_cache: false,
         }
     }
 }
@@ -233,7 +236,8 @@ pub fn compile_with_manifest(
     project_manifest.validate_specs(&api_specs)?;
 
     // Resolve used plugins (loads WASM bytes)
-    let resolved_plugins = project_manifest.resolve_used_plugins(&api_specs, manifest_base_path)?;
+    let resolved_plugins =
+        project_manifest.resolve_used_plugins(&api_specs, manifest_base_path, options.no_cache)?;
 
     // Convert to PluginBundle
     let plugin_bundles: Vec<PluginBundle> = resolved_plugins

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -36,7 +36,7 @@ pub struct CompileOptions {
     pub provenance_commit: Option<String>,
     /// Source identifier for build provenance (e.g., "ci/github-actions").
     pub provenance_source: Option<String>,
-    /// Disable plugin download cache (force re-download of remote plugins).
+    /// Bypass the plugin download cache entirely (no read, no write).
     pub no_cache: bool,
 }
 

--- a/crates/barbacane-compiler/src/cache.rs
+++ b/crates/barbacane-compiler/src/cache.rs
@@ -1,0 +1,202 @@
+//! Local file cache for downloaded remote plugins.
+//!
+//! Cache layout:
+//! ```text
+//! ~/.barbacane/cache/plugins/<sha256-of-url>/
+//!   plugin.wasm
+//!   plugin.toml        (optional)
+//!   metadata.json
+//! ```
+
+use std::path::PathBuf;
+
+use sha2::{Digest, Sha256};
+
+use crate::error::CompileError;
+
+/// Cached plugin data.
+pub struct CachedPlugin {
+    /// WASM binary content.
+    pub wasm_bytes: Vec<u8>,
+    /// Raw plugin.toml content (if available).
+    pub plugin_toml: Option<String>,
+}
+
+/// Plugin download cache backed by the local filesystem.
+pub struct PluginCache {
+    cache_dir: PathBuf,
+}
+
+impl PluginCache {
+    /// Create a new cache rooted at `~/.barbacane/cache/plugins/`.
+    pub fn new() -> Result<Self, CompileError> {
+        let home = home::home_dir().ok_or_else(|| {
+            CompileError::PluginResolution("could not determine home directory".to_string())
+        })?;
+        let cache_dir = home.join(".barbacane").join("cache").join("plugins");
+        std::fs::create_dir_all(&cache_dir).map_err(|e| {
+            CompileError::PluginResolution(format!(
+                "failed to create plugin cache directory {}: {e}",
+                cache_dir.display()
+            ))
+        })?;
+        Ok(Self { cache_dir })
+    }
+
+    /// Create a cache at a custom path (for testing).
+    #[cfg(test)]
+    pub fn with_dir(cache_dir: PathBuf) -> Result<Self, CompileError> {
+        std::fs::create_dir_all(&cache_dir).map_err(|e| {
+            CompileError::PluginResolution(format!(
+                "failed to create plugin cache directory {}: {e}",
+                cache_dir.display()
+            ))
+        })?;
+        Ok(Self { cache_dir })
+    }
+
+    /// Compute the cache key (SHA-256 of the URL).
+    fn cache_key(url: &str) -> String {
+        hex::encode(Sha256::digest(url.as_bytes()))
+    }
+
+    /// Directory for a specific cached plugin.
+    fn entry_dir(&self, url: &str) -> PathBuf {
+        self.cache_dir.join(Self::cache_key(url))
+    }
+
+    /// Look up a cached plugin.
+    ///
+    /// If `expected_sha256` is provided, validates the cached WASM against it.
+    /// Returns `None` on cache miss or checksum mismatch.
+    pub fn get(&self, url: &str, expected_sha256: Option<&str>) -> Option<CachedPlugin> {
+        let dir = self.entry_dir(url);
+        let wasm_path = dir.join("plugin.wasm");
+        let wasm_bytes = std::fs::read(&wasm_path).ok()?;
+
+        // Validate checksum if provided
+        if let Some(expected) = expected_sha256 {
+            let actual = hex::encode(Sha256::digest(&wasm_bytes));
+            if actual != expected {
+                tracing::warn!(
+                    url,
+                    expected,
+                    actual,
+                    "cached plugin checksum mismatch, will re-download"
+                );
+                return None;
+            }
+        }
+
+        let plugin_toml = std::fs::read_to_string(dir.join("plugin.toml")).ok();
+
+        Some(CachedPlugin {
+            wasm_bytes,
+            plugin_toml,
+        })
+    }
+
+    /// Store a downloaded plugin in the cache.
+    pub fn put(
+        &self,
+        url: &str,
+        wasm_bytes: &[u8],
+        plugin_toml: Option<&str>,
+    ) -> Result<(), CompileError> {
+        let dir = self.entry_dir(url);
+        std::fs::create_dir_all(&dir).map_err(|e| {
+            CompileError::PluginResolution(format!(
+                "failed to create cache entry {}: {e}",
+                dir.display()
+            ))
+        })?;
+
+        std::fs::write(dir.join("plugin.wasm"), wasm_bytes).map_err(|e| {
+            CompileError::PluginResolution(format!("failed to write cached plugin wasm: {e}"))
+        })?;
+
+        if let Some(toml_content) = plugin_toml {
+            std::fs::write(dir.join("plugin.toml"), toml_content).map_err(|e| {
+                CompileError::PluginResolution(format!("failed to write cached plugin.toml: {e}"))
+            })?;
+        }
+
+        // Write metadata
+        let metadata = serde_json::json!({
+            "url": url,
+            "sha256": hex::encode(Sha256::digest(wasm_bytes)),
+            "downloaded_at": chrono::Utc::now().to_rfc3339(),
+        });
+        std::fs::write(
+            dir.join("metadata.json"),
+            serde_json::to_string_pretty(&metadata)
+                .expect("metadata JSON serialization is infallible"),
+        )
+        .map_err(|e| {
+            CompileError::PluginResolution(format!("failed to write cache metadata: {e}"))
+        })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_cache() -> (TempDir, PluginCache) {
+        let temp = TempDir::new().expect("tempdir");
+        let cache = PluginCache::with_dir(temp.path().join("cache")).expect("cache");
+        (temp, cache)
+    }
+
+    #[test]
+    fn cache_miss_returns_none() {
+        let (_temp, cache) = test_cache();
+        assert!(cache.get("https://example.com/plugin.wasm", None).is_none());
+    }
+
+    #[test]
+    fn cache_put_and_get() {
+        let (_temp, cache) = test_cache();
+        let url = "https://example.com/plugin.wasm";
+        let wasm = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+        let toml_content = "[plugin]\nname = \"test\"\nversion = \"1.0.0\"\ntype = \"middleware\"";
+
+        cache.put(url, &wasm, Some(toml_content)).expect("put");
+
+        let cached = cache.get(url, None).expect("cache hit");
+        assert_eq!(cached.wasm_bytes, wasm);
+        assert_eq!(cached.plugin_toml.as_deref(), Some(toml_content));
+    }
+
+    #[test]
+    fn cache_sha256_mismatch_invalidates() {
+        let (_temp, cache) = test_cache();
+        let url = "https://example.com/plugin.wasm";
+        let wasm = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+
+        cache.put(url, &wasm, None).expect("put");
+
+        // Wrong checksum should miss
+        assert!(cache.get(url, Some("deadbeef")).is_none());
+
+        // Correct checksum should hit
+        let correct = hex::encode(sha2::Sha256::digest(&wasm));
+        assert!(cache.get(url, Some(&correct)).is_some());
+    }
+
+    #[test]
+    fn cache_without_plugin_toml() {
+        let (_temp, cache) = test_cache();
+        let url = "https://example.com/plugin.wasm";
+        let wasm = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+
+        cache.put(url, &wasm, None).expect("put");
+
+        let cached = cache.get(url, None).expect("cache hit");
+        assert_eq!(cached.wasm_bytes, wasm);
+        assert!(cached.plugin_toml.is_none());
+    }
+}

--- a/crates/barbacane-compiler/src/download.rs
+++ b/crates/barbacane-compiler/src/download.rs
@@ -1,0 +1,134 @@
+//! HTTP download logic for remote plugins.
+
+use std::time::Duration;
+
+use crate::error::CompileError;
+
+/// Result of downloading a remote plugin.
+#[derive(Debug)]
+pub struct DownloadResult {
+    /// WASM binary content.
+    pub wasm_bytes: Vec<u8>,
+    /// Raw plugin.toml content (if found at sibling URL).
+    pub plugin_toml: Option<String>,
+}
+
+/// Build a blocking HTTP client with appropriate defaults.
+fn build_client() -> Result<reqwest::blocking::Client, CompileError> {
+    reqwest::blocking::Client::builder()
+        .connect_timeout(Duration::from_secs(30))
+        .timeout(Duration::from_secs(120))
+        .user_agent(format!("barbacane-compiler/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| CompileError::PluginResolution(format!("failed to build HTTP client: {e}")))
+}
+
+/// Derive candidate plugin.toml URLs from a .wasm URL.
+///
+/// Returns up to two candidates:
+/// 1. `<name>.plugin.toml` — sibling file convention (GitHub release assets are flat)
+///    e.g. `https://github.com/.../v0.5.0/jwt-auth.wasm` -> `https://github.com/.../v0.5.0/jwt-auth.plugin.toml`
+/// 2. `plugin.toml` — directory convention (self-hosted / structured URLs)
+///    e.g. `https://example.com/plugins/jwt-auth/1.0.0/jwt-auth.wasm` -> `https://example.com/plugins/jwt-auth/1.0.0/plugin.toml`
+fn derive_plugin_toml_urls(wasm_url: &str) -> Vec<String> {
+    let mut urls = Vec::new();
+    if let Some(stripped) = wasm_url.strip_suffix(".wasm") {
+        urls.push(format!("{stripped}.plugin.toml"));
+    }
+    if let Some(last_slash) = wasm_url.rfind('/') {
+        urls.push(format!("{}/plugin.toml", &wasm_url[..last_slash]));
+    }
+    urls
+}
+
+/// Download a plugin from a remote HTTPS URL.
+///
+/// Fetches the .wasm binary and attempts to fetch `plugin.toml` from
+/// the same directory (best-effort — 404 is fine).
+pub fn download_plugin(url: &str) -> Result<DownloadResult, CompileError> {
+    if !url.starts_with("https://") {
+        return Err(CompileError::PluginResolution(format!(
+            "plugin URL must use HTTPS: {url}"
+        )));
+    }
+
+    let client = build_client()?;
+
+    tracing::info!(url, "downloading remote plugin");
+
+    // Download the .wasm file
+    let response = client.get(url).send().map_err(|e| {
+        CompileError::PluginResolution(format!("failed to download plugin from {url}: {e}"))
+    })?;
+
+    if !response.status().is_success() {
+        return Err(CompileError::PluginResolution(format!(
+            "failed to download plugin from {url}: HTTP {}",
+            response.status()
+        )));
+    }
+
+    let wasm_bytes = response.bytes().map_err(|e| {
+        CompileError::PluginResolution(format!(
+            "failed to read plugin response body from {url}: {e}"
+        ))
+    })?;
+
+    // Best-effort: try to fetch plugin.toml from candidate URLs
+    let plugin_toml = derive_plugin_toml_urls(url)
+        .into_iter()
+        .find_map(|toml_url| {
+            tracing::debug!(url = %toml_url, "attempting to fetch plugin.toml");
+            let resp = client.get(&toml_url).send().ok()?;
+            if resp.status().is_success() {
+                resp.text().ok()
+            } else {
+                None
+            }
+        });
+
+    Ok(DownloadResult {
+        wasm_bytes: wasm_bytes.to_vec(),
+        plugin_toml,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reject_http_url() {
+        let result = download_plugin("http://example.com/plugin.wasm");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("HTTPS"));
+    }
+
+    #[test]
+    fn derive_plugin_toml_urls_from_wasm() {
+        let urls =
+            derive_plugin_toml_urls("https://example.com/plugins/jwt-auth/1.0.0/jwt-auth.wasm");
+        assert_eq!(urls.len(), 2);
+        // First: sibling <name>.plugin.toml
+        assert_eq!(
+            urls[0],
+            "https://example.com/plugins/jwt-auth/1.0.0/jwt-auth.plugin.toml"
+        );
+        // Second: directory plugin.toml
+        assert_eq!(
+            urls[1],
+            "https://example.com/plugins/jwt-auth/1.0.0/plugin.toml"
+        );
+    }
+
+    #[test]
+    fn derive_plugin_toml_urls_github_release() {
+        let urls = derive_plugin_toml_urls(
+            "https://github.com/barbacane-dev/barbacane/releases/download/v0.5.0/jwt-auth.wasm",
+        );
+        assert_eq!(
+            urls[0],
+            "https://github.com/barbacane-dev/barbacane/releases/download/v0.5.0/jwt-auth.plugin.toml"
+        );
+    }
+}

--- a/crates/barbacane-compiler/src/lib.rs
+++ b/crates/barbacane-compiler/src/lib.rs
@@ -4,6 +4,8 @@
 //! and produces a self-contained archive for the data plane.
 
 pub mod artifact;
+pub(crate) mod cache;
+pub(crate) mod download;
 pub mod error;
 pub mod manifest;
 pub mod spec_parser;

--- a/crates/barbacane-compiler/src/manifest.rs
+++ b/crates/barbacane-compiler/src/manifest.rs
@@ -159,14 +159,16 @@ fn resolve_url_plugin(
         }
     }
 
-    // Store in cache
-    let cache = PluginCache::new()?;
-    cache.put(
-        url,
-        &downloaded.wasm_bytes,
-        downloaded.plugin_toml.as_deref(),
-    )?;
-    tracing::info!(name, url, "cached remote plugin");
+    // Store in cache (unless --no-cache)
+    if !no_cache {
+        let cache = PluginCache::new()?;
+        cache.put(
+            url,
+            &downloaded.wasm_bytes,
+            downloaded.plugin_toml.as_deref(),
+        )?;
+        tracing::info!(name, url, "cached remote plugin");
+    }
 
     Ok((downloaded.wasm_bytes, downloaded.plugin_toml))
 }

--- a/crates/barbacane-compiler/src/manifest.rs
+++ b/crates/barbacane-compiler/src/manifest.rs
@@ -6,10 +6,13 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+use sha2::{Digest, Sha256};
+
+use crate::cache::PluginCache;
+use crate::download;
+use crate::error::CompileError;
 use crate::spec_parser::ApiSpec;
 use serde::{Deserialize, Serialize};
-
-use crate::error::CompileError;
 
 /// Minimal plugin.toml structure for extracting metadata.
 #[derive(Debug, Deserialize)]
@@ -39,16 +42,21 @@ struct PluginMetadata {
     body_access: bool,
 }
 
-/// Try to read plugin metadata from plugin.toml in the same directory as the WASM file.
-fn read_plugin_metadata(wasm_path: &Path) -> Option<PluginMetadata> {
-    let plugin_toml_path = wasm_path.parent()?.join("plugin.toml");
-    let content = std::fs::read_to_string(&plugin_toml_path).ok()?;
-    let parsed: PluginToml = toml::from_str(&content).ok()?;
+/// Parse plugin metadata from TOML content.
+fn parse_plugin_metadata(content: &str) -> Option<PluginMetadata> {
+    let parsed: PluginToml = toml::from_str(content).ok()?;
     Some(PluginMetadata {
         version: parsed.plugin.version,
         plugin_type: parsed.plugin.plugin_type,
         body_access: parsed.capabilities.body_access,
     })
+}
+
+/// Try to read plugin metadata from plugin.toml in the same directory as the WASM file.
+fn read_plugin_metadata(wasm_path: &Path) -> Option<PluginMetadata> {
+    let plugin_toml_path = wasm_path.parent()?.join("plugin.toml");
+    let content = std::fs::read_to_string(&plugin_toml_path).ok()?;
+    parse_plugin_metadata(&content)
 }
 
 /// Resolve a WASM path from a plugin source, relative to a base path.
@@ -65,25 +73,22 @@ fn resolve_plugin(
     name: &str,
     source: &PluginSource,
     base_path: &Path,
+    no_cache: bool,
 ) -> Result<ResolvedPlugin, CompileError> {
-    let wasm_bytes = match source {
+    let (wasm_bytes, plugin_toml_content) = match source {
         PluginSource::Path(path_source) => {
             let wasm_path = resolve_wasm_path(path_source, base_path);
-            std::fs::read(&wasm_path).map_err(|e| {
+            let bytes = std::fs::read(&wasm_path).map_err(|e| {
                 CompileError::PluginResolution(format!(
                     "failed to read plugin '{}' from {}: {}",
                     name,
                     wasm_path.display(),
                     e
                 ))
-            })?
+            })?;
+            (bytes, None)
         }
-        PluginSource::Url(url_source) => {
-            return Err(CompileError::PluginResolution(format!(
-                "URL plugin sources not yet implemented: {} -> {}",
-                name, url_source.url
-            )));
-        }
+        PluginSource::Url(url_source) => resolve_url_plugin(name, url_source, no_cache)?,
     };
 
     // Validate WASM magic number
@@ -103,7 +108,9 @@ fn resolve_plugin(
             let wasm_path = resolve_wasm_path(path_source, base_path);
             read_plugin_metadata(&wasm_path)
         }
-        PluginSource::Url(_) => None,
+        PluginSource::Url(_) => plugin_toml_content
+            .as_deref()
+            .and_then(parse_plugin_metadata),
     };
 
     Ok(ResolvedPlugin {
@@ -114,6 +121,54 @@ fn resolve_plugin(
         plugin_type: metadata.as_ref().map(|m| m.plugin_type.clone()),
         body_access: metadata.as_ref().is_some_and(|m| m.body_access),
     })
+}
+
+/// Resolve a plugin from a remote URL, using the cache when possible.
+fn resolve_url_plugin(
+    name: &str,
+    url_source: &UrlSource,
+    no_cache: bool,
+) -> Result<(Vec<u8>, Option<String>), CompileError> {
+    let url = &url_source.url;
+
+    if !url.starts_with("https://") {
+        return Err(CompileError::PluginResolution(format!(
+            "plugin '{name}' URL must use HTTPS: {url}"
+        )));
+    }
+
+    // Check cache (unless --no-cache)
+    if !no_cache {
+        let cache = PluginCache::new()?;
+        if let Some(cached) = cache.get(url, url_source.sha256.as_deref()) {
+            tracing::info!(name, url, "using cached plugin");
+            return Ok((cached.wasm_bytes, cached.plugin_toml));
+        }
+    }
+
+    // Download
+    let downloaded = download::download_plugin(url)?;
+
+    // Verify checksum if provided
+    if let Some(expected) = &url_source.sha256 {
+        let actual = hex::encode(Sha256::digest(&downloaded.wasm_bytes));
+        if actual != *expected {
+            return Err(CompileError::PluginResolution(format!(
+                "plugin '{name}' checksum mismatch: expected {expected}, got {actual}"
+            )));
+        }
+    }
+
+    // Store in cache
+    let cache = PluginCache::new()?;
+    cache.put(
+        url,
+        &downloaded.wasm_bytes,
+        downloaded.plugin_toml.as_deref(),
+    )?;
+    tracing::info!(name, url, "cached remote plugin");
+
+    Ok((downloaded.wasm_bytes, downloaded.plugin_toml))
 }
 
 /// A project manifest (`barbacane.yaml`).
@@ -148,6 +203,9 @@ pub struct PathSource {
 pub struct UrlSource {
     /// HTTPS URL to the .wasm file.
     pub url: String,
+    /// Optional SHA-256 checksum for integrity verification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
 }
 
 impl PluginSource {
@@ -207,10 +265,15 @@ impl ProjectManifest {
     /// Resolve all plugins: load WASM bytes from their sources.
     ///
     /// The `base_path` is used to resolve relative paths in `path:` sources.
-    pub fn resolve_plugins(&self, base_path: &Path) -> Result<Vec<ResolvedPlugin>, CompileError> {
+    /// If `no_cache` is true, remote plugins are always re-downloaded.
+    pub fn resolve_plugins(
+        &self,
+        base_path: &Path,
+        no_cache: bool,
+    ) -> Result<Vec<ResolvedPlugin>, CompileError> {
         self.plugins
             .iter()
-            .map(|(name, source)| resolve_plugin(name, source, base_path))
+            .map(|(name, source)| resolve_plugin(name, source, base_path, no_cache))
             .collect()
     }
 
@@ -236,10 +299,12 @@ impl ProjectManifest {
     /// Resolve only the plugins that are actually used in the specs.
     ///
     /// This is more efficient than `resolve_plugins` when not all declared plugins are used.
+    /// If `no_cache` is true, remote plugins are always re-downloaded.
     pub fn resolve_used_plugins(
         &self,
         specs: &[ApiSpec],
         base_path: &Path,
+        no_cache: bool,
     ) -> Result<Vec<ResolvedPlugin>, CompileError> {
         self.validate_specs(specs)?;
 
@@ -251,7 +316,7 @@ impl ProjectManifest {
                 Some(s) => s,
                 None => continue, // Already validated, shouldn't happen
             };
-            resolved.push(resolve_plugin(&name, source, base_path)?);
+            resolved.push(resolve_plugin(&name, source, base_path, no_cache)?);
         }
 
         Ok(resolved)
@@ -343,9 +408,38 @@ plugins:
         assert!(manifest.has_plugin("jwt-auth"));
         if let PluginSource::Url(u) = &manifest.plugins["jwt-auth"] {
             assert!(u.url.starts_with("https://"));
+            assert!(u.sha256.is_none());
         } else {
             panic!("Expected URL source");
         }
+    }
+
+    #[test]
+    fn parse_manifest_with_url_and_sha256() {
+        let content = r#"
+plugins:
+  jwt-auth:
+    url: https://plugins.barbacane.io/jwt-auth/1.0.0/jwt-auth.wasm
+    sha256: abc123def456
+"#;
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+
+        if let PluginSource::Url(u) = &manifest.plugins["jwt-auth"] {
+            assert_eq!(u.sha256.as_deref(), Some("abc123def456"));
+        } else {
+            panic!("Expected URL source");
+        }
+    }
+
+    #[test]
+    fn reject_http_url_in_resolve() {
+        let source = PluginSource::Url(UrlSource {
+            url: "http://example.com/plugin.wasm".to_string(),
+            sha256: None,
+        });
+        let result = resolve_plugin("test", &source, Path::new("."), false);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("HTTPS"));
     }
 
     #[test]
@@ -371,7 +465,7 @@ plugins:
 "#;
         let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
 
-        let resolved = manifest.resolve_plugins(temp.path()).unwrap();
+        let resolved = manifest.resolve_plugins(temp.path(), false).unwrap();
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].name, "mock");
         assert_eq!(resolved[0].wasm_bytes, wasm_content);
@@ -394,7 +488,7 @@ plugins:
 "#;
         let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
 
-        let result = manifest.resolve_plugins(temp.path());
+        let result = manifest.resolve_plugins(temp.path(), false);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -413,7 +507,7 @@ plugins:
 "#;
         let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
 
-        let result = manifest.resolve_plugins(temp.path());
+        let result = manifest.resolve_plugins(temp.path(), false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("failed to read"));
     }
@@ -635,7 +729,9 @@ plugins:
         let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
         let spec = make_spec_using_plugin("mock");
 
-        let resolved = manifest.resolve_used_plugins(&[spec], temp.path()).unwrap();
+        let resolved = manifest
+            .resolve_used_plugins(&[spec], temp.path(), false)
+            .unwrap();
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].name, "mock");
         assert_eq!(resolved[0].wasm_bytes, wasm_content);
@@ -659,7 +755,9 @@ plugins:
         let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
         let spec = make_spec_using_plugin("mock");
 
-        let resolved = manifest.resolve_used_plugins(&[spec], temp.path()).unwrap();
+        let resolved = manifest
+            .resolve_used_plugins(&[spec], temp.path(), false)
+            .unwrap();
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].name, "mock");
     }
@@ -679,7 +777,7 @@ plugins:
         let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
         let spec = make_spec_using_plugin("bad");
 
-        let result = manifest.resolve_used_plugins(&[spec], temp.path());
+        let result = manifest.resolve_used_plugins(&[spec], temp.path(), false);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -699,7 +797,7 @@ plugins:
         let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
         let spec = make_spec_using_plugin("missing");
 
-        let result = manifest.resolve_used_plugins(&[spec], temp.path());
+        let result = manifest.resolve_used_plugins(&[spec], temp.path(), false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("failed to read"));
     }
@@ -712,7 +810,7 @@ plugins:
         let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
         let spec = make_spec_using_plugin("unknown");
 
-        let result = manifest.resolve_used_plugins(&[spec], temp.path());
+        let result = manifest.resolve_used_plugins(&[spec], temp.path(), false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("E1040"));
     }
@@ -740,7 +838,7 @@ plugins:
 "#;
         let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
 
-        let resolved = manifest.resolve_plugins(temp.path()).unwrap();
+        let resolved = manifest.resolve_plugins(temp.path(), false).unwrap();
         assert_eq!(resolved[0].version, Some("1.2.3".to_string()));
         assert_eq!(resolved[0].plugin_type, Some("dispatcher".to_string()));
     }
@@ -768,7 +866,9 @@ plugins:
         let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
         let spec = make_spec_using_plugin("mock");
 
-        let resolved = manifest.resolve_used_plugins(&[spec], temp.path()).unwrap();
+        let resolved = manifest
+            .resolve_used_plugins(&[spec], temp.path(), false)
+            .unwrap();
         assert_eq!(resolved[0].version, Some("2.0.0".to_string()));
         assert_eq!(resolved[0].plugin_type, Some("middleware".to_string()));
     }

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -452,6 +452,10 @@ enum Commands {
         /// Build source identifier for provenance (e.g., "ci/github-actions").
         #[arg(long)]
         provenance_source: Option<String>,
+
+        /// Disable plugin download cache (force re-download of remote plugins).
+        #[arg(long)]
+        no_cache: bool,
     },
 
     /// Validate OpenAPI spec(s) without compiling.
@@ -3011,6 +3015,7 @@ fn run_compile(
     allow_plaintext: bool,
     provenance_commit: Option<String>,
     provenance_source: Option<String>,
+    no_cache: bool,
 ) -> ExitCode {
     let spec_paths: Vec<&Path> = specs.iter().map(Path::new).collect();
     let output_path = Path::new(output);
@@ -3027,6 +3032,7 @@ fn run_compile(
         allow_plaintext,
         provenance_commit,
         provenance_source,
+        no_cache,
         ..Default::default()
     };
 
@@ -3635,6 +3641,7 @@ async fn main() -> ExitCode {
             allow_plaintext,
             provenance_commit,
             provenance_source,
+            no_cache,
         } => run_compile(
             &spec,
             &output,
@@ -3642,6 +3649,7 @@ async fn main() -> ExitCode {
             allow_plaintext,
             provenance_commit,
             provenance_source,
+            no_cache,
         ),
         Commands::Validate { spec, format } => run_validate(&spec, &format),
         Commands::Init {

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -453,7 +453,7 @@ enum Commands {
         #[arg(long)]
         provenance_source: Option<String>,
 
-        /// Disable plugin download cache (force re-download of remote plugins).
+        /// Bypass the plugin download cache entirely (no read, no write).
         #[arg(long)]
         no_cache: bool,
     },

--- a/docs/contributing/plugins.md
+++ b/docs/contributing/plugins.md
@@ -305,7 +305,7 @@ plugins:
     sha256: abc123...  # optional integrity check
 ```
 
-Remote plugins are downloaded at compile time and cached at `~/.barbacane/cache/plugins/`. Use `--no-cache` to force re-download.
+Remote plugins are downloaded at compile time and cached at `~/.barbacane/cache/plugins/`. Use `--no-cache` to bypass the cache entirely (re-download without caching).
 
 ### Use in OpenAPI spec
 

--- a/docs/contributing/plugins.md
+++ b/docs/contributing/plugins.md
@@ -291,11 +291,21 @@ unsafe { host_http_call(json.as_ptr() as i32, json.len() as i32); }
 
 ### Declare in barbacane.yaml
 
+Plugins can be sourced from a local path or a remote URL:
+
 ```yaml
 plugins:
+  # Local path (development)
   my-plugin:
     path: ./plugins/my_plugin.wasm
+
+  # Remote URL (production, CI/CD)
+  jwt-auth:
+    url: https://github.com/barbacane-dev/barbacane/releases/download/v0.5.0/jwt-auth.wasm
+    sha256: abc123...  # optional integrity check
 ```
+
+Remote plugins are downloaded at compile time and cached at `~/.barbacane/cache/plugins/`. Use `--no-cache` to force re-download.
 
 ### Use in OpenAPI spec
 
@@ -447,3 +457,45 @@ Your plugin exceeded resource limits or panicked. Check logs for details. Common
 ### Unknown capability
 
 You're using a host function not declared in `plugin.toml`. Add it to `capabilities.host_functions`.
+
+## Distributing Plugins
+
+### GitHub Releases
+
+The recommended way to distribute plugins is as GitHub release assets. Upload both the `.wasm` binary and `plugin.toml` alongside your release:
+
+```
+my-plugin.wasm
+my-plugin.plugin.toml
+```
+
+Generate checksums for integrity verification:
+
+```bash
+sha256sum my-plugin.wasm > checksums.txt
+```
+
+Users reference your plugin by URL in their `barbacane.yaml`:
+
+```yaml
+plugins:
+  my-plugin:
+    url: https://github.com/your-org/my-plugin/releases/download/v1.0.0/my-plugin.wasm
+    sha256: <from checksums.txt>
+```
+
+### Official Plugins
+
+All official Barbacane plugins are published as release assets on every tagged release. Pre-built `.wasm` files and checksums (`plugin-checksums.txt`) are available at:
+
+```
+https://github.com/barbacane-dev/barbacane/releases/download/v<VERSION>/<plugin-name>.wasm
+```
+
+### Plugin Metadata Discovery
+
+When resolving a `url:` source, the compiler attempts to fetch `plugin.toml` from sibling URLs to extract version and type metadata:
+1. `<name>.plugin.toml` (same directory as the `.wasm`)
+2. `plugin.toml` (parent directory)
+
+If neither is found, the plugin still works but without version/type metadata in the artifact manifest.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -183,8 +183,18 @@ plugins:
     path: ./plugins/http-upstream.wasm
 ```
 
-The manifest declares all WASM plugins used by your spec. Plugins are sourced from a local path:
+The manifest declares all WASM plugins used by your spec. Plugins can be sourced from a local path or a remote URL:
 - **Local path**: `path: ./plugins/name.wasm`
+- **Remote URL**: `url: https://github.com/barbacane-dev/barbacane/releases/download/v0.5.0/name.wasm`
+
+Remote plugins are downloaded at compile time and cached locally. You can optionally pin integrity with a `sha256` checksum:
+
+```yaml
+plugins:
+  jwt-auth:
+    url: https://github.com/barbacane-dev/barbacane/releases/download/v0.5.0/jwt-auth.wasm
+    sha256: abc123...
+```
 
 ### 3. Validate the Spec
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -126,7 +126,7 @@ barbacane compile --spec <FILES>... --manifest <PATH> --output <PATH>
 | `--allow-plaintext` | No | `false` | Allow `http://` upstream URLs during compilation |
 | `--provenance-commit` | No | - | Git commit SHA to embed in artifact provenance metadata |
 | `--provenance-source` | No | - | Build source identifier (e.g., `ci/github-actions`) to embed in artifact provenance |
-| `--no-cache` | No | `false` | Disable plugin download cache (force re-download of remote `url:` plugins) |
+| `--no-cache` | No | `false` | Bypass the plugin download cache entirely — remote plugins are re-downloaded and not cached |
 
 ### Examples
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -126,6 +126,7 @@ barbacane compile --spec <FILES>... --manifest <PATH> --output <PATH>
 | `--allow-plaintext` | No | `false` | Allow `http://` upstream URLs during compilation |
 | `--provenance-commit` | No | - | Git commit SHA to embed in artifact provenance metadata |
 | `--provenance-source` | No | - | Build source identifier (e.g., `ci/github-actions`) to embed in artifact provenance |
+| `--no-cache` | No | `false` | Disable plugin download cache (force re-download of remote `url:` plugins) |
 
 ### Examples
 

--- a/specs/SPEC-003-plugin-system.md
+++ b/specs/SPEC-003-plugin-system.md
@@ -2,7 +2,8 @@
 
 **Status:** Draft
 **Date:** 2026-01-28
-**Derived from:** ADR-0006, ADR-0008, ADR-0016
+**Updated:** 2026-03-17
+**Derived from:** ADR-0006, ADR-0008, ADR-0016, ADR-0029
 
 ---
 
@@ -64,7 +65,7 @@ If the plugin takes no config, the schema should be:
 
 ### 2.3 WASM binary
 
-The `.wasm` file compiled from the plugin's source code. Must target `wasm32-wasip1`. The binary must export the functions defined in section 3.
+The `.wasm` file compiled from the plugin's source code. Must target `wasm32-unknown-unknown` (not `wasm32-wasip1` — WASI imports cause init failures in the Barbacane WASM runtime). The binary must export the functions defined in section 3.
 
 ---
 
@@ -256,7 +257,7 @@ Metrics are auto-prefixed: `barbacane_plugin_<plugin_name>_<metric_name>`. Label
 
 ## 5. Data Formats
 
-All data crossing the WASM boundary is JSON-encoded UTF-8.
+Metadata (method, path, headers, status) crosses the WASM boundary as JSON-encoded UTF-8. Bodies travel as raw bytes via side-channel host functions — they are **not** included in the JSON payload.
 
 ### 5.1 Request
 
@@ -269,7 +270,6 @@ All data crossing the WASM boundary is JSON-encoded UTF-8.
     "content-type": "application/json",
     "authorization": "Bearer eyJ..."
   },
-  "body": "<base64-encoded bytes or null>",
   "client_ip": "192.168.1.1",
   "path_params": {
     "id": "123"
@@ -280,12 +280,13 @@ All data crossing the WASM boundary is JSON-encoded UTF-8.
 | Field | Type | Description |
 |-------|------|-------------|
 | `method` | string | HTTP method (uppercase) |
-| `path` | string | Request path (decoded) |
+| `path` | string | Resolved request path (e.g. `/users/123`, not the OpenAPI template) |
 | `query` | string or null | Raw query string (without `?`) |
 | `headers` | object | Header map (lowercase keys, last value wins for duplicates) |
-| `body` | string or null | Base64-encoded request body, or `null` if no body |
 | `client_ip` | string | Client IP address |
 | `path_params` | object | Captured path parameters from routing |
+
+The request body is available via side-channel host functions (`host_body_len`, `host_body_read`). Middleware plugins only receive the body if `body_access = true` is declared in `plugin.toml` capabilities (SPEC-008). Dispatchers always receive the body.
 
 ### 5.2 Response
 
@@ -294,8 +295,7 @@ All data crossing the WASM boundary is JSON-encoded UTF-8.
   "status": 200,
   "headers": {
     "content-type": "application/json"
-  },
-  "body": "<base64-encoded bytes or null>"
+  }
 }
 ```
 
@@ -303,7 +303,8 @@ All data crossing the WASM boundary is JSON-encoded UTF-8.
 |-------|------|-------------|
 | `status` | integer | HTTP status code |
 | `headers` | object | Response headers |
-| `body` | string or null | Base64-encoded response body |
+
+The response body is written via side-channel host functions (`host_body_set`). In the plugin SDK, `request.body` and `response.body` are `Option<Vec<u8>>` fields with `#[serde(skip)]` — the proc macros handle the side-channel protocol transparently.
 
 ---
 
@@ -319,11 +320,11 @@ Each WASM instance is constrained:
 
 | Limit | Default |
 |-------|---------|
-| Linear memory | 16 MB |
+| Linear memory | max(16 MB, max_body_size + 4 MB) |
 | Execution time per call | 100 ms (per `on_request` / `on_response` / `dispatch` call) |
 | Stack size | 1 MB |
 
-If a plugin exceeds execution time, the WASM runtime traps and the gateway returns `500`. If memory is exhausted, the runtime traps.
+WASM memory scales automatically based on the configured `max_body_size`. If a plugin exceeds execution time, the WASM runtime traps and the gateway returns `500`. If memory is exhausted, the runtime traps.
 
 ### 6.3 Concurrency
 
@@ -352,57 +353,36 @@ The Rust SDK is a crate that abstracts the raw WASM ABI.
 
 ```rust
 use barbacane_plugin_sdk::prelude::*;
+use serde::Deserialize;
 
+#[barbacane_middleware]
 #[derive(Deserialize)]
-struct Config {
+pub struct RateLimit {
     quota: u32,
     window: u32,
-    #[serde(default = "default_quota_unit")]
-    quota_unit: String,
     #[serde(default = "default_key")]
     key: String,
-    #[serde(default = "default_policy_name")]
-    policy_name: String,
 }
 
-fn default_quota_unit() -> String { "requests".into() }
 fn default_key() -> String { "client_ip".into() }
-fn default_policy_name() -> String { "default".into() }
 
-#[barbacane_middleware]
-fn on_request(req: &Request, config: &Config) -> Action<Request> {
-    let key_value = if config.key.starts_with("context:") {
-        barbacane::context::get(&config.key[8..]).unwrap_or_default()
-    } else if config.key.starts_with("header:") {
-        req.header(&config.key[7..]).unwrap_or_default()
-    } else {
-        req.client_ip.clone()
-    };
+impl RateLimit {
+    pub fn on_request(&mut self, req: Request) -> Action {
+        let key_value = if self.key.starts_with("header:") {
+            req.headers.get(&self.key[7..]).cloned().unwrap_or_default()
+        } else {
+            req.client_ip.clone()
+        };
 
-    let remaining = get_remaining(&key_value, config.quota, config.window);
+        // ... rate limit check logic ...
 
-    if remaining == 0 {
-        let reset_in = get_reset_seconds(&key_value, config.window);
-        Action::ShortCircuit(
-            Response::new(429)
-                .header("content-type", "application/problem+json")
-                .header("ratelimit-policy", &format!("\"{}\":q={};w={}", config.policy_name, config.quota, config.window))
-                .header("ratelimit", &format!("\"{}\":r=0;t={}", config.policy_name, reset_in))
-                .header("retry-after", &reset_in.to_string())
-                .body(r#"{"type":"urn:barbacane:error:rate-limited","title":"Too Many Requests","status":429}"#)
-        )
-    } else {
-        Action::Continue(req.clone())
+        Action::Continue(req)
     }
-}
 
-#[barbacane_middleware]
-fn on_response(res: &Response, config: &Config) -> Response {
-    let remaining = get_current_remaining(config);
-    let reset_in = get_current_reset(config);
-    res.clone()
-        .header("ratelimit-policy", &format!("\"{}\":q={};w={}", config.policy_name, config.quota, config.window))
-        .header("ratelimit", &format!("\"{}\":r={};t={}", config.policy_name, remaining, reset_in))
+    pub fn on_response(&mut self, resp: Response) -> Response {
+        // Add rate limit headers to response
+        resp
+    }
 }
 ```
 
@@ -410,32 +390,21 @@ fn on_response(res: &Response, config: &Config) -> Response {
 
 ```rust
 use barbacane_plugin_sdk::prelude::*;
-
-#[derive(Deserialize)]
-struct Config {
-    url: String,
-    timeout: Option<String>,
-}
+use serde::Deserialize;
 
 #[barbacane_dispatcher]
-fn dispatch(req: &Request, config: &Config) -> Response {
-    let upstream_req = HttpRequest {
-        method: req.method.clone(),
-        url: format!("{}{}", config.url, req.path),
-        headers: req.headers.clone(),
-        body: req.body.clone(),
-    };
+#[derive(Deserialize)]
+pub struct MyUpstream {
+    url: String,
+    #[serde(default)]
+    timeout: Option<f64>,
+}
 
-    match barbacane::http::call(&upstream_req) {
-        Ok(res) => Response::new(res.status)
-            .headers(res.headers)
-            .body_bytes(res.body),
-        Err(e) => {
-            barbacane::log::error(&format!("upstream call failed: {}", e));
-            Response::new(502)
-                .header("content-type", "application/problem+json")
-                .body(r#"{"type":"urn:barbacane:error:upstream-unavailable","title":"Bad Gateway","status":502}"#)
-        }
+impl MyUpstream {
+    pub fn dispatch(&mut self, req: Request) -> Response {
+        // Use host_http_call to proxy to upstream
+        // Request/response bodies travel via side-channel automatically
+        Response::text(200, Default::default(), "ok")
     }
 }
 ```
@@ -443,13 +412,13 @@ fn dispatch(req: &Request, config: &Config) -> Response {
 ### 7.3 What the macros generate
 
 `#[barbacane_middleware]` generates:
-- `init` export: deserializes config JSON into the `Config` struct, stores in a `static`
-- `on_request` export: deserializes request JSON, calls the user function, serializes the result, calls `host_set_output`
-- `on_response` export: no-op pass-through (unless the user defines an `on_response` function)
+- `init` export: deserializes config JSON into the struct, stores in a `static`
+- `on_request` export: deserializes request JSON, reads body via side-channel (if `body_access = true`), calls `self.on_request()`, serializes result, writes body via side-channel, calls `host_set_output`
+- `on_response` export: same pattern for response phase; no-op if not defined
 
 `#[barbacane_dispatcher]` generates:
 - `init` export: same as above
-- `dispatch` export: deserializes request, calls user function, serializes response, calls `host_set_output`
+- `dispatch` export: deserializes request, reads body via side-channel, calls `self.dispatch()`, serializes response, writes body via side-channel, calls `host_set_output`
 
 ---
 
@@ -477,7 +446,37 @@ The control plane validates:
 5. The `.wasm` binary does not import host functions outside its declared capabilities
 6. No plugin with the same `name@version` already exists (versions are immutable once registered)
 
-### 8.3 Version resolution
+### 8.3 Plugin Sources in Manifest (`barbacane.yaml`)
+
+The project manifest declares available plugins with two source types (ADR-0029):
+
+```yaml
+plugins:
+  # Local file path
+  mock:
+    path: ./plugins/mock.wasm
+
+  # Remote HTTPS URL
+  jwt-auth:
+    url: https://github.com/barbacane-dev/barbacane/releases/download/v0.5.0/jwt-auth.wasm
+    sha256: abc123...  # optional integrity check
+```
+
+| Source | Fields | Resolution |
+|--------|--------|------------|
+| `path` | `path` (string) | Resolved relative to the manifest directory, or absolute |
+| `url` | `url` (string), `sha256` (string, optional) | Downloaded over HTTPS at compile time, cached at `~/.barbacane/cache/plugins/` |
+
+**URL source rules:**
+
+- URL must use HTTPS (HTTP is rejected)
+- If `sha256` is provided, the downloaded bytes are verified against it; mismatches cause a compile error
+- The compiler attempts to fetch `plugin.toml` metadata from sibling URLs (`<name>.plugin.toml` then `plugin.toml` in the parent directory)
+- `--no-cache` flag forces re-download, bypassing the local cache
+
+Official Barbacane plugins are published as GitHub release assets on every tagged release, with checksums in `plugin-checksums.txt`.
+
+### 8.4 Version resolution
 
 In specs, plugins can be referenced as:
 

--- a/specs/SPEC-003-plugin-system.md
+++ b/specs/SPEC-003-plugin-system.md
@@ -472,7 +472,7 @@ plugins:
 - URL must use HTTPS (HTTP is rejected)
 - If `sha256` is provided, the downloaded bytes are verified against it; mismatches cause a compile error
 - The compiler attempts to fetch `plugin.toml` metadata from sibling URLs (`<name>.plugin.toml` then `plugin.toml` in the parent directory)
-- `--no-cache` flag forces re-download, bypassing the local cache
+- `--no-cache` flag bypasses the cache entirely — plugins are re-downloaded and not written to cache
 
 Official Barbacane plugins are published as GitHub release assets on every tagged release, with checksums in `plugin-checksums.txt`.
 

--- a/specs/SPEC-004-security.md
+++ b/specs/SPEC-004-security.md
@@ -287,7 +287,7 @@ WASM plugins execute in `wasmtime` with:
 - No clock access (except via `clock_now` host function)
 - No access to other plugins' memory
 - Execution time limits (100ms per call)
-- Memory limits (16 MB per instance)
+- Memory limits (max(16 MB, max_body_size + 4 MB) per instance)
 
 ### 8.2 Capability enforcement
 

--- a/specs/SPEC-007-testing.md
+++ b/specs/SPEC-007-testing.md
@@ -20,12 +20,14 @@ Standard Rust testing via `cargo test`. Every crate in the workspace has unit te
 
 | Crate | What is tested |
 |-------|----------------|
-| `barbacane-spec-parser` | OpenAPI/AsyncAPI parsing, `x-barbacane-*` extension extraction, `$ref` resolution |
-| `barbacane-compiler` | Routing trie generation, schema compilation, middleware chain resolution, plugin config validation |
-| `barbacane-validator` | JSON Schema validation for all supported keywords, edge cases (nullable, oneOf, format) |
-| `barbacane-router` | Prefix-trie path matching, parameter extraction, method filtering, static-vs-param precedence |
-| `barbacane-wasm-host` | Plugin loading, host function contracts, sandbox enforcement (memory limits, time limits) |
+| `barbacane-compiler` | OpenAPI/AsyncAPI parsing, `x-barbacane-*` extension extraction, `$ref` resolution, routing trie generation, schema compilation, middleware chain resolution, plugin config validation, remote plugin download/cache |
+| `barbacane-wasm` | Plugin loading, host function contracts, sandbox enforcement (memory limits, time limits), side-channel body passing |
 | `barbacane-plugin-sdk` | Macro expansion, serialization, Action type handling |
+| `barbacane-plugin-macros` | Proc macro code generation for `#[barbacane_middleware]` and `#[barbacane_dispatcher]` |
+| `barbacane-telemetry` | Prometheus metrics, tracing setup |
+| `barbacane-sigv4` | AWS SigV4 request signing |
+| `barbacane-control` | Control plane API, database operations, plugin registry |
+| `barbacane` | CLI commands, gateway server, router, request validation |
 
 ### 2.2 Integration tests
 
@@ -227,7 +229,7 @@ Publish artifacts                 (container images, binary releases)
 
 | Requirement | Details |
 |-------------|---------|
-| Rust toolchain | Stable + `wasm32-wasip1` target |
+| Rust toolchain | Stable + `wasm32-unknown-unknown` target |
 | `wasmtime` | For WASM tests |
 | PostgreSQL | For control plane integration tests |
 | No external services | All dispatch tests use `mock` dispatcher |


### PR DESCRIPTION
## Summary

- Implement `url:` plugin sources in `barbacane.yaml` — the compiler downloads WASM plugins from remote HTTPS URLs at compile time
- Downloaded plugins are cached locally at `~/.barbacane/cache/plugins/` with optional `sha256` integrity verification
- Add `--no-cache` flag to `barbacane compile` to force re-download
- Add `build-plugins` job to release workflow — all 27 plugins are built and published as GitHub release assets with checksums
- Add ADR-0029 documenting the remote plugin distribution decision

### Usage

```yaml
# barbacane.yaml
plugins:
  jwt-auth:
    url: https://github.com/barbacane-dev/barbacane/releases/download/v0.5.0/jwt-auth.wasm
    sha256: abc123...  # optional
  mock:
    path: ./plugins/mock.wasm  # local sources still work
```

## Changes

### Code
- **`crates/barbacane-compiler/src/download.rs`** — new module: HTTPS download via `reqwest::blocking`, sibling `plugin.toml` metadata discovery
- **`crates/barbacane-compiler/src/cache.rs`** — new module: local file cache with checksum-based invalidation
- **`crates/barbacane-compiler/src/manifest.rs`** — `UrlSource.sha256` field, `resolve_url_plugin()` with cache → download → verify → store flow
- **`crates/barbacane-compiler/src/artifact.rs`** — `CompileOptions.no_cache` field
- **`crates/barbacane/src/main.rs`** — `--no-cache` CLI flag on compile command

### CI
- **`.github/workflows/release.yml`** — new `build-plugins` job builds all plugins to `wasm32-unknown-unknown`, uploads `<name>.wasm` + `<name>.plugin.toml` + `plugin-checksums.txt` as release assets

### Documentation
- **`adr/0029-remote-plugin-distribution.md`** — ADR for HTTPS distribution over OCI
- **`CHANGELOG.md`** — 6 entries under `[Unreleased]`
- **`ROADMAP.md`** — "URL plugin source" marked done
- **`docs/reference/cli.md`** — `--no-cache` flag
- **`docs/guide/getting-started.md`** — `url:` + `sha256` manifest syntax
- **`docs/contributing/plugins.md`** — new "Distributing Plugins" section

### Spec fixes (pre-existing issues)
- **SPEC-003** — fixed WASM target (`wasm32-unknown-unknown`), body side-channel, memory formula, SDK examples, added plugin sources section
- **SPEC-004** — fixed memory limit formula
- **SPEC-007** — fixed WASM target, replaced non-existent crate names with actual workspace crates

## Test plan

- [x] All 91 `barbacane-compiler` tests pass (including new URL parsing, sha256, and cache tests)
- [x] Full workspace tests pass
- [x] `cargo clippy --all-targets` clean
- [x] Pre-commit hooks pass
- [x] Manual test: compile with a `url:` source pointing to a real GitHub release asset
- [x] Manual test: verify `--no-cache` forces re-download
- [x] Manual test: verify `sha256` mismatch is rejected