### PR TITLE
fix: resolve secret references in auth plugin configs

### DIFF
--- a/crates/barbacane-test/tests/proxy.rs
+++ b/crates/barbacane-test/tests/proxy.rs
@@ -212,7 +212,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              test-key-123:
+              - key: test-key-123
                 id: key-1
                 name: testuser
       requestBody:
@@ -322,7 +322,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              test-key-123:
+              - key: test-key-123
                 id: key-1
                 name: testuser
       requestBody:
@@ -578,7 +578,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              test-key-123:
+              - key: test-key-123
                 id: key-1
                 name: testuser
       requestBody:
@@ -679,7 +679,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              test-key-123:
+              - key: test-key-123
                 id: key-1
                 name: testuser
       requestBody:
@@ -785,7 +785,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              test-key-123:
+              - key: test-key-123
                 id: key-1
                 name: testuser
       requestBody:
@@ -906,7 +906,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              test-key-123:
+              - key: test-key-123
                 id: key-1
                 name: testuser
       requestBody:
@@ -1103,7 +1103,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              test-key-123:
+              - key: test-key-123
                 id: key-1
                 name: testuser
       x-barbacane-dispatch:

--- a/crates/barbacane-test/tests/streaming.rs
+++ b/crates/barbacane-test/tests/streaming.rs
@@ -102,7 +102,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              secret-key:
+              - key: secret-key
                 id: key-1
                 name: test
       x-barbacane-dispatch:

--- a/crates/barbacane-test/tests/workload.rs
+++ b/crates/barbacane-test/tests/workload.rs
@@ -163,7 +163,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              test-key-123:
+              - key: test-key-123
                 id: key-1
                 name: testuser
       requestBody:
@@ -233,7 +233,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              test-key-123:
+              - key: test-key-123
                 id: key-1
                 name: testuser
       requestBody:
@@ -688,7 +688,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              test-key-123:
+              - key: test-key-123
                 id: key-1
                 name: testuser
       requestBody:
@@ -808,7 +808,7 @@ paths:
           config:
             header_name: x-api-key
             keys:
-              test-key-123:
+              - key: test-key-123
                 id: key-1
                 name: testuser
       x-barbacane-dispatch:

--- a/docs/guide/middlewares.md
+++ b/docs/guide/middlewares.md
@@ -188,15 +188,17 @@ x-barbacane-middlewares:
       header_name: X-API-Key      # when key_location is "header"
       query_param: api_key        # when key_location is "query"
       keys:
-        sk_live_abc123:
+        - key: "env://API_KEY_PRODUCTION"
           id: key-001
           name: Production Key
           scopes: ["read", "write"]
-        sk_test_xyz789:
+        - key: sk_test_xyz789
           id: key-002
           name: Test Key
           scopes: ["read"]
 ```
+
+The `key` field supports secret references (`env://`, `file://`) which are resolved at gateway startup. See [Secrets](secrets.md) for details.
 
 #### Configuration
 
@@ -205,7 +207,7 @@ x-barbacane-middlewares:
 | `key_location` | string | `header` | Where to find key (`header` or `query`) |
 | `header_name` | string | `X-API-Key` | Header name (when `key_location: header`) |
 | `query_param` | string | `api_key` | Query param name (when `key_location: query`) |
-| `keys` | object | `{}` | Map of valid API keys to metadata |
+| `keys` | array | `[]` | List of API key entries with metadata |
 
 #### Context Headers
 
@@ -336,10 +338,10 @@ x-barbacane-middlewares:
       realm: "My API"
       strip_credentials: true
       credentials:
-        admin:
+        - username: admin
           password: "env://ADMIN_PASSWORD"
           roles: ["admin", "editor"]
-        readonly:
+        - username: readonly
           password: "env://READONLY_PASSWORD"
           roles: ["viewer"]
 ```
@@ -350,12 +352,13 @@ x-barbacane-middlewares:
 |----------|------|---------|-------------|
 | `realm` | string | `api` | Authentication realm shown in `WWW-Authenticate` challenge |
 | `strip_credentials` | boolean | `true` | Remove `Authorization` header before forwarding to upstream |
-| `credentials` | object | `{}` | Map of username to credential entry |
+| `credentials` | array | `[]` | List of credential entries |
 
 Each credential entry:
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
+| `username` | string | **required** | Username for this credential |
 | `password` | string | **required** | Password for this user (supports secret references) |
 | `roles` | array | `[]` | Optional roles for authorization |
 
@@ -394,10 +397,10 @@ x-barbacane-middlewares:
     config:
       realm: "my-api"
       credentials:
-        admin:
+        - username: admin
           password: "env://ADMIN_PASSWORD"
           roles: ["admin", "editor"]
-        viewer:
+        - username: viewer
           password: "env://VIEWER_PASSWORD"
           roles: ["viewer"]
   - name: acl

--- a/docs/rulesets/functions/barbacane-validate-middleware-config.js
+++ b/docs/rulesets/functions/barbacane-validate-middleware-config.js
@@ -22,7 +22,7 @@ const schemas = {
       key_location: { type: "string" },
       header_name: { type: "string" },
       query_param: { type: "string" },
-      keys: { type: "object" },
+      keys: { type: "array" },
     },
     additionalProperties: false,
   },
@@ -32,7 +32,7 @@ const schemas = {
     properties: {
       realm: { type: "string" },
       strip_credentials: { type: "boolean" },
-      credentials: { type: "object" },
+      credentials: { type: "array" },
     },
     additionalProperties: false,
   },

--- a/plugins/apikey-auth/config-schema.json
+++ b/plugins/apikey-auth/config-schema.json
@@ -22,12 +22,16 @@
       "default": "api_key"
     },
     "keys": {
-      "type": "object",
-      "description": "Map of valid API keys to their metadata",
-      "additionalProperties": {
+      "type": "array",
+      "description": "List of valid API keys with their metadata",
+      "items": {
         "type": "object",
-        "required": ["id"],
+        "required": ["key", "id"],
         "properties": {
+          "key": {
+            "type": "string",
+            "description": "The API key value. Supports secret references (e.g. env://MY_API_KEY)."
+          },
           "id": {
             "type": "string",
             "description": "Unique identifier for this key (for logging/auditing)"
@@ -47,7 +51,7 @@
         },
         "additionalProperties": false
       },
-      "default": {}
+      "default": []
     }
   },
   "additionalProperties": false

--- a/plugins/apikey-auth/src/lib.rs
+++ b/plugins/apikey-auth/src/lib.rs
@@ -26,16 +26,17 @@ pub struct ApiKeyAuth {
     #[serde(default = "default_query_param")]
     query_param: String,
 
-    /// Map of valid API keys to their metadata.
-    /// Key: the API key string
-    /// Value: key metadata (id, name, optional scopes)
+    /// List of valid API keys with their metadata.
     #[serde(default)]
-    keys: BTreeMap<String, ApiKeyEntry>,
+    keys: Vec<ApiKeyEntry>,
 }
 
-/// Metadata for a single API key.
+/// A single API key entry.
 #[derive(Debug, Clone, Deserialize)]
 struct ApiKeyEntry {
+    /// The API key value. Supports secret references (e.g. `env://MY_API_KEY`).
+    key: String,
+
     /// Unique identifier for this key (for logging/auditing).
     id: String,
 
@@ -179,7 +180,10 @@ impl ApiKeyAuth {
 
     /// Look up the API key in the configured key store.
     fn lookup_key(&self, key: &str) -> Result<&ApiKeyEntry, ApiKeyError> {
-        self.keys.get(key).ok_or(ApiKeyError::InvalidKey)
+        self.keys
+            .iter()
+            .find(|e| e.key == key)
+            .ok_or(ApiKeyError::InvalidKey)
     }
 
     /// Generate 401 Unauthorized response.
@@ -244,11 +248,11 @@ mod tests {
 
     fn test_plugin() -> ApiKeyAuth {
         serde_json::from_value(serde_json::json!({
-            "keys": {
-                "sk-test-123": { "id": "key1", "name": "Test Key", "scopes": ["read", "write"] },
-                "sk-readonly": { "id": "key2", "scopes": ["read"] },
-                "sk-noname": { "id": "key3" }
-            }
+            "keys": [
+                { "key": "sk-test-123", "id": "key1", "name": "Test Key", "scopes": ["read", "write"] },
+                { "key": "sk-readonly", "id": "key2", "scopes": ["read"] },
+                { "key": "sk-noname", "id": "key3" }
+            ]
         }))
         .unwrap()
     }
@@ -417,8 +421,8 @@ mod tests {
         match plugin.on_request(req) {
             Action::Continue(r) => {
                 assert_eq!(r.headers.get("x-auth-key-id").unwrap(), "key3");
-                assert!(r.headers.get("x-auth-key-name").is_none());
-                assert!(r.headers.get("x-auth-key-scopes").is_none());
+                assert!(!r.headers.contains_key("x-auth-key-name"));
+                assert!(!r.headers.contains_key("x-auth-key-scopes"));
                 assert_eq!(r.headers.get("x-auth-consumer").unwrap(), "key3");
                 assert!(!r.headers.contains_key("x-auth-consumer-groups"));
             }
@@ -456,7 +460,7 @@ mod tests {
     fn test_on_request_query_location() {
         let mut plugin: ApiKeyAuth = serde_json::from_value(serde_json::json!({
             "key_location": "query",
-            "keys": { "mykey": { "id": "q1" } }
+            "keys": [{ "key": "mykey", "id": "q1" }]
         }))
         .unwrap();
         let req = request_with_query("api_key=mykey");
@@ -520,7 +524,7 @@ mod tests {
     fn test_config_custom_header() {
         let plugin: ApiKeyAuth = serde_json::from_value(serde_json::json!({
             "header_name": "Authorization",
-            "keys": { "Bearer tok": { "id": "t1" } }
+            "keys": [{ "key": "Bearer tok", "id": "t1" }]
         }))
         .unwrap();
         assert_eq!(plugin.header_name, "Authorization");

--- a/plugins/basic-auth/config-schema.json
+++ b/plugins/basic-auth/config-schema.json
@@ -16,15 +16,19 @@
       "default": true
     },
     "credentials": {
-      "type": "object",
-      "description": "Map of username to credential entry",
-      "additionalProperties": {
+      "type": "array",
+      "description": "List of credential entries (username, password, and optional roles)",
+      "items": {
         "type": "object",
-        "required": ["password"],
+        "required": ["username", "password"],
         "properties": {
+          "username": {
+            "type": "string",
+            "description": "Username for this credential"
+          },
           "password": {
             "type": "string",
-            "description": "Password for this user"
+            "description": "Password for this user. Supports secret references (e.g. env://MY_PASSWORD)."
           },
           "roles": {
             "type": "array",
@@ -35,7 +39,7 @@
         },
         "additionalProperties": false
       },
-      "default": {}
+      "default": []
     }
   },
   "additionalProperties": false

--- a/plugins/basic-auth/src/lib.rs
+++ b/plugins/basic-auth/src/lib.rs
@@ -20,15 +20,18 @@ pub struct BasicAuth {
     #[serde(default = "default_strip_credentials")]
     strip_credentials: bool,
 
-    /// Map of username to credential entry (password and optional roles).
+    /// List of credential entries (username, password, and optional roles).
     #[serde(default)]
-    credentials: BTreeMap<String, CredentialEntry>,
+    credentials: Vec<CredentialEntry>,
 }
 
 /// Credential entry for a single user.
 #[derive(Debug, Clone, Deserialize)]
 struct CredentialEntry {
-    /// Password for this user.
+    /// Username for this credential.
+    username: String,
+
+    /// Password for this user. Supports secret references (e.g. `env://MY_PASSWORD`).
     password: String,
 
     /// Optional roles/permissions for this user.
@@ -129,7 +132,8 @@ impl BasicAuth {
         let (username, password) = self.extract_credentials(req)?;
         let entry = self
             .credentials
-            .get(&username)
+            .iter()
+            .find(|e| e.username == username)
             .ok_or(BasicAuthError::InvalidCredentials)?;
         if entry.password != password {
             return Err(BasicAuthError::InvalidCredentials);
@@ -207,21 +211,18 @@ mod tests {
 
     /// Helper: build a BasicAuth instance with test credentials.
     fn test_plugin() -> BasicAuth {
-        let mut credentials = BTreeMap::new();
-        credentials.insert(
-            "admin".to_string(),
+        let credentials = vec![
             CredentialEntry {
+                username: "admin".to_string(),
                 password: "secret123".to_string(),
                 roles: vec!["admin".to_string(), "editor".to_string()],
             },
-        );
-        credentials.insert(
-            "reader".to_string(),
             CredentialEntry {
+                username: "reader".to_string(),
                 password: "readonly456".to_string(),
                 roles: vec![],
             },
-        );
+        ];
         BasicAuth {
             realm: "test-api".to_string(),
             strip_credentials: true,
@@ -523,16 +524,18 @@ mod tests {
         let json = r#"{
             "realm": "myapp",
             "strip_credentials": false,
-            "credentials": {
-                "alice": { "password": "p@ss", "roles": ["admin"] },
-                "bob": { "password": "secret" }
-            }
+            "credentials": [
+                { "username": "alice", "password": "p@ss", "roles": ["admin"] },
+                { "username": "bob", "password": "secret" }
+            ]
         }"#;
         let config: BasicAuth = serde_json::from_str(json).unwrap();
         assert_eq!(config.realm, "myapp");
         assert!(!config.strip_credentials);
         assert_eq!(config.credentials.len(), 2);
-        assert_eq!(config.credentials["alice"].roles, vec!["admin"]);
-        assert!(config.credentials["bob"].roles.is_empty());
+        assert_eq!(config.credentials[0].username, "alice");
+        assert_eq!(config.credentials[0].roles, vec!["admin"]);
+        assert_eq!(config.credentials[1].username, "bob");
+        assert!(config.credentials[1].roles.is_empty());
     }
 }

--- a/tests/fixtures/acl.yaml
+++ b/tests/fixtures/acl.yaml
@@ -11,20 +11,20 @@ x-barbacane-middlewares:
     config:
       realm: "acl-test"
       credentials:
-        admin:
+        - username: admin
           password: "admin123"
           roles:
             - admin
             - editor
-        editor:
+        - username: editor
           password: "editor123"
           roles:
             - editor
-        viewer:
+        - username: viewer
           password: "viewer123"
           roles:
             - viewer
-        banned_user:
+        - username: banned_user
           password: "banned123"
           roles:
             - viewer
@@ -40,16 +40,16 @@ paths:
           config:
             realm: "acl-test"
             credentials:
-              admin:
+              - username: admin
                 password: "admin123"
                 roles: [admin, editor]
-              editor:
+              - username: editor
                 password: "editor123"
                 roles: [editor]
-              viewer:
+              - username: viewer
                 password: "viewer123"
                 roles: [viewer]
-              banned_user:
+              - username: banned_user
                 password: "banned123"
                 roles: [viewer, banned]
         - name: acl
@@ -77,16 +77,16 @@ paths:
           config:
             realm: "acl-test"
             credentials:
-              admin:
+              - username: admin
                 password: "admin123"
                 roles: [admin, editor]
-              editor:
+              - username: editor
                 password: "editor123"
                 roles: [editor]
-              viewer:
+              - username: viewer
                 password: "viewer123"
                 roles: [viewer]
-              banned_user:
+              - username: banned_user
                 password: "banned123"
                 roles: [viewer, banned]
         - name: acl
@@ -115,16 +115,16 @@ paths:
           config:
             realm: "acl-test"
             credentials:
-              admin:
+              - username: admin
                 password: "admin123"
                 roles: [admin, editor]
-              editor:
+              - username: editor
                 password: "editor123"
                 roles: [editor]
-              viewer:
+              - username: viewer
                 password: "viewer123"
                 roles: [viewer]
-              banned_user:
+              - username: banned_user
                 password: "banned123"
                 roles: [viewer, banned]
         - name: acl
@@ -152,10 +152,10 @@ paths:
           config:
             realm: "acl-test"
             credentials:
-              admin:
+              - username: admin
                 password: "admin123"
                 roles: [admin, editor]
-              editor:
+              - username: editor
                 password: "editor123"
                 roles: [editor]
         - name: acl
@@ -185,10 +185,10 @@ paths:
           config:
             realm: "acl-test"
             credentials:
-              admin:
+              - username: admin
                 password: "admin123"
                 roles: [admin]
-              viewer:
+              - username: viewer
                 password: "viewer123"
                 roles: [viewer]
         - name: acl

--- a/tests/fixtures/apikey-auth.yaml
+++ b/tests/fixtures/apikey-auth.yaml
@@ -11,13 +11,13 @@ x-barbacane-middlewares:
       key_location: header
       header_name: X-API-Key
       keys:
-        test-key-123:
+        - key: test-key-123
           id: key-001
           name: Test Key
           scopes:
             - read
             - write
-        readonly-key-456:
+        - key: readonly-key-456
           id: key-002
           name: Read Only Key
           scopes:
@@ -79,7 +79,7 @@ paths:
             key_location: query
             query_param: api_key
             keys:
-              query-key-789:
+              - key: query-key-789
                 id: key-003
                 name: Query Key
                 scopes:

--- a/tests/fixtures/basic-auth.yaml
+++ b/tests/fixtures/basic-auth.yaml
@@ -10,13 +10,13 @@ x-barbacane-middlewares:
     config:
       realm: "test-api"
       credentials:
-        admin:
+        - username: admin
           password: "secret123"
           roles:
             - admin
             - read
             - write
-        reader:
+        - username: reader
           password: "readonly456"
           roles:
             - read

--- a/tests/fixtures/cel.yaml
+++ b/tests/fixtures/cel.yaml
@@ -54,10 +54,10 @@ paths:
           config:
             realm: "cel-test"
             credentials:
-              admin:
+              - username: admin
                 password: "admin123"
                 roles: [admin, editor]
-              viewer:
+              - username: viewer
                 password: "viewer123"
                 roles: [viewer]
         - name: cel

--- a/tests/fixtures/opa-authz.yaml
+++ b/tests/fixtures/opa-authz.yaml
@@ -38,10 +38,10 @@ paths:
           config:
             realm: "opa-test"
             credentials:
-              admin:
+              - username: admin
                 password: "admin123"
                 roles: [admin]
-              viewer:
+              - username: viewer
                 password: "viewer123"
                 roles: [viewer]
         - name: opa-authz


### PR DESCRIPTION
## Summary

- **apikey-auth**: change `keys` from object (API key as map key) to array of entries with explicit `key` field
- **basic-auth**: change `credentials` from object (username as map key) to array of entries with explicit `username` field
- Fix: `env://` and `file://` secret references in apikey-auth keys were silently ignored because the secret resolver only walks JSON object **values**, not keys

## BREAKING CHANGE

`apikey-auth` and `basic-auth` config formats changed from map to array:

```yaml
# Before (apikey-auth)
keys:
  sk_live_abc123:
    id: key-001

# After
keys:
  - key: "env://MY_API_KEY"
    id: key-001
```

```yaml
# Before (basic-auth)
credentials:
  admin:
    password: "env://ADMIN_PW"

# After
credentials:
  - username: admin
    password: "env://ADMIN_PW"
```

## Test plan

- [x] apikey-auth plugin unit tests (25 pass)
- [x] basic-auth plugin unit tests (18 pass)
- [x] Workspace unit tests pass
- [x] Vacuum ruleset tests pass (13/13)
- [x] Clippy clean on both plugins
- [x] Integration tests (require Docker)