### PR TITLE
fix: add CORS headers to /__barbacane/* endpoints

### DIFF
--- a/crates/barbacane-test/tests/specs.rs
+++ b/crates/barbacane-test/tests/specs.rs
@@ -3,6 +3,7 @@
 //! Run with: `cargo test -p barbacane-test`
 
 use barbacane_test::TestGateway;
+use reqwest::Method;
 
 fn fixture(name: &str) -> String {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -325,4 +326,60 @@ async fn test_specs_merged_asyncapi_empty() {
     // Should return 404 when no AsyncAPI specs exist
     let resp = gateway.get("/__barbacane/specs/asyncapi").await.unwrap();
     assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test]
+async fn test_specs_cors_headers_on_get() {
+    let gateway = TestGateway::from_spec(&fixture("minimal.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    let resp = gateway.get("/__barbacane/specs").await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers().get("access-control-allow-origin").unwrap(),
+        "*"
+    );
+}
+
+#[tokio::test]
+async fn test_specs_cors_preflight() {
+    let gateway = TestGateway::from_spec(&fixture("minimal.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    let resp = gateway
+        .request_builder(Method::OPTIONS, "/__barbacane/specs/openapi")
+        .header("origin", "https://example.com")
+        .header("access-control-request-method", "GET")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 204);
+    assert_eq!(
+        resp.headers().get("access-control-allow-origin").unwrap(),
+        "*"
+    );
+    assert!(resp
+        .headers()
+        .get("access-control-allow-methods")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .contains("GET"));
+}
+
+#[tokio::test]
+async fn test_health_cors_headers() {
+    let gateway = TestGateway::from_spec(&fixture("minimal.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    let resp = gateway.get("/__barbacane/health").await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers().get("access-control-allow-origin").unwrap(),
+        "*"
+    );
 }

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -1910,12 +1910,27 @@ impl Gateway {
     }
 
     /// Handle reserved /__barbacane/* endpoints.
+    ///
+    /// These endpoints always allow cross-origin requests (`Access-Control-Allow-Origin: *`)
+    /// so that Swagger UI, Redoc, or similar tools hosted on different domains can fetch specs.
     fn handle_barbacane_endpoint(
         &self,
         path: &str,
         method: &Method,
         query: Option<&str>,
     ) -> Response<Full<Bytes>> {
+        // Handle CORS preflight for internal endpoints
+        if method == Method::OPTIONS {
+            return Response::builder()
+                .status(StatusCode::NO_CONTENT)
+                .header("access-control-allow-origin", "*")
+                .header("access-control-allow-methods", "GET, OPTIONS")
+                .header("access-control-allow-headers", "content-type, accept")
+                .header("access-control-max-age", "86400")
+                .body(Full::new(Bytes::new()))
+                .expect("valid response");
+        }
+
         if method != Method::GET {
             return self.method_not_allowed_response(vec!["GET".to_string()]);
         }
@@ -1925,7 +1940,7 @@ impl Gateway {
             .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("format=")))
             .unwrap_or("yaml");
 
-        match path {
+        let mut response = match path {
             "/__barbacane/health" => self.health_response(),
             "/__barbacane/specs" => self.specs_index_response(),
             "/__barbacane/specs/openapi" => self.merged_openapi_response(format),
@@ -1938,7 +1953,13 @@ impl Gateway {
                     self.not_found_response()
                 }
             }
-        }
+        };
+
+        response
+            .headers_mut()
+            .insert("access-control-allow-origin", HeaderValue::from_static("*"));
+
+        response
     }
 
     /// Build the specs index response (always JSON).


### PR DESCRIPTION
## Summary

- Add `Access-Control-Allow-Origin: *` to all `/__barbacane/*` endpoint responses (health, specs index, merged specs, individual specs)
- Handle `OPTIONS` preflight requests with `204 No Content` + standard CORS headers (`Allow-Methods`, `Allow-Headers`, `Max-Age`)
- Fixes CORS errors when loading specs from Swagger UI, Redoc, or similar tools hosted on different domains

## Test plan

- [x] `cargo clippy` clean
- [x] `cargo test -p barbacane` passes
- [x] 3 new integration tests: CORS on GET, OPTIONS preflight, health endpoint CORS