### PR TITLE
fix: HTTP/2 framing error with TLS enabled

### DIFF
--- a/crates/barbacane-test/src/gateway.rs
+++ b/crates/barbacane-test/src/gateway.rs
@@ -210,9 +210,12 @@ impl TestGateway {
                 TestError::StartupFailed(format!("failed to add root cert: {:?}", e))
             })?;
 
-            let tls_config = rustls::ClientConfig::builder()
+            let mut tls_config = rustls::ClientConfig::builder()
                 .with_root_certificates(root_store)
                 .with_no_client_auth();
+
+            // Enable ALPN so the client can negotiate HTTP/2 over TLS
+            tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 
             reqwest::Client::builder()
                 .use_preconfigured_tls(tls_config)

--- a/crates/barbacane-test/tests/proxy.rs
+++ b/crates/barbacane-test/tests/proxy.rs
@@ -149,6 +149,22 @@ async fn test_tls_gateway_404() {
     assert_eq!(resp.status(), 404);
 }
 
+#[tokio::test]
+async fn test_tls_gateway_http2() {
+    let gateway = TestGateway::from_spec_with_tls(&fixture("minimal.yaml"))
+        .await
+        .expect("failed to start TLS gateway");
+
+    // HTTP/2 should be negotiated via ALPN when TLS is enabled
+    let resp = gateway.get("/health").await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.version(),
+        reqwest::Version::HTTP_2,
+        "expected HTTP/2 negotiated via ALPN over TLS"
+    );
+}
+
 // ========================
 // Middleware + POST body
 // ========================

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -32,7 +32,7 @@ type AnyBody = BoxBody<Bytes, Infallible>;
 fn box_full(r: Response<Full<Bytes>>) -> Response<AnyBody> {
     r.map(BoxBody::new)
 }
-use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 use hyper_util::server::conn::auto;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::ServerConfig;
@@ -3826,6 +3826,7 @@ async fn run_serve(
                                 builder.http1().keep_alive(true);
                                 builder
                                     .http2()
+                                    .timer(TokioTimer::new())
                                     .keep_alive_interval(Some(std::time::Duration::from_secs(20)));
                                 let conn = builder.serve_connection_with_upgrades(io, service);
 
@@ -3863,6 +3864,7 @@ async fn run_serve(
                         builder.http1().keep_alive(true);
                         builder
                             .http2()
+                            .timer(TokioTimer::new())
                             .keep_alive_interval(Some(std::time::Duration::from_secs(20)));
                         let conn = builder.serve_connection_with_upgrades(io, service);
 


### PR DESCRIPTION
## Summary

- Supply `TokioTimer` to hyper's HTTP/2 server builder — without it, any HTTP/2 connection panicked with `You must supply a timer`
- Fix test client TLS config to advertise `h2` via ALPN — previously it always fell back to HTTP/1.1, masking the server bug
- Add `test_tls_gateway_http2` integration test asserting HTTP/2 protocol negotiation

Closes #60

## Test plan

- [x] `test_tls_gateway_http2` passes — asserts `resp.version() == HTTP/2`
- [x] Existing TLS tests (`test_tls_gateway_health`, `test_tls_gateway_mock_response`, `test_tls_gateway_404`) still pass
- [x] `cargo clippy --all-targets` clean