### PR TITLE
feat: add barbacane dev local dev server with file watching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **cli**: `barbacane dev` — local development server with file watching and automatic hot-reload. Compiles specs, starts the gateway, watches for changes to specs, manifest, and plugin WASM files, and reloads the gateway on every save. No more manual compile-serve cycle during development.
+- **compiler**: `specs` field in `barbacane.yaml` — point to a folder (e.g., `specs: ./specs/`) and all `*.yaml`/`*.json` files are discovered automatically. Used by `barbacane dev` for zero-config operation and as a fallback for `barbacane compile` when `--spec` is omitted.
+- **cli**: `barbacane compile` now discovers specs from the manifest's `specs` folder when `--spec` is not provided — `barbacane compile -m barbacane.yaml -o api.bca` works with zero spec args.
+- **cli**: `barbacane init` now scaffolds a `specs/` directory and places the generated spec in `specs/api.yaml` with `specs: ./specs/` in the manifest.
+
 ## [0.6.3] - 2026-04-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -125,9 +125,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -262,9 +262,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.13"
+version = "0.13.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bce4948d2520386c6d92a6ea2d472300257702242e5a1d01d6add52bd2e7c1"
+checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
 dependencies = [
  "bindgen",
  "cc",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -417,6 +417,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "jsonschema",
+ "notify",
  "parking_lot",
  "reqwest",
  "rustls",
@@ -614,10 +615,10 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -642,6 +643,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -725,9 +732,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -850,9 +857,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -868,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compression-codecs"
@@ -1482,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
@@ -1600,6 +1607,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,7 +1720,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "debugid",
  "rustc-hash",
  "serde",
@@ -1770,7 +1786,7 @@ checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -1792,7 +1808,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1843,6 +1859,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1945,9 +1967,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1960,7 +1982,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1968,15 +1989,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2045,12 +2065,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2058,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2071,9 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2085,15 +2106,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2105,15 +2126,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2177,14 +2198,43 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2201,9 +2251,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2237,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2255,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "ittapi"
@@ -2291,10 +2341,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2325,6 +2377,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,9 +2413,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -2363,14 +2435,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2391,9 +2463,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2514,11 +2586,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2570,6 +2643,34 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2646,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2709,7 +2810,7 @@ checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "crc32fast",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -2892,7 +2993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2922,12 +3023,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2950,9 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -3008,9 +3103,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3294,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3331,16 +3426,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3596,9 +3691,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3615,7 +3710,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3624,16 +3719,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.11",
  "subtle",
  "zeroize",
 ]
@@ -3682,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3745,7 +3840,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3764,9 +3859,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -3882,7 +3977,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3960,9 +4055,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "sized-chunks"
@@ -4066,7 +4161,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "once_cell",
@@ -4129,7 +4224,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -4173,7 +4268,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "crc",
@@ -4417,9 +4512,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4437,9 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4452,9 +4547,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -4469,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4567,7 +4662,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -4600,7 +4695,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -4702,7 +4797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4787,9 +4882,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4930,9 +5025,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5035,9 +5130,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5048,23 +5143,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5072,9 +5163,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5085,9 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -5101,7 +5192,7 @@ dependencies = [
  "anyhow",
  "heck",
  "im-rc",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "petgraph",
  "serde",
@@ -5134,13 +5225,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.246.2",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
@@ -5164,9 +5265,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5176,11 +5277,22 @@ version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+dependencies = [
+ "bitflags 2.11.0",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -5202,7 +5314,7 @@ checksum = "ce205cd643d661b5ba5ba4717e13730262e8cdbc8f2eacbc7b906d45c1a74026"
 dependencies = [
  "addr2line",
  "async-trait",
- "bitflags",
+ "bitflags 2.11.0",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -5260,7 +5372,7 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "object",
  "postcard",
@@ -5445,39 +5557,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7900c3e3c1d6e475bc225d73b02d6d5484815f260022e6964dca9558e50dd01a"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wit-parser 0.245.1",
 ]
 
 [[package]]
 name = "wast"
-version = "245.0.1"
+version = "246.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
+checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.245.1",
+ "wasm-encoder 0.246.2",
 ]
 
 [[package]]
 name = "wat"
-version = "1.245.1"
+version = "1.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5918,7 +6030,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -5948,8 +6060,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
- "indexmap 2.13.0",
+ "bitflags 2.11.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5968,7 +6080,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5987,7 +6099,7 @@ dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5999,9 +6111,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -6024,9 +6136,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6035,9 +6147,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6047,18 +6159,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6067,18 +6179,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6094,9 +6206,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6105,9 +6217,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6116,9 +6228,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chro
 chrono = { version = "0.4", features = ["serde", "clock"] }
 base64 = "0.22"
 tempfile = "3"
+notify = "7"
 
 # Proc macros
 syn = { version = "2", features = ["full", "parsing"] }

--- a/README.md
+++ b/README.md
@@ -38,11 +38,19 @@ git clone https://github.com/barbacane-dev/barbacane.git
 cd barbacane
 cargo build --release
 
-# Compile your OpenAPI spec
-./target/release/barbacane compile --spec api.yaml --manifest barbacane.yaml --output api.bca
+# Initialize a project
+./target/release/barbacane init my-api --fetch-plugins
+cd my-api
 
-# Run the gateway
-./target/release/barbacane serve --artifact api.bca --listen 0.0.0.0:8080
+# Start the dev server (auto-compiles and hot-reloads on save)
+../target/release/barbacane dev
+```
+
+For production, use the explicit compile-and-serve workflow:
+
+```bash
+barbacane compile -m barbacane.yaml -o api.bca
+barbacane serve --artifact api.bca --listen 0.0.0.0:8080
 ```
 
 ## Documentation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ What's actively being worked on:
 
 - [x] `request-transformer` plugin — modify headers, query params, path, body before upstream
 - [x] `response-transformer` plugin — modify response status code, headers, body before client
-- [ ] Documentation for transformation plugins
+- [x] Documentation for transformation plugins — **done** (documented in `docs/guide/middlewares.md`)
 
 ---
 
@@ -24,7 +24,7 @@ Near-term items ready to be picked up:
 - [x] Security plugins documentation — **done** (documented in `docs/guide/middlewares.md`)
 - [ ] Structured log format documentation
 - [ ] Integration guides (Datadog, Splunk, ELK)
-- [ ] `barbacane dev` — local dev server with file watching
+- [x] `barbacane dev` — local dev server with file watching — **done**
 - [ ] `barbacane plugin init` — scaffold new plugin projects
 - [ ] Improved error messages
 - [ ] Installation guide update
@@ -124,14 +124,14 @@ Near-term items ready to be picked up:
 | Plugin registry | Central registry for discovering and versioning plugins | P2 |
 | Multi-tenancy | Organization/team isolation with SNI-based routing | P3 |
 | Health metrics collection | Aggregate CPU, memory, request rates from data planes | P2 |
-| MCP server | Native data plane MCP server (ADR-0025): auto-generate MCP tools from compiled `.bca` artifact; tool calls route through the full middleware pipeline (auth, rate limiting, validation); Streamable HTTP transport; `x-barbacane-mcp` spec extension to opt in/out per operation | P1 |
+| ~~MCP server~~ | ~~Native data plane MCP server (ADR-0025): auto-generate MCP tools from compiled `.bca` artifact; tool calls route through the full middleware pipeline (auth, rate limiting, validation); Streamable HTTP transport; `x-barbacane-mcp` spec extension to opt in/out per operation~~ — **done** (v0.6.0) | ~~P1~~ |
 
 ### Developer Experience
 
 | Feature | Description | Priority |
 |---------|-------------|----------|
 | ~~Vacuum ruleset~~ | ~~Publish `vacuum:barbacane` ruleset validating `x-barbacane-*` extensions against plugin JSON schemas — catch upstream refs, plugin config errors, and missing auth opt-outs at lint time instead of compile/runtime~~ — **done** (`docs/rulesets/barbacane.yaml`) | ~~P0~~ |
-| `barbacane dev` | Local development server with file watching | P1 |
+| ~~`barbacane dev`~~ | ~~Local development server with file watching~~ — **done** | ~~P1~~ |
 | `barbacane plugin init` | Scaffold new plugin projects from template | P1 |
 | Plugin template repo | `barbacane-plugin-template` repository with minimal scaffolding | P1 |
 | VS Code extension | Spec editing with validation and autocomplete | P2 |

--- a/crates/barbacane-compiler/src/manifest.rs
+++ b/crates/barbacane-compiler/src/manifest.rs
@@ -181,6 +181,12 @@ pub struct ProjectManifest {
     /// Plugin declarations: name -> source.
     #[serde(default)]
     pub plugins: HashMap<String, PluginSource>,
+
+    /// Path to a folder containing spec files (relative to manifest or absolute).
+    /// All `*.yaml` and `*.json` files in this folder are discovered as specs.
+    /// Used by `barbacane dev` and as a fallback for `barbacane compile`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub specs: Option<String>,
 }
 
 /// Source location for a plugin.
@@ -254,6 +260,68 @@ impl ProjectManifest {
         })
     }
 
+    /// Discover spec files from the `specs` folder.
+    ///
+    /// Resolves the `specs` path relative to `base_path`, then globs for all
+    /// `*.yaml` and `*.json` files in it. Returns sorted paths.
+    /// Returns `Ok(vec![])` if no `specs` folder is configured.
+    pub fn discover_spec_files(
+        &self,
+        base_path: &Path,
+    ) -> Result<Vec<std::path::PathBuf>, CompileError> {
+        let specs_dir_str = match &self.specs {
+            Some(s) => s,
+            None => return Ok(vec![]),
+        };
+
+        let specs_dir = if Path::new(specs_dir_str).is_absolute() {
+            std::path::PathBuf::from(specs_dir_str)
+        } else {
+            base_path.join(specs_dir_str)
+        };
+
+        if !specs_dir.is_dir() {
+            return Err(CompileError::ManifestError(format!(
+                "specs folder not found: {}",
+                specs_dir.display()
+            )));
+        }
+
+        let mut spec_files = Vec::new();
+        let entries = std::fs::read_dir(&specs_dir).map_err(|e| {
+            CompileError::ManifestError(format!(
+                "failed to read specs folder {}: {}",
+                specs_dir.display(),
+                e
+            ))
+        })?;
+
+        for entry in entries {
+            let entry = entry.map_err(|e| {
+                CompileError::ManifestError(format!("failed to read directory entry: {}", e))
+            })?;
+            let path = entry.path();
+            if path.is_file() {
+                if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                    if ext == "yaml" || ext == "yml" || ext == "json" {
+                        spec_files.push(path);
+                    }
+                }
+            }
+        }
+
+        spec_files.sort();
+
+        if spec_files.is_empty() {
+            return Err(CompileError::ManifestError(format!(
+                "no spec files (*.yaml, *.yml, *.json) found in {}",
+                specs_dir.display()
+            )));
+        }
+
+        Ok(spec_files)
+    }
+
     /// Check if a plugin is declared in the manifest.
     pub fn has_plugin(&self, name: &str) -> bool {
         self.plugins.contains_key(name)
@@ -262,6 +330,19 @@ impl ProjectManifest {
     /// Get all declared plugin names.
     pub fn plugin_names(&self) -> Vec<&str> {
         self.plugins.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Get resolved paths for all local (`path:`) plugin WASM files.
+    ///
+    /// Useful for file watching in dev mode — only local plugins can change.
+    pub fn local_plugin_paths(&self, base_path: &Path) -> Vec<std::path::PathBuf> {
+        self.plugins
+            .values()
+            .filter_map(|source| match source {
+                PluginSource::Path(p) => Some(resolve_wasm_path(p, base_path)),
+                PluginSource::Url(_) => None,
+            })
+            .collect()
     }
 
     /// Resolve all plugins: load WASM bytes from their sources.
@@ -888,5 +969,113 @@ plugins:
             .unwrap();
         assert_eq!(resolved[0].version, Some("2.0.0".to_string()));
         assert_eq!(resolved[0].plugin_type, Some("middleware".to_string()));
+    }
+
+    #[test]
+    fn parse_manifest_without_specs() {
+        let content = r#"
+plugins:
+  mock:
+    path: ./plugins/mock.wasm
+"#;
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+        assert!(manifest.specs.is_none());
+    }
+
+    #[test]
+    fn parse_manifest_with_specs_folder() {
+        let content = r#"
+specs: ./specs/
+plugins:
+  mock:
+    path: ./plugins/mock.wasm
+"#;
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+        assert_eq!(manifest.specs.as_deref(), Some("./specs/"));
+    }
+
+    #[test]
+    fn discover_spec_files_from_folder() {
+        let temp = TempDir::new().unwrap();
+        let specs_dir = temp.path().join("specs");
+        std::fs::create_dir_all(&specs_dir).unwrap();
+
+        std::fs::write(specs_dir.join("api.yaml"), "openapi: '3.1.0'").unwrap();
+        std::fs::write(specs_dir.join("events.json"), "{}").unwrap();
+        std::fs::write(specs_dir.join("notes.txt"), "not a spec").unwrap();
+
+        let content = "specs: ./specs/\nplugins: {}";
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+
+        let files = manifest.discover_spec_files(temp.path()).unwrap();
+        assert_eq!(files.len(), 2);
+        assert!(files[0].ends_with("api.yaml"));
+        assert!(files[1].ends_with("events.json"));
+    }
+
+    #[test]
+    fn discover_spec_files_yml_extension() {
+        let temp = TempDir::new().unwrap();
+        let specs_dir = temp.path().join("specs");
+        std::fs::create_dir_all(&specs_dir).unwrap();
+
+        std::fs::write(specs_dir.join("api.yml"), "openapi: '3.1.0'").unwrap();
+
+        let content = "specs: ./specs/\nplugins: {}";
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+
+        let files = manifest.discover_spec_files(temp.path()).unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].ends_with("api.yml"));
+    }
+
+    #[test]
+    fn discover_spec_files_no_specs_configured() {
+        let manifest = ProjectManifest::parse("plugins: {}", Path::new("barbacane.yaml")).unwrap();
+        let files = manifest.discover_spec_files(Path::new(".")).unwrap();
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn discover_spec_files_missing_folder() {
+        let content = "specs: ./nonexistent/\nplugins: {}";
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+
+        let result = manifest.discover_spec_files(Path::new("."));
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("specs folder not found"));
+    }
+
+    #[test]
+    fn discover_spec_files_empty_folder() {
+        let temp = TempDir::new().unwrap();
+        let specs_dir = temp.path().join("specs");
+        std::fs::create_dir_all(&specs_dir).unwrap();
+
+        let content = "specs: ./specs/\nplugins: {}";
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+
+        let result = manifest.discover_spec_files(temp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no spec files"));
+    }
+
+    #[test]
+    fn local_plugin_paths_filters_url_sources() {
+        let content = r#"
+plugins:
+  mock:
+    path: ./plugins/mock.wasm
+  jwt-auth:
+    url: https://plugins.barbacane.io/jwt-auth.wasm
+"#;
+        let manifest = ProjectManifest::parse(content, Path::new("barbacane.yaml")).unwrap();
+        let paths = manifest.local_plugin_paths(Path::new("/project"));
+
+        assert_eq!(paths.len(), 1);
+        assert!(paths[0].ends_with("plugins/mock.wasm"));
     }
 }

--- a/crates/barbacane-test/src/cli.rs
+++ b/crates/barbacane-test/src/cli.rs
@@ -297,3 +297,126 @@ fn init_fails_on_existing_nonempty_directory() {
         .failure()
         .code(1);
 }
+
+#[test]
+fn init_manifest_contains_specs_folder() {
+    let tmp = TempDir::new().expect("temp dir");
+    let project = tmp.path().join("my-api");
+
+    barbacane().args(["init"]).arg(&project).assert().success();
+
+    let manifest = std::fs::read_to_string(project.join("barbacane.yaml")).expect("read manifest");
+    assert!(
+        manifest.contains("specs: ./specs/"),
+        "manifest should contain specs folder declaration"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// barbacane dev
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dev_missing_manifest_exits_one() {
+    barbacane()
+        .args(["dev", "--manifest", "nonexistent.yaml"])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(contains("manifest not found"));
+}
+
+#[test]
+fn dev_no_specs_configured_exits_one() {
+    let tmp = TempDir::new().expect("temp dir");
+    let manifest = tmp.path().join("barbacane.yaml");
+    std::fs::write(&manifest, "plugins: {}\n").expect("write manifest");
+
+    barbacane()
+        .args(["dev", "--manifest"])
+        .arg(&manifest)
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(contains("no specs found"));
+}
+
+#[test]
+fn dev_missing_spec_override_exits_one() {
+    let tmp = TempDir::new().expect("temp dir");
+    let manifest = tmp.path().join("barbacane.yaml");
+    std::fs::write(&manifest, "plugins: {}\n").expect("write manifest");
+
+    barbacane()
+        .args(["dev", "--manifest"])
+        .arg(&manifest)
+        .args(["--spec", "nonexistent.yaml"])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(contains("compile error"));
+}
+
+#[test]
+fn dev_help_shows_expected_options() {
+    barbacane()
+        .args(["dev", "--help"])
+        .assert()
+        .success()
+        .stdout(contains("auto-reload"))
+        .stdout(contains("--manifest"))
+        .stdout(contains("--spec"))
+        .stdout(contains("--debounce-ms"));
+}
+
+// ---------------------------------------------------------------------------
+// barbacane compile (specs from manifest)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compile_no_specs_and_no_manifest_specs_exits_one() {
+    let tmp = TempDir::new().expect("temp dir");
+    let manifest = tmp.path().join("barbacane.yaml");
+    std::fs::write(&manifest, "plugins: {}\n").expect("write manifest");
+
+    barbacane()
+        .args(["compile", "--manifest"])
+        .arg(&manifest)
+        .arg("--output")
+        .arg(tmp.path().join("out.bca"))
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(contains("no spec files provided"));
+}
+
+#[test]
+fn compile_discovers_specs_from_manifest_folder() {
+    let tmp = TempDir::new().expect("temp dir");
+    let specs_dir = tmp.path().join("specs");
+    std::fs::create_dir_all(&specs_dir).expect("create specs dir");
+
+    // Copy a minimal spec into the specs folder.
+    let spec_content = std::fs::read_to_string(fixtures().join("minimal.yaml")).expect("read spec");
+    std::fs::write(specs_dir.join("api.yaml"), &spec_content).expect("write spec");
+
+    // Manifest with specs folder and the mock plugin declared.
+    let manifest_content = format!(
+        "specs: ./specs/\nplugins:\n  mock:\n    path: {}\n",
+        fixtures().join("../../plugins/mock/mock.wasm").display()
+    );
+    let manifest = tmp.path().join("barbacane.yaml");
+    std::fs::write(&manifest, &manifest_content).expect("write manifest");
+
+    let output = tmp.path().join("out.bca");
+    barbacane()
+        .args(["compile", "--manifest"])
+        .arg(&manifest)
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success()
+        .stderr(contains("compiled 1 spec(s)"));
+
+    assert!(output.exists(), "artifact should be created");
+}

--- a/crates/barbacane-test/src/cli.rs
+++ b/crates/barbacane-test/src/cli.rs
@@ -229,7 +229,11 @@ fn init_creates_project_directory() {
         project.join("barbacane.yaml").exists(),
         "barbacane.yaml missing"
     );
-    assert!(project.join("api.yaml").exists(), "api.yaml missing");
+    assert!(
+        project.join("specs/api.yaml").exists(),
+        "specs/api.yaml missing"
+    );
+    assert!(project.join("specs").is_dir(), "specs/ dir missing");
     assert!(project.join("plugins").is_dir(), "plugins/ dir missing");
     assert!(project.join(".gitignore").exists(), ".gitignore missing");
 }
@@ -245,7 +249,7 @@ fn init_in_current_directory() {
         .success();
 
     assert!(tmp.path().join("barbacane.yaml").exists());
-    assert!(tmp.path().join("api.yaml").exists());
+    assert!(tmp.path().join("specs/api.yaml").exists());
 }
 
 #[test]
@@ -261,7 +265,7 @@ fn init_minimal_template() {
         .success();
 
     assert!(project.join("barbacane.yaml").exists());
-    assert!(project.join("api.yaml").exists());
+    assert!(project.join("specs/api.yaml").exists());
 }
 
 #[test]

--- a/crates/barbacane/Cargo.toml
+++ b/crates/barbacane/Cargo.toml
@@ -44,6 +44,8 @@ arc-swap = "1.7"
 parking_lot = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+notify = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 fips = ["rustls/fips"]
@@ -52,7 +54,6 @@ fips = ["rustls/fips"]
 workspace = true
 
 [dev-dependencies]
-tempfile = { workspace = true }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/barbacane/src/dev.rs
+++ b/crates/barbacane/src/dev.rs
@@ -1,0 +1,208 @@
+//! Dev server file watcher.
+//!
+//! Watches spec files, manifest, and local plugin WASM files for changes,
+//! bridging `notify` events to a tokio channel with debouncing.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
+use tokio::sync::mpsc;
+
+/// File watcher for the dev server.
+///
+/// Watches a set of paths (files and directories) and produces debounced
+/// change notifications via an async channel.
+pub struct DevWatcher {
+    watcher: RecommendedWatcher,
+    rx: mpsc::UnboundedReceiver<PathBuf>,
+    watched: HashSet<PathBuf>,
+}
+
+impl DevWatcher {
+    /// Create a new watcher for the given paths.
+    ///
+    /// Files are watched non-recursively; directories are watched recursively
+    /// (so new spec files in the specs folder are picked up automatically).
+    pub fn new(paths: &[PathBuf]) -> Result<Self, String> {
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        let watcher = RecommendedWatcher::new(
+            move |res: Result<notify::Event, notify::Error>| {
+                if let Ok(event) = res {
+                    for path in event.paths {
+                        let _ = tx.send(path);
+                    }
+                }
+            },
+            Config::default(),
+        )
+        .map_err(|e| format!("failed to create file watcher: {e}"))?;
+
+        let mut dev_watcher = Self {
+            watcher,
+            rx,
+            watched: HashSet::new(),
+        };
+
+        for path in paths {
+            dev_watcher.watch(path)?;
+        }
+
+        Ok(dev_watcher)
+    }
+
+    /// Watch a single path (file or directory).
+    fn watch(&mut self, path: &Path) -> Result<(), String> {
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+
+        if self.watched.contains(&canonical) {
+            return Ok(());
+        }
+
+        let mode = if canonical.is_dir() {
+            RecursiveMode::Recursive
+        } else {
+            RecursiveMode::NonRecursive
+        };
+
+        self.watcher
+            .watch(&canonical, mode)
+            .map_err(|e| format!("failed to watch {}: {e}", canonical.display()))?;
+
+        self.watched.insert(canonical);
+        Ok(())
+    }
+
+    /// Wait for the next batch of file changes, debounced.
+    ///
+    /// Blocks until at least one change arrives, then collects any additional
+    /// changes within the debounce window. Returns deduplicated changed paths.
+    pub async fn next_change(&mut self, debounce: Duration) -> Vec<PathBuf> {
+        // Wait for first event.
+        let first = match self.rx.recv().await {
+            Some(p) => p,
+            None => return vec![],
+        };
+
+        let mut changed = vec![first];
+        let deadline = tokio::time::Instant::now() + debounce;
+
+        // Drain additional events within debounce window.
+        loop {
+            tokio::select! {
+                _ = tokio::time::sleep_until(deadline) => break,
+                path = self.rx.recv() => {
+                    match path {
+                        Some(p) => {
+                            if !changed.contains(&p) {
+                                changed.push(p);
+                            }
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+
+        changed
+    }
+
+    /// Replace the set of watched paths.
+    ///
+    /// Unwatches paths no longer in the set and watches new ones.
+    pub fn update_watches(&mut self, new_paths: &[PathBuf]) -> Result<(), String> {
+        let new_set: HashSet<PathBuf> = new_paths
+            .iter()
+            .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
+            .collect();
+
+        // Unwatch removed paths.
+        let to_remove: Vec<PathBuf> = self.watched.difference(&new_set).cloned().collect();
+
+        for path in &to_remove {
+            let _ = self.watcher.unwatch(path);
+            self.watched.remove(path);
+        }
+
+        // Watch new paths.
+        for path in &new_set {
+            if !self.watched.contains(path) {
+                self.watch(path)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watcher_creation_with_valid_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("test.yaml");
+        std::fs::write(&file, "test").unwrap();
+
+        let watcher = DevWatcher::new(&[file.clone()]);
+        assert!(watcher.is_ok());
+    }
+
+    #[test]
+    fn watcher_creation_with_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let watcher = DevWatcher::new(&[temp.path().to_path_buf()]);
+        assert!(watcher.is_ok());
+    }
+
+    #[tokio::test]
+    async fn watcher_detects_file_change() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("test.yaml");
+        std::fs::write(&file, "v1").unwrap();
+
+        let mut watcher = DevWatcher::new(&[file.clone()]).unwrap();
+
+        // Write a change after a small delay.
+        let file_clone = file.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            std::fs::write(&file_clone, "v2").unwrap();
+        });
+
+        let changed = tokio::time::timeout(
+            Duration::from_secs(5),
+            watcher.next_change(Duration::from_millis(200)),
+        )
+        .await
+        .expect("timed out waiting for change");
+
+        assert!(!changed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn watcher_detects_new_file_in_directory() {
+        let temp = tempfile::tempdir().unwrap();
+
+        let mut watcher = DevWatcher::new(&[temp.path().to_path_buf()]).unwrap();
+
+        // Create a new file after a small delay.
+        let dir = temp.path().to_path_buf();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            std::fs::write(dir.join("new.yaml"), "content").unwrap();
+        });
+
+        let changed = tokio::time::timeout(
+            Duration::from_secs(5),
+            watcher.next_change(Duration::from_millis(200)),
+        )
+        .await
+        .expect("timed out waiting for change");
+
+        assert!(!changed.is_empty());
+    }
+}

--- a/crates/barbacane/src/lib.rs
+++ b/crates/barbacane/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod admin;
 pub mod control_plane;
+pub mod dev;
 pub mod hot_reload;
 pub mod mcp;
 pub mod router;

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -430,7 +430,8 @@ enum Commands {
     /// Compile OpenAPI spec(s) into a .bca artifact.
     Compile {
         /// Input spec file(s) (YAML or JSON).
-        #[arg(short, long, required = true, num_args = 1..)]
+        /// If omitted, discovers specs from the manifest's `specs` folder.
+        #[arg(short, long, num_args = 1..)]
         spec: Vec<String>,
 
         /// Output artifact path.
@@ -488,6 +489,37 @@ enum Commands {
         /// Download official plugins (mock, http-upstream) from GitHub releases.
         #[arg(long)]
         fetch_plugins: bool,
+    },
+
+    /// Start a local development server with auto-reload.
+    ///
+    /// Compiles specs from barbacane.yaml, starts the gateway, watches for
+    /// file changes, and hot-reloads automatically. Equivalent to running
+    /// compile + serve in a loop.
+    Dev {
+        /// Listen address.
+        #[arg(long, default_value = "0.0.0.0:8080")]
+        listen: String,
+
+        /// Path to barbacane.yaml manifest.
+        #[arg(short, long, default_value = "barbacane.yaml")]
+        manifest: String,
+
+        /// Override spec files (uses these instead of the manifest's specs folder).
+        #[arg(short, long)]
+        spec: Vec<String>,
+
+        /// Log level (error, warn, info, debug, trace).
+        #[arg(long, default_value = "info")]
+        log_level: String,
+
+        /// Admin API listen address. Set to "off" to disable.
+        #[arg(long, default_value = "127.0.0.1:8081")]
+        admin_bind: String,
+
+        /// Debounce delay in milliseconds before recompiling after a file change.
+        #[arg(long, default_value = "300")]
+        debounce_ms: u64,
     },
 
     /// Run the gateway server.
@@ -2932,10 +2964,16 @@ async fn run_init(name: &str, template: &str, fetch_plugins: bool) -> ExitCode {
         }
     }
 
-    // Create plugins directory
+    // Create plugins and specs directories
     let plugins_dir = project_dir.join("plugins");
     if let Err(e) = fs::create_dir_all(&plugins_dir) {
         eprintln!("error: failed to create plugins directory: {}", e);
+        return ExitCode::from(1);
+    }
+
+    let specs_dir = project_dir.join("specs");
+    if let Err(e) = fs::create_dir_all(&specs_dir) {
+        eprintln!("error: failed to create specs directory: {}", e);
         return ExitCode::from(1);
     }
 
@@ -2963,6 +3001,8 @@ async fn run_init(name: &str, template: &str, fetch_plugins: bool) -> ExitCode {
         r#"# Barbacane project manifest
 # See https://barbacane.dev/docs/guide/spec-configuration for details
 
+specs: ./specs/
+
 plugins: {}
   # Example plugin configuration:
   # my-plugin:
@@ -2973,6 +3013,7 @@ plugins: {}
         let mut content = String::from(
             "# Barbacane project manifest\n\
              # See https://barbacane.dev/docs/guide/spec-configuration for details\n\n\
+             specs: ./specs/\n\n\
              plugins:\n",
         );
         for (plugin_name, filename) in &downloaded_plugins {
@@ -3135,8 +3176,8 @@ paths:
 "#
     };
 
-    if let Err(e) = fs::write(project_dir.join("api.yaml"), spec_content) {
-        eprintln!("error: failed to create api.yaml: {}", e);
+    if let Err(e) = fs::write(specs_dir.join("api.yaml"), spec_content) {
+        eprintln!("error: failed to create specs/api.yaml: {}", e);
         return ExitCode::from(1);
     }
 
@@ -3170,9 +3211,9 @@ Thumbs.db
     eprintln!("✓ Initialized Barbacane project in {}", dir_name);
     eprintln!();
     eprintln!("Created:");
-    eprintln!("  barbacane.yaml  - project manifest");
+    eprintln!("  barbacane.yaml    - project manifest");
     eprintln!(
-        "  api.yaml        - OpenAPI specification ({} template)",
+        "  specs/api.yaml    - OpenAPI specification ({} template)",
         template
     );
     if !downloaded_plugins.is_empty() {
@@ -3180,25 +3221,19 @@ Thumbs.db
             eprintln!("  plugins/{}  - {} plugin", filename, plugin_name);
         }
     } else {
-        eprintln!("  plugins/        - directory for WASM plugins");
+        eprintln!("  plugins/          - directory for WASM plugins");
     }
-    eprintln!("  .gitignore      - Git ignore file");
+    eprintln!("  .gitignore        - Git ignore file");
     eprintln!();
     eprintln!("Next steps:");
     if downloaded_plugins.is_empty() && !fetch_plugins {
         eprintln!("  1. Download plugins: barbacane init . --fetch-plugins");
         eprintln!("     Or add them manually to plugins/");
-        eprintln!("  2. Edit api.yaml to define your API");
-        eprintln!(
-            "  3. Run: barbacane compile --spec api.yaml --manifest barbacane.yaml --output api.bca"
-        );
-        eprintln!("  4. Run: barbacane serve --artifact api.bca --dev");
+        eprintln!("  2. Edit specs/api.yaml to define your API");
+        eprintln!("  3. Run: barbacane dev");
     } else {
-        eprintln!("  1. Edit api.yaml to define your API");
-        eprintln!(
-            "  2. Run: barbacane compile --spec api.yaml --manifest barbacane.yaml --output api.bca"
-        );
-        eprintln!("  3. Run: barbacane serve --artifact api.bca --dev");
+        eprintln!("  1. Edit specs/api.yaml to define your API");
+        eprintln!("  2. Run: barbacane dev");
     }
 
     ExitCode::SUCCESS
@@ -3318,16 +3353,7 @@ fn run_compile(
     provenance_source: Option<String>,
     no_cache: bool,
 ) -> ExitCode {
-    let spec_paths: Vec<&Path> = specs.iter().map(Path::new).collect();
     let output_path = Path::new(output);
-
-    // Check that all spec files exist
-    for path in &spec_paths {
-        if !path.exists() {
-            eprintln!("error: spec file not found: {}", path.display());
-            return ExitCode::from(1);
-        }
-    }
 
     let options = CompileOptions {
         allow_plaintext,
@@ -3354,6 +3380,38 @@ fn run_compile(
 
     // Get the base path for resolving plugin paths (directory containing the manifest)
     let base_path = manifest_path.parent().unwrap_or(Path::new("."));
+
+    // Determine spec paths: from --spec args, or discover from manifest's specs folder.
+    let discovered_specs: Vec<std::path::PathBuf>;
+    let spec_paths: Vec<&Path> = if !specs.is_empty() {
+        specs.iter().map(Path::new).collect()
+    } else {
+        match project_manifest.discover_spec_files(base_path) {
+            Ok(paths) if paths.is_empty() => {
+                eprintln!(
+                    "error: no spec files provided. Use --spec or add 'specs: ./specs/' to {}",
+                    manifest_file
+                );
+                return ExitCode::from(1);
+            }
+            Ok(paths) => {
+                discovered_specs = paths;
+                discovered_specs.iter().map(|p| p.as_path()).collect()
+            }
+            Err(e) => {
+                eprintln!("error: {}", e);
+                return ExitCode::from(1);
+            }
+        }
+    };
+
+    // Check that all spec files exist
+    for path in &spec_paths {
+        if !path.exists() {
+            eprintln!("error: spec file not found: {}", path.display());
+            return ExitCode::from(1);
+        }
+    }
 
     let result = compile_with_manifest(
         &spec_paths,
@@ -3387,7 +3445,7 @@ fn run_compile(
             };
             eprintln!(
                 "compiled {} spec(s) to {} ({} routes{})",
-                specs.len(),
+                spec_paths.len(),
                 output,
                 manifest.routes_count,
                 plugin_info
@@ -3399,6 +3457,450 @@ fn run_compile(
             ExitCode::from(1)
         }
     }
+}
+
+/// Run the dev server: compile, serve, watch, and hot-reload on changes.
+async fn run_dev(
+    manifest_file: &str,
+    spec_overrides: &[String],
+    listen: &str,
+    metrics: Arc<MetricsRegistry>,
+    admin_bind: &str,
+    debounce_ms: u64,
+) -> ExitCode {
+    use barbacane_lib::dev::DevWatcher;
+
+    let manifest_path = Path::new(manifest_file);
+    if !manifest_path.exists() {
+        eprintln!("barbacane dev: manifest not found: {}", manifest_file);
+        return ExitCode::from(1);
+    }
+
+    let manifest_dir = manifest_path
+        .parent()
+        .unwrap_or(Path::new("."))
+        .to_path_buf();
+
+    // Load manifest.
+    let mut project_manifest = match ProjectManifest::load(manifest_path) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("barbacane dev: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+
+    // Determine spec files.
+    let mut spec_paths = if !spec_overrides.is_empty() {
+        spec_overrides
+            .iter()
+            .map(std::path::PathBuf::from)
+            .collect()
+    } else {
+        match project_manifest.discover_spec_files(&manifest_dir) {
+            Ok(paths) if paths.is_empty() => {
+                eprintln!(
+                    "barbacane dev: no specs found. Add 'specs: ./specs/' to {} or pass --spec",
+                    manifest_file
+                );
+                return ExitCode::from(1);
+            }
+            Ok(paths) => paths,
+            Err(e) => {
+                eprintln!("barbacane dev: {}", e);
+                return ExitCode::from(1);
+            }
+        }
+    };
+
+    let spec_count = spec_paths.len();
+    let plugin_count = project_manifest.plugins.len();
+    eprintln!(
+        "barbacane dev: loaded {} ({} spec(s), {} plugin(s))",
+        manifest_file, spec_count, plugin_count,
+    );
+
+    // Initial compile.
+    // no_cache is false: local path: plugins are always read fresh from disk,
+    // and url: plugins should use the download cache to avoid re-fetching on every reload.
+    let compile_options = CompileOptions {
+        allow_plaintext: true,
+        ..Default::default()
+    };
+
+    let mut temp_artifact = match tempfile::NamedTempFile::new() {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("barbacane dev: failed to create temp file: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+
+    let temp_path = temp_artifact.path().to_path_buf();
+
+    let spec_refs: Vec<&Path> = spec_paths.iter().map(|p| p.as_path()).collect();
+    let compile_start = Instant::now();
+    if let Err(e) = compile_with_manifest(
+        &spec_refs,
+        &project_manifest,
+        &manifest_dir,
+        &temp_path,
+        &compile_options,
+    ) {
+        eprintln!("barbacane dev: compile error: {}", e);
+        return ExitCode::from(1);
+    }
+    let compile_ms = compile_start.elapsed().as_millis();
+
+    // Load gateway.
+    let limits = RequestLimits::default();
+    let gateway: SharedGateway =
+        match Gateway::load(&temp_path, true, limits.clone(), true, metrics.clone()) {
+            Ok(g) => {
+                eprintln!(
+                    "barbacane dev: compiled {} route(s) in {}ms",
+                    g.manifest.routes_count, compile_ms
+                );
+                Arc::new(ArcSwap::new(Arc::new(g)))
+            }
+            Err(e) => {
+                eprintln!("barbacane dev: {}", e);
+                return ExitCode::from(1);
+            }
+        };
+
+    // Parse listen address.
+    let addr: SocketAddr = match listen.parse() {
+        Ok(a) => a,
+        Err(_) => {
+            eprintln!("barbacane dev: invalid listen address: {}", listen);
+            return ExitCode::from(1);
+        }
+    };
+
+    let listener = match TcpListener::bind(addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("barbacane dev: failed to bind to {}: {}", addr, e);
+            return ExitCode::from(1);
+        }
+    };
+
+    eprintln!("barbacane dev: listening on http://{}", addr);
+
+    // Shutdown signal.
+    let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+    let shutdown_tx_clone = shutdown_tx.clone();
+    tokio::spawn(async move {
+        let _ = wait_for_shutdown_signal().await;
+        eprintln!("\nbarbacane dev: shutting down...");
+        let _ = shutdown_tx_clone.send(true);
+    });
+
+    // Admin API.
+    let admin_manifest: Arc<ArcSwap<barbacane_compiler::Manifest>> = {
+        let gw = gateway.load();
+        Arc::new(ArcSwap::new(Arc::new(gw.manifest.clone())))
+    };
+    let drift_detected = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    if admin_bind != "off" {
+        let admin_addr: SocketAddr = match admin_bind.parse() {
+            Ok(a) => a,
+            Err(e) => {
+                eprintln!(
+                    "barbacane dev: invalid --admin-bind address '{}': {}",
+                    admin_bind, e
+                );
+                return ExitCode::from(1);
+            }
+        };
+
+        let admin_state = Arc::new(admin::AdminState {
+            manifest: admin_manifest.clone(),
+            metrics: metrics.clone(),
+            drift_detected: drift_detected.clone(),
+            started_at: Instant::now(),
+        });
+
+        let admin_shutdown_rx = shutdown_rx.clone();
+        tokio::spawn(async move {
+            if let Err(e) =
+                admin::start_admin_server(admin_addr, admin_state, admin_shutdown_rx).await
+            {
+                tracing::error!(error = %e, "Admin server failed");
+            }
+        });
+        eprintln!("barbacane dev: admin API on http://{}", admin_addr);
+    }
+
+    // File watcher.
+    let mut watch_paths: Vec<std::path::PathBuf> = vec![manifest_path
+        .canonicalize()
+        .unwrap_or(manifest_path.to_path_buf())];
+
+    // Watch spec sources: specs folder (if using manifest discovery) or individual files (if --spec overrides).
+    if spec_overrides.is_empty() {
+        if let Some(ref specs_dir) = project_manifest.specs {
+            let resolved = if Path::new(specs_dir).is_absolute() {
+                std::path::PathBuf::from(specs_dir)
+            } else {
+                manifest_dir.join(specs_dir)
+            };
+            if resolved.is_dir() {
+                watch_paths.push(resolved);
+            }
+        } else {
+            for p in &spec_paths {
+                watch_paths.push(p.clone());
+            }
+        }
+    } else {
+        for p in &spec_paths {
+            watch_paths.push(p.clone());
+        }
+    }
+
+    // Watch local plugin .wasm files.
+    for p in project_manifest.local_plugin_paths(&manifest_dir) {
+        if p.exists() {
+            watch_paths.push(p);
+        }
+    }
+
+    let watch_display: Vec<String> = watch_paths
+        .iter()
+        .filter_map(|p| p.strip_prefix(&manifest_dir).ok().or(Some(p.as_path())))
+        .map(|p| p.display().to_string())
+        .collect();
+    eprintln!("barbacane dev: watching {}", watch_display.join(", "));
+
+    let mut watcher = match DevWatcher::new(&watch_paths) {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!("barbacane dev: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+
+    let debounce = Duration::from_millis(debounce_ms);
+
+    // MCP session eviction task.
+    {
+        let gw = gateway.clone();
+        let mut evict_shutdown = shutdown_rx.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(300));
+            interval.tick().await;
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let g = gw.load();
+                        if let Some(ref mcp) = g.mcp_server {
+                            mcp.evict_expired_sessions();
+                        }
+                    }
+                    _ = evict_shutdown.changed() => break,
+                }
+            }
+        });
+    }
+
+    // Main loop: accept connections + watch for file changes.
+    loop {
+        tokio::select! {
+            // Shutdown.
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() {
+                    break;
+                }
+            }
+            // File change detected.
+            changed = watcher.next_change(debounce) => {
+                if changed.is_empty() {
+                    continue;
+                }
+
+                let changed_display: Vec<String> = changed
+                    .iter()
+                    .filter_map(|p| p.strip_prefix(&manifest_dir).ok().or(Some(p.as_path())))
+                    .map(|p| p.display().to_string())
+                    .collect();
+                eprint!("barbacane dev: [{}] recompiling...", changed_display.join(", "));
+
+                // Re-read manifest if it changed.
+                let manifest_canonical = manifest_path
+                    .canonicalize()
+                    .unwrap_or(manifest_path.to_path_buf());
+                let manifest_changed = changed.iter().any(|p| {
+                    p.canonicalize().unwrap_or(p.clone()) == manifest_canonical
+                });
+
+                if manifest_changed {
+                    match ProjectManifest::load(manifest_path) {
+                        Ok(m) => project_manifest = m,
+                        Err(e) => {
+                            eprintln!(" manifest error: {}", e);
+                            eprintln!("barbacane dev: serving previous version");
+                            continue;
+                        }
+                    }
+                }
+
+                // Re-discover specs if using manifest folder (picks up additions/removals).
+                if spec_overrides.is_empty() {
+                    match project_manifest.discover_spec_files(&manifest_dir) {
+                        Ok(paths) if !paths.is_empty() => spec_paths = paths,
+                        Ok(_) => {
+                            eprintln!(" no spec files found");
+                            eprintln!("barbacane dev: serving previous version");
+                            continue;
+                        }
+                        Err(e) => {
+                            eprintln!(" {}", e);
+                            eprintln!("barbacane dev: serving previous version");
+                            continue;
+                        }
+                    }
+                }
+
+                // Compile to new temp file.
+                let new_temp = match tempfile::NamedTempFile::new() {
+                    Ok(f) => f,
+                    Err(e) => {
+                        eprintln!(" temp file error: {}", e);
+                        continue;
+                    }
+                };
+                let new_path = new_temp.path().to_path_buf();
+
+                let spec_refs: Vec<&Path> = spec_paths.iter().map(|p| p.as_path()).collect();
+                let compile_start = Instant::now();
+                if let Err(e) = compile_with_manifest(
+                    &spec_refs,
+                    &project_manifest,
+                    &manifest_dir,
+                    &new_path,
+                    &compile_options,
+                ) {
+                    eprintln!(" compile error: {}", e);
+                    eprintln!("barbacane dev: serving previous version");
+                    continue;
+                }
+
+                // Load new gateway.
+                match Gateway::load(&new_path, true, limits.clone(), true, metrics.clone()) {
+                    Ok(new_gw) => {
+                        let routes = new_gw.manifest.routes_count;
+                        let ms = compile_start.elapsed().as_millis();
+
+                        // Atomic swap.
+                        let old = gateway.swap(Arc::new(new_gw));
+                        tokio::task::spawn_blocking(move || drop(old));
+
+                        // Update admin manifest.
+                        let gw = gateway.load();
+                        admin_manifest.store(Arc::new(gw.manifest.clone()));
+
+                        // Replace temp artifact.
+                        temp_artifact = new_temp;
+
+                        eprintln!(" reloaded {} route(s) in {}ms", routes, ms);
+                    }
+                    Err(e) => {
+                        eprintln!(" load error: {}", e);
+                        eprintln!("barbacane dev: serving previous version");
+                    }
+                }
+
+                // Update watches if manifest changed (new plugins or specs folder).
+                if manifest_changed {
+                    let mut new_watch_paths: Vec<std::path::PathBuf> = vec![
+                        manifest_path.canonicalize().unwrap_or(manifest_path.to_path_buf()),
+                    ];
+                    if let Some(ref specs_dir) = project_manifest.specs {
+                        let resolved = if Path::new(specs_dir).is_absolute() {
+                            std::path::PathBuf::from(specs_dir)
+                        } else {
+                            manifest_dir.join(specs_dir)
+                        };
+                        if resolved.is_dir() {
+                            new_watch_paths.push(resolved);
+                        }
+                    }
+                    for p in project_manifest.local_plugin_paths(&manifest_dir) {
+                        if p.exists() {
+                            new_watch_paths.push(p);
+                        }
+                    }
+                    if let Err(e) = watcher.update_watches(&new_watch_paths) {
+                        tracing::warn!(error = %e, "failed to update file watches");
+                    }
+                }
+            }
+            // Accept new connection.
+            accept_result = listener.accept() => {
+                let (stream, peer_addr) = match accept_result {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        tracing::debug!(error = %e, "accept failed");
+                        continue;
+                    }
+                };
+
+                metrics.connection_opened();
+
+                let gateway_snapshot = gateway.load_full();
+                let conn_metrics = metrics.clone();
+                let mut conn_shutdown_rx = shutdown_rx.clone();
+                let client_addr = Some(peer_addr);
+
+                tokio::spawn(async move {
+                    let service = service_fn(move |req| {
+                        let gateway = Arc::clone(&gateway_snapshot);
+                        let client_addr = client_addr;
+                        async move { gateway.handle_request(req, client_addr).await }
+                    });
+
+                    let io = TokioIo::new(stream);
+                    let mut builder = auto::Builder::new(TokioExecutor::new());
+                    builder.http1().keep_alive(true);
+                    builder
+                        .http2()
+                        .timer(TokioTimer::new())
+                        .keep_alive_interval(Some(Duration::from_secs(20)));
+                    let conn = builder.serve_connection_with_upgrades(io, service);
+
+                    tokio::pin!(conn);
+
+                    loop {
+                        tokio::select! {
+                            result = conn.as_mut() => {
+                                if let Err(e) = result {
+                                    if !e.to_string().contains("connection closed") {
+                                        tracing::debug!(error = %e, "connection error");
+                                    }
+                                }
+                                break;
+                            }
+                            _ = conn_shutdown_rx.changed() => {
+                                if *conn_shutdown_rx.borrow() {
+                                    conn.as_mut().graceful_shutdown();
+                                }
+                            }
+                        }
+                    }
+
+                    conn_metrics.connection_closed();
+                });
+            }
+        }
+    }
+
+    // Clean up temp artifact.
+    drop(temp_artifact);
+
+    ExitCode::SUCCESS
 }
 
 /// TLS configuration for the server.
@@ -3976,6 +4478,37 @@ async fn main() -> ExitCode {
             no_cache,
         ),
         Commands::Validate { spec, format } => run_validate(&spec, &format),
+        Commands::Dev {
+            listen,
+            manifest,
+            spec,
+            log_level,
+            admin_bind,
+            debounce_ms,
+        } => {
+            let log_fmt = barbacane_telemetry::LogFormat::Pretty;
+            let telemetry_config = barbacane_telemetry::TelemetryConfig::new()
+                .with_log_level(&log_level)
+                .with_log_format(log_fmt);
+
+            let telemetry = match barbacane_telemetry::Telemetry::init(telemetry_config) {
+                Ok(t) => t,
+                Err(e) => {
+                    eprintln!("error: failed to initialize telemetry: {}", e);
+                    return ExitCode::from(1);
+                }
+            };
+
+            run_dev(
+                &manifest,
+                &spec,
+                &listen,
+                telemetry.metrics_clone(),
+                &admin_bind,
+                debounce_ms,
+            )
+            .await
+        }
         Commands::Init {
             name,
             template,

--- a/deny.toml
+++ b/deny.toml
@@ -8,4 +8,7 @@ ignore = [
 
     # CRL Distribution Point matching logic in rustls-webpki 0.102.x — pinned by async-nats
     "RUSTSEC-2026-0049",
+
+    # instant crate unmaintained — pinned by notify 7.x (transitive via notify-types), no safe upgrade
+    "RUSTSEC-2024-0384",
 ]

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -114,11 +114,16 @@ cargo test -p barbacane-router trie::tests::static_takes_precedence
 ### Run
 
 ```bash
+# Dev server (auto-compiles and hot-reloads on save)
+cargo run --bin barbacane -- dev --manifest tests/fixtures/barbacane.yaml --spec tests/fixtures/minimal.yaml
+
+# Or the manual workflow:
 # Validate a spec
 cargo run --bin barbacane -- validate --spec tests/fixtures/minimal.yaml
 
 # Compile a spec
-cargo run --bin barbacane -- compile --spec tests/fixtures/minimal.yaml --output test.bca
+cargo run --bin barbacane -- compile --spec tests/fixtures/minimal.yaml \
+  --manifest tests/fixtures/barbacane.yaml --output test.bca
 
 # Run the gateway
 cargo run --bin barbacane -- serve --artifact test.bca --listen 127.0.0.1:8080 --dev

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -99,8 +99,8 @@ cd my-api
 ```
 
 This creates:
-- `barbacane.yaml` — project manifest with plugins configured
-- `api.yaml` — OpenAPI spec with example endpoints
+- `barbacane.yaml` — project manifest with plugins and specs folder configured
+- `specs/api.yaml` — OpenAPI spec with example endpoints
 - `plugins/mock.wasm` — mock dispatcher plugin
 - `plugins/http-upstream.wasm` — HTTP proxy plugin
 - `.gitignore` — ignores build artifacts
@@ -111,7 +111,13 @@ For a minimal skeleton without example endpoints:
 barbacane init my-api --template minimal --fetch-plugins
 ```
 
-Skip to [Step 3: Validate the Spec](#3-validate-the-spec) if using `barbacane init`.
+If using `barbacane init`, you can skip straight to running the gateway:
+
+```bash
+barbacane dev
+```
+
+Or continue below for the manual step-by-step setup.
 
 ### 1. Create an OpenAPI Spec
 
@@ -173,9 +179,11 @@ The key additions are:
 
 ### 2. Create a Manifest
 
-Create a `barbacane.yaml` manifest to declare which plugins to use:
+Create a `barbacane.yaml` manifest to declare your specs folder and plugins:
 
 ```yaml
+specs: ./specs/
+
 plugins:
   mock:
     path: ./plugins/mock.wasm
@@ -183,7 +191,9 @@ plugins:
     path: ./plugins/http-upstream.wasm
 ```
 
-The manifest declares all WASM plugins used by your spec. Plugins can be sourced from a local path or a remote URL:
+The `specs` field points to a folder containing your spec files — all `*.yaml`/`*.json` files are discovered automatically. This enables `barbacane dev` and `barbacane compile` to work without explicit `--spec` flags.
+
+The manifest also declares all WASM plugins used by your spec. Plugins can be sourced from a local path or a remote URL:
 - **Local path**: `path: ./plugins/name.wasm`
 - **Remote URL**: `url: https://github.com/barbacane-dev/barbacane/releases/download/v0.5.2/name.wasm`
 
@@ -274,13 +284,17 @@ curl -X POST http://127.0.0.1:8080/health
 
 ## Development Mode
 
-The `--dev` flag enables:
-- Verbose error messages with dispatcher details
-- Detailed logging
-- No production-only restrictions
+For the fastest development workflow, use `barbacane dev`:
 
-For production, omit the flag:
 ```bash
+barbacane dev
+```
+
+This compiles your specs, starts the gateway, and watches for file changes. Every time you save a spec or plugin, the gateway recompiles and hot-reloads automatically — no manual compile-serve cycle needed.
+
+For production, use the explicit compile-and-serve workflow:
+```bash
+barbacane compile -m barbacane.yaml -o api.bca
 barbacane serve --artifact api.bca --listen 0.0.0.0:8080
 ```
 

--- a/docs/guide/spec-configuration.md
+++ b/docs/guide/spec-configuration.md
@@ -65,6 +65,41 @@ A `GET /files/my-bucket/docs/2024/report.pdf` request captures `bucket=my-bucket
 
 ---
 
+## Project Manifest (`barbacane.yaml`)
+
+The manifest declares the specs folder and plugins available to the gateway:
+
+```yaml
+specs: ./specs/
+
+plugins:
+  mock:
+    path: ./plugins/mock.wasm
+  http-upstream:
+    path: ./plugins/http-upstream.wasm
+  jwt-auth:
+    url: https://github.com/barbacane-dev/barbacane/releases/download/v0.6.3/jwt-auth.wasm
+    sha256: abc123...
+```
+
+### `specs` (optional)
+
+Path to a folder containing spec files (relative to the manifest). All `*.yaml`, `*.yml`, and `*.json` files in this folder are discovered as specs.
+
+Used by:
+- `barbacane dev` — auto-discovers specs for compilation and file watching
+- `barbacane compile` — falls back to this folder when `--spec` is not provided
+
+### `plugins` (required)
+
+Declares all WASM plugins used by your specs. Each plugin maps a name to a source:
+
+- **Local path**: `path: ./plugins/name.wasm` — relative to the manifest directory
+- **Remote URL**: `url: https://...` — downloaded at compile time, cached in `~/.barbacane/cache/plugins/`
+- **Checksum** (optional): `sha256: ...` — integrity verification for remote plugins
+
+---
+
 ## Dispatchers
 
 Every operation needs an `x-barbacane-dispatch` to tell Barbacane how to handle it:

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,11 +57,17 @@ cd barbacane
 cargo build --release
 make plugins
 
-# Compile your OpenAPI spec
-./target/release/barbacane compile --spec api.yaml --manifest barbacane.yaml --output api.bca
+# Initialize a project and start the dev server
+./target/release/barbacane init my-api --fetch-plugins
+cd my-api
+../target/release/barbacane dev
+```
 
-# Run the gateway
-./target/release/barbacane serve --artifact api.bca --listen 0.0.0.0:8080
+For production, use the explicit compile-and-serve workflow:
+
+```bash
+barbacane compile -m barbacane.yaml -o api.bca
+barbacane serve --artifact api.bca --listen 0.0.0.0:8080
 ```
 
 ## Documentation

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -15,6 +15,7 @@ barbacane <COMMAND> [OPTIONS]
 | Command | Description |
 |---------|-------------|
 | `init` | Initialize a new Barbacane project |
+| `dev` | Start a local development server with auto-reload |
 | `compile` | Compile OpenAPI spec(s) into a `.bca` artifact |
 | `validate` | Validate spec(s) without compiling |
 | `serve` | Run the gateway server |
@@ -93,8 +94,9 @@ barbacane init my-api -t minimal
 
 ```
 my-api/
-├── barbacane.yaml    # Project manifest (plugin declarations)
-├── api.yaml          # OpenAPI 3.1 specification
+├── barbacane.yaml    # Project manifest (plugin declarations, specs folder)
+├── specs/
+│   └── api.yaml      # OpenAPI 3.1 specification
 ├── plugins/          # Directory for WASM plugins
 └── .gitignore        # Ignores *.bca, target/, plugins/*.wasm
 ```
@@ -108,19 +110,97 @@ my-api/
 
 ---
 
-## barbacane compile
+## barbacane dev
 
-Compile one or more OpenAPI specs into a `.bca` artifact.
+Start a local development server with automatic file watching and hot-reload. Compiles specs from `barbacane.yaml`, starts the gateway, watches for file changes, and reloads automatically on every save.
 
 ```bash
-barbacane compile --spec <FILES>... --manifest <PATH> --output <PATH>
+barbacane dev [OPTIONS]
 ```
 
 ### Options
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
-| `--spec`, `-s` | Yes | - | One or more spec files (YAML or JSON) |
+| `--listen` | No | `0.0.0.0:8080` | Listen address |
+| `--manifest`, `-m` | No | `barbacane.yaml` | Path to `barbacane.yaml` manifest |
+| `--spec`, `-s` | No | - | Override spec files (uses these instead of the manifest's `specs` folder) |
+| `--log-level` | No | `info` | Log level (trace, debug, info, warn, error) |
+| `--admin-bind` | No | `127.0.0.1:8081` | Admin API listen address. Set to `off` to disable |
+| `--debounce-ms` | No | `300` | Debounce delay in milliseconds before recompiling after a file change |
+
+Dev mode is always enabled (verbose errors, plaintext HTTP upstreams allowed).
+
+### Spec Discovery
+
+The dev server discovers spec files from the `specs` field in `barbacane.yaml`:
+
+```yaml
+specs: ./specs/
+plugins:
+  mock:
+    path: ./plugins/mock.wasm
+```
+
+All `*.yaml`, `*.yml`, and `*.json` files in the specified folder are compiled. New files added to the folder are picked up on the next reload.
+
+Use `--spec` to override the manifest's specs folder with explicit files.
+
+### File Watching
+
+The dev server watches for changes to:
+- `barbacane.yaml` manifest
+- The `specs` folder (recursively — new files are detected)
+- All local plugin `.wasm` files referenced in the manifest
+
+On file change, the server recompiles and hot-reloads the gateway. If compilation fails, the previous version continues serving while the error is printed to stderr.
+
+### Examples
+
+```bash
+# Start with default settings (reads barbacane.yaml in current directory)
+barbacane dev
+
+# Custom manifest and port
+barbacane dev --manifest path/to/barbacane.yaml --listen 127.0.0.1:3000
+
+# Override spec files instead of using manifest's specs folder
+barbacane dev --spec api.yaml --spec events.yaml
+
+# Increase debounce for slow plugin builds
+barbacane dev --debounce-ms 1000
+```
+
+### Example Output
+
+```
+barbacane dev: loaded barbacane.yaml (2 spec(s), 3 plugin(s))
+barbacane dev: compiled 5 route(s) in 42ms
+barbacane dev: listening on http://0.0.0.0:8080
+barbacane dev: admin API on http://127.0.0.1:8081
+barbacane dev: watching barbacane.yaml, specs/, plugins/mock.wasm
+
+[specs/api.yaml] recompiling... reloaded 5 route(s) in 38ms
+
+[specs/api.yaml] recompiling... compile error: E1010 — missing x-barbacane-dispatch on GET /users
+barbacane dev: serving previous version
+```
+
+---
+
+## barbacane compile
+
+Compile one or more OpenAPI specs into a `.bca` artifact.
+
+```bash
+barbacane compile [--spec <FILES>...] --manifest <PATH> --output <PATH>
+```
+
+### Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--spec`, `-s` | No | - | One or more spec files (YAML or JSON). If omitted, discovers specs from the manifest's `specs` folder |
 | `--output`, `-o` | Yes | - | Output artifact path |
 | `--manifest`, `-m` | Yes | - | Path to `barbacane.yaml` manifest |
 | `--allow-plaintext` | No | `false` | Allow `http://` upstream URLs during compilation |
@@ -131,6 +211,9 @@ barbacane compile --spec <FILES>... --manifest <PATH> --output <PATH>
 ### Examples
 
 ```bash
+# Compile using specs folder from manifest (zero spec args)
+barbacane compile -m barbacane.yaml -o api.bca
+
 # Compile single spec with manifest
 barbacane compile --spec api.yaml --manifest barbacane.yaml --output api.bca
 
@@ -585,16 +668,12 @@ See [Secrets Guide](../guide/secrets.md) for full documentation.
 ### Development Cycle
 
 ```bash
-# Edit spec and manifest
-vim api.yaml barbacane.yaml
+# Recommended: use the dev server (auto-compiles and hot-reloads on save)
+barbacane dev
 
-# Validate (quick check)
+# Or manually: edit, compile, serve
 barbacane validate --spec api.yaml
-
-# Compile with manifest
 barbacane compile --spec api.yaml --manifest barbacane.yaml --output api.bca
-
-# Run in dev mode
 barbacane serve --artifact api.bca --dev
 ```
 
@@ -637,8 +716,8 @@ barbacane compile \
 ### Testing Locally
 
 ```bash
-# Start gateway
-barbacane serve --artifact api.bca --dev --listen 127.0.0.1:8080 &
+# Start dev server (auto-compiles and reloads)
+barbacane dev --listen 127.0.0.1:8080 &
 
 # Test endpoints
 curl http://localhost:8080/health


### PR DESCRIPTION
## Summary

- Add `barbacane dev` CLI command — compiles specs, starts the gateway, watches for file changes (specs folder, manifest, local plugin `.wasm` files), and hot-reloads automatically via ArcSwap. Compile errors print to stderr while the previous version keeps serving.
- Add `specs` folder field to `barbacane.yaml` — point to a directory (e.g. `specs: ./specs/`) and all `*.yaml`/`*.json` files are discovered automatically. Used by `barbacane dev` for zero-config and as a fallback for `barbacane compile` when `--spec` is omitted.
- Update `barbacane init` to scaffold a `specs/` directory with the generated spec and `specs: ./specs/` in the manifest.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --lib --bins` — zero warnings
- [x] `cargo test --workspace` — 518 tests pass, 0 failures (12 new tests: 8 manifest, 4 file watcher)
- [ ] Manual: `barbacane dev --manifest tests/fixtures/barbacane.yaml --spec tests/fixtures/minimal.yaml` — starts server, responds on /health
- [ ] Manual: edit a spec file while dev server is running — observe hot-reload log
- [ ] Manual: introduce a spec error — observe error message, old version still serving
- [ ] Manual: Ctrl+C — clean shutdown
- [ ] Manual: `barbacane compile -m barbacane.yaml -o api.bca` (no `--spec`) — discovers specs from manifest folder