### PR TITLE
fix(deps): resolve RUSTSEC-2026-0104 and -0105 via upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5af9ebfb0a14481d3eaf6101e6391261e4f30d25b26a7635ade8a39482ded0"
+checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
 dependencies = [
  "base64",
  "bytes",
@@ -181,7 +181,6 @@ dependencies = [
  "memchr",
  "nkeys",
  "nuid",
- "once_cell",
  "pin-project",
  "portable-atomic",
  "rand 0.8.5",
@@ -189,7 +188,7 @@ dependencies = [
  "ring",
  "rustls-native-certs",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -618,7 +617,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -913,9 +912,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -926,15 +925,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpp_demangle"
@@ -2287,15 +2277,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2834,9 +2815,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
@@ -3609,12 +3590,11 @@ dependencies = [
 
 [[package]]
 name = "rsasl"
-version = "2.2.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1bcb95b531681a622f3d6972eaab523e17e2aad6d6209f0276628eb1cb5038"
+checksum = "ed828a88913fd477c73bc3768b05d4b335ee775e29f2397bb59b9a4dd69ffb83"
 dependencies = [
  "base64",
- "core2",
  "digest",
  "hmac",
  "pbkdf2",
@@ -3728,19 +3708,18 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.11",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -3767,19 +3746,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3836,9 +3805,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tar = "0.4"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "stream", "blocking"] }
 
 # NATS client
-async-nats = "0.46"
+async-nats = "0.47"
 
 # Kafka client
 rskafka = "0.6"

--- a/deny.toml
+++ b/deny.toml
@@ -6,15 +6,6 @@ ignore = [
     # rustls-pemfile unmaintained — pinned by rustls-pemfile 2.x (transitive dep, no safe upgrade)
     "RUSTSEC-2025-0134",
 
-    # CRL Distribution Point matching logic in rustls-webpki 0.102.x — pinned by async-nats
-    "RUSTSEC-2026-0049",
-
-    # Name constraints for URI names incorrectly accepted in rustls-webpki — pinned by async-nats (0.102.8 + 0.103.11)
-    "RUSTSEC-2026-0098",
-
-    # Name constraints accepted for certificates asserting a wildcard name in rustls-webpki — pinned by async-nats
-    "RUSTSEC-2026-0099",
-
     # instant crate unmaintained — pinned by notify 7.x (transitive via notify-types), no safe upgrade
     "RUSTSEC-2024-0384",
 ]


### PR DESCRIPTION
## Summary

Upgrades close out two new advisories surfaced by `cargo deny check advisories` — no new ignores needed.

- **RUSTSEC-2026-0104** — *Reachable panic in `rustls-webpki` CRL parsing*. Fixed in `>=0.103.13`.
  - Direct line: `cargo update -p rustls-webpki@0.103.11` → `0.103.13`.
  - Transitive via `async-nats 0.46 → 0.47`: drops the orphan `rustls-webpki 0.102.8` line entirely.
- **RUSTSEC-2026-0105** — *`core2` unmaintained, all versions yanked*. Reached us via `rskafka 0.6 → rsasl 2.2 → core2 0.4`. `cargo update -p rsasl` bumps `rsasl 2.2 → 2.3`, which dropped the `core2` dependency upstream.

Also removed three now-stale ignores from `deny.toml` (`RUSTSEC-2026-0049/-0098/-0099`) — all three only matched the `rustls-webpki 0.102.x` line that's no longer in the tree.

After this, `cargo deny check advisories` passes with only the two pre-existing pinned-transitive ignores (`rustls-pemfile` via `rustls-pemfile 2.x`, `instant` via `notify-types`).

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --lib --bins` — zero warnings on production code
- [x] `cargo test --workspace --exclude barbacane-test` — all green
- [x] `cargo deny check advisories` — `advisories ok`
- [x] `cargo fmt --all -- --check` — clean
- [x] CI green on PR