### PR TITLE
Security hardening pass + security test framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **security**: control-plane admin authentication (`BARBACANE_CONTROL_ADMIN_TOKEN`), CORS allowlist (`BARBACANE_CONTROL_ALLOWED_ORIGINS`).
+- **security**: `.bca` Ed25519 signing (`BARBACANE_SIGNING_KEY`) and verify-on-load against a pinned key (`BARBACANE_TRUSTED_PUBKEY`), plus per-plugin/spec/route checksum verification on load.
+- **security**: WASM plugin SSRF guard (blocks loopback/link-local/private/metadata egress; `BARBACANE_ALLOW_INTERNAL_EGRESS` to override) and redirect following disabled.
+- **security**: WASM plugin capability enforcement — plugins may only import host functions covered by the capabilities declared in `plugin.toml`.
+- **security**: `jwt-auth` performs real signature verification via the host `verify_signature` capability (inline JWK).
+- **security**: a security testing framework — adversarial integration suite (`crates/barbacane-test/tests/security/`) and `cargo-fuzz` targets (`fuzz/`).
+- **docs**: [Configuration & environment variables](reference/configuration.md) reference.
+
+### Changed (breaking, secure-by-default)
+
+- The control plane refuses to start without `BARBACANE_CONTROL_ADMIN_TOKEN`, and all API routes (except `/health` and the data-plane WebSocket) require the bearer token.
+- `file://` secret references require `BARBACANE_SECRETS_DIR` and are confined to it.
+- MCP requires a valid session for non-`initialize` requests.
+- Plugin HTTP egress to internal/metadata addresses is blocked by default.
+
+### Fixed
+
+- **security**: fail-open middleware short-circuit downgrade in the WASM chain.
+- **security**: panic on hostile `x-request-id` / `traceparent`; unbounded Prometheus path-label cardinality on unmatched routes.
+- **deps**: bump `anyhow` to 1.0.103 (RUSTSEC-2026-0190).
+
 ## [0.7.0] - 2026-05-05
 
 Headline: AI gateway extensions land — caller-owned model, glob-based dynamic routing, stateless Responses API, aggregated model catalog, and four new policy middlewares (ADR-0024 + ADR-0030).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM gcr.io/distroless/cc-debian12:nonroot
 # OCI labels for GitHub Container Registry
 LABEL org.opencontainers.image.source="https://github.com/barbacane-dev/barbacane"
 LABEL org.opencontainers.image.description="Barbacane API Gateway - Data Plane"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 
 # Copy the binary from builder
 COPY --from=builder /usr/local/bin/barbacane /barbacane

--- a/Dockerfile.control
+++ b/Dockerfile.control
@@ -38,7 +38,7 @@ FROM debian:bookworm-slim
 # OCI labels for GitHub Container Registry
 LABEL org.opencontainers.image.source="https://github.com/barbacane-dev/barbacane"
 LABEL org.opencontainers.image.description="Barbacane API Gateway - Control Plane"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 
 # Install runtime dependencies and nginx for serving UI
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -76,9 +76,17 @@ RUN mkdir -p /plugins && \
 # ---------------------------------------------------------------------------
 FROM debian:bookworm-slim
 
+# OCI labels
+LABEL org.opencontainers.image.source="https://github.com/barbacane-dev/barbacane"
+LABEL org.opencontainers.image.description="Barbacane API Gateway - Standalone"
+LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd -r barbacane && useradd -r -g barbacane barbacane
 
 # Binary
 COPY --from=binary-builder /usr/local/bin/barbacane /usr/local/bin/barbacane
@@ -90,4 +98,9 @@ COPY --from=plugin-builder /plugins/ /plugins/
 COPY docker/plugins.yaml /etc/barbacane/plugins.yaml
 
 WORKDIR /workspace
+RUN chown -R barbacane:barbacane /workspace
+
+# Run as non-root (gateway listens on a high port; no privileged bind needed)
+USER barbacane
+
 ENTRYPOINT ["barbacane"]

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ clean:
 # Test & Lint
 # -----------------------------------------------------------------------------
 
-.PHONY: test test-verbose test-one check clippy fmt fmt-check
+.PHONY: test test-verbose test-one check clippy fmt fmt-check security-test security-test-build fuzz-build
 
 test:
 	cargo test --workspace
@@ -88,6 +88,24 @@ test-verbose:
 
 test-one:
 	cargo test --workspace $(TEST) -- --nocapture
+
+# Adversarial security suite (Layer 1). Tests assert hardened behaviour, so they
+# are RED until each finding is fixed. Needs the binaries the harness drives:
+# `barbacane` (data plane), `barbacane-control` (control plane, needs Postgres +
+# DATABASE_URL), and the WASM plugins (`make plugins`).
+# See docs/contributing/security-testing.md.
+security-test: plugins
+	cargo build -p barbacane -p barbacane-control
+	cargo test -p barbacane-test --test security -- --nocapture
+
+# Compile-only check of the security suite (does not require running services).
+security-test-build:
+	cargo test -p barbacane-test --test security --no-run
+
+# Build (not run) the standalone cargo-fuzz targets on stable, to catch bit-rot.
+# Actually fuzzing needs nightly + cargo-fuzz: `cd fuzz && cargo +nightly fuzz run <target>`.
+fuzz-build:
+	cd fuzz && cargo build --bins
 
 check: fmt-check clippy
 
@@ -189,6 +207,8 @@ help:
 	@echo "  make release        Build release"
 	@echo "  make test           Run all tests"
 	@echo "  make test-verbose   Run tests with output"
+	@echo "  make security-test  Run the adversarial security suite (RED until fixed)"
+	@echo "  make fuzz-build     Build the cargo-fuzz targets (run with +nightly)"
 	@echo "  make test-one TEST=name"
 	@echo "  make check          Run fmt-check + clippy"
 	@echo "  make clippy         Run clippy lints"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,21 @@ Forward-looking priorities for Barbacane. See [CHANGELOG.md](CHANGELOG.md) for w
 
 Actively being worked on:
 
-- _(open — pick up from Next)_
+### Security hardening (in progress)
+
+A security review drove a hardening pass. Landed on `security/hardening-and-test-framework`:
+
+- [x] **Control-plane authentication** — admin bearer token (`BARBACANE_CONTROL_ADMIN_TOKEN`) required on all routes except `/health` and the data-plane WebSocket; server fails closed without it. CORS tightened to an allowlist (`BARBACANE_CONTROL_ALLOWED_ORIGINS`).
+- [x] **Artifact integrity & signing** — `.bca` now carries an Ed25519 signature over its content hash; the data plane recomputes every plugin/spec/route checksum and verifies the signature against a pinned key (`BARBACANE_TRUSTED_PUBKEY`) on load. Sign at compile with `BARBACANE_SIGNING_KEY`.
+- [x] **MCP session enforcement** — non-`initialize` requests without a valid session are rejected (no more header-omission bypass).
+- [x] **Plugin egress SSRF guard** — the WASM host HTTP client rejects loopback/link-local/private/metadata targets and no longer follows redirects (override with `BARBACANE_ALLOW_INTERNAL_EGRESS`).
+- [x] **`jwt-auth` real verification** — signatures verified via the host `verify_signature` capability (inline JWK); the test-only skip flag is ignored in production builds.
+- [x] **Secret confinement** — `file://` secret references confined to `BARBACANE_SECRETS_DIR`.
+- [x] **Security test framework** — adversarial integration suite (`crates/barbacane-test/tests/security/`) + `cargo-fuzz` targets (`fuzz/`). See `docs/contributing/security-testing.md`.
+
+In flight:
+
+- [ ] **WASM capability enforcement** — capability map corrected (`cache`/`rate_limit`/`http_stream`); per-plugin default-deny linker + `validate_imports` gate pending the plugin-manifest migration (most official `plugin.toml`s use a legacy capability dialect) and the wasm/Docker integration run.
 
 ---
 
@@ -51,7 +65,7 @@ Committed but not yet scheduled. Grouped by concern.
 | RBAC | P2 | Role-based access control for control plane API |
 | Plugin registry | P2 | Central registry for discovering and versioning plugins |
 | Data plane groups | P2 | Deploy to specific subsets of data planes |
-| Artifact signing | P2 | GPG/private-key signing + verification on load |
+| Artifact signing | ✅ | Ed25519 signing + verify-on-load shipped (security hardening); remaining: key distribution/rotation tooling, optional Sigstore/transparency-log |
 | Health metrics collection | P2 | Aggregate CPU, memory, request rates from data planes |
 | Multi-tenancy | P3 | Organization/team isolation with SNI-based routing |
 
@@ -112,6 +126,12 @@ The first three rungs of the trusted spec-to-run pipeline are shipped (artifact 
 | E1032 validation | P2 | Warn on OpenAPI security scheme without matching auth middleware |
 | OPA WASM compilation | P1 | Define OPA version, compilation flags, error handling |
 | Auth plugin auditing | P1 | Security review process for auth plugins |
+| Ingress timeouts & limits | P1 | Header-read/idle/handshake timeouts, connection cap, streaming body-size limit on the data plane (wire the parsed `--keepalive-timeout`) |
+| Per-plugin secret & capability scope | P1 | Scope resolved secrets per plugin; complete the per-plugin default-deny host-function linker + migrate official `plugin.toml` capability dialects |
+| Plugin SDK hardening helpers | P2 | Shared SDK helpers: constant-time secret compare, trusted-proxy client-IP extraction, RFC-9457 errors, CRLF-safe headers (removes per-plugin drift) |
+| WASM execution budget | P2 | Epoch-interruption wall-clock deadline + host-imposed timeouts/body caps on blocking host calls |
+| CI/supply-chain hardening | P2 | SHA-pin third-party Actions, scope job token permissions, `cargo deny check` (licenses/bans/sources) as a gate, SBOM + image signing |
+| Control-plane container non-root | P2 | Run `barbacane-control` (nginx) as non-root (high port or capability) |
 | Trace volume guidance | P1 | Documentation for managing trace volume at scale |
 | Integration tests | P2 | Full control plane API lifecycle tests with PostgreSQL |
 | Compile safety CI | P2 | Fitness functions: deterministic build verification, fuzz testing |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,10 +19,11 @@ A security review drove a hardening pass. Landed on `security/hardening-and-test
 - [x] **`jwt-auth` real verification** — signatures verified via the host `verify_signature` capability (inline JWK); the test-only skip flag is ignored in production builds.
 - [x] **Secret confinement** — `file://` secret references confined to `BARBACANE_SECRETS_DIR`.
 - [x] **Security test framework** — adversarial integration suite (`crates/barbacane-test/tests/security/`) + `cargo-fuzz` targets (`fuzz/`). See `docs/contributing/security-testing.md`.
+- [x] **WASM capability enforcement** — all 33 official `plugin.toml`s migrated to the canonical `host_functions` dialect (verified against each plugin's real wasm imports); the data plane runs `validate_imports` on load and rejects any plugin importing a host function outside its declared capabilities. Enforced when the artifact's capabilities are authoritative (`capabilities_enforced`), i.e. compiled from `plugin.toml`.
 
 In flight:
 
-- [ ] **WASM capability enforcement** — capability map corrected (`cache`/`rate_limit`/`http_stream`); per-plugin default-deny linker + `validate_imports` gate pending the plugin-manifest migration (most official `plugin.toml`s use a legacy capability dialect) and the wasm/Docker integration run.
+- [ ] **Control-plane capability persistence** — the registry does not yet store plugin capabilities, so control-plane-compiled artifacts are capability-less and load without enforcement. Add a capabilities column + parse `plugin.toml` on plugin upload/seed so control-plane artifacts are enforced too.
 
 ---
 

--- a/crates/barbacane-compiler/Cargo.toml
+++ b/crates/barbacane-compiler/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 chrono = { workspace = true }
 hex = { workspace = true }
 home = "0.5"
+ring = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -20,7 +20,12 @@ use crate::error::{CompileError, CompileWarning};
 use crate::manifest::ProjectManifest;
 
 /// Current artifact format version.
-pub const ARTIFACT_VERSION: u32 = 3;
+///
+/// v4 adds Ed25519 signing fields and records each plugin's declared capability
+/// `host_functions` in the manifest. Whether those capabilities are enforced on
+/// load is gated by the manifest `capabilities_enforced` flag (WA-1), not by the
+/// version, so older artifacts and capability-less builds load without rejection.
+pub const ARTIFACT_VERSION: u32 = 4;
 
 /// Options for compilation.
 #[derive(Debug, Clone)]
@@ -104,6 +109,11 @@ pub struct Manifest {
     /// (informational; verification uses the operator's pinned trusted key).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signing_public_key: Option<String>,
+    /// Whether per-plugin `capabilities.host_functions` are authoritative (read
+    /// from plugin.toml). The data plane enforces the capability contract on
+    /// load only when this is true (WA-1).
+    #[serde(default)]
+    pub capabilities_enforced: bool,
 }
 
 /// MCP server configuration extracted from `x-barbacane-mcp`.
@@ -151,6 +161,10 @@ pub struct PluginCapabilities {
     /// Whether the middleware receives the request body in `on_request`.
     #[serde(default)]
     pub body_access: bool,
+    /// Declared capability host-function names from plugin.toml. The data plane
+    /// enforces these against the module's actual imports at load (WA-1).
+    #[serde(default)]
+    pub host_functions: Vec<String>,
 }
 
 /// A plugin loaded from a .bca artifact, ready for compilation.
@@ -245,7 +259,11 @@ pub fn compile(
     options: &CompileOptions,
 ) -> Result<CompileResult, CompileError> {
     let specs = parse_specs(spec_paths)?;
-    compile_inner(&specs, plugins, output, options)
+    // Plain `compile` receives caller-built bundles whose declared capabilities
+    // may not have been read from plugin.toml (e.g. the control plane builds
+    // bundles from the registry, which does not yet persist capabilities), so
+    // the resulting artifact is not marked capability-authoritative.
+    compile_inner(&specs, plugins, output, options, false)
 }
 
 /// Compile specs with a project manifest into a .bca artifact.
@@ -288,10 +306,13 @@ pub fn compile_with_manifest(
             plugin_type: p.plugin_type.unwrap_or_else(|| "plugin".to_string()),
             wasm_bytes: p.wasm_bytes,
             body_access: p.body_access,
+            host_functions: p.host_functions,
         })
         .collect();
 
-    compile_inner(&specs, &plugin_bundles, output, options)
+    // Bundles were resolved from plugin.toml, so their declared capabilities are
+    // authoritative and the artifact is eligible for load-time enforcement.
+    compile_inner(&specs, &plugin_bundles, output, options, true)
 }
 
 /// Load a manifest from a .bca artifact.
@@ -419,6 +440,8 @@ pub struct PluginBundle {
     pub wasm_bytes: Vec<u8>,
     /// Whether this plugin needs the request body.
     pub body_access: bool,
+    /// Declared capability host-function names from plugin.toml.
+    pub host_functions: Vec<String>,
 }
 
 /// Parse spec files into (ApiSpec, content, sha256) tuples.
@@ -463,6 +486,7 @@ fn compile_inner(
     plugins: &[PluginBundle],
     output: &Path,
     options: &CompileOptions,
+    capabilities_authoritative: bool,
 ) -> Result<CompileResult, CompileError> {
     let mut warnings: Vec<CompileWarning> = Vec::new();
     let mut operations: Vec<CompiledOperation> = Vec::new();
@@ -691,6 +715,7 @@ fn compile_inner(
             sha256,
             capabilities: PluginCapabilities {
                 body_access: plugin.body_access,
+                host_functions: plugin.host_functions.clone(),
             },
         });
     }
@@ -752,6 +777,7 @@ fn compile_inner(
         mcp,
         signature: None,
         signing_public_key: None,
+        capabilities_enforced: capabilities_authoritative,
     };
 
     // AR-1: sign the artifact when a signing key is configured. The signature
@@ -1579,6 +1605,7 @@ paths:
             plugin_type: "middleware".to_string(),
             wasm_bytes: fake_wasm.clone(),
             body_access: false,
+            host_functions: vec![],
         }];
 
         let result = compile(
@@ -2868,6 +2895,7 @@ paths:
             mcp: McpConfig::default(),
             signature: None,
             signing_public_key: None,
+            capabilities_enforced: false,
         }
     }
 

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -96,6 +96,14 @@ pub struct Manifest {
     /// MCP server configuration (from root-level x-barbacane-mcp).
     #[serde(default)]
     pub mcp: McpConfig,
+    /// Detached Ed25519 signature (hex) over `artifact_hash`. Present when the
+    /// artifact was signed at compile time (AR-1). Excluded from `artifact_hash`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+    /// Hex-encoded Ed25519 public key the signature was produced with
+    /// (informational; verification uses the operator's pinned trusted key).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signing_public_key: Option<String>,
 }
 
 /// MCP server configuration extracted from `x-barbacane-mcp`.
@@ -731,7 +739,7 @@ fn compile_inner(
         cfg
     };
 
-    let manifest = Manifest {
+    let mut manifest = Manifest {
         barbacane_artifact_version: ARTIFACT_VERSION,
         compiled_at: now_utc_iso8601(),
         compiler_version: COMPILER_VERSION.to_string(),
@@ -742,7 +750,14 @@ fn compile_inner(
         artifact_hash,
         provenance,
         mcp,
+        signature: None,
+        signing_public_key: None,
     };
+
+    // AR-1: sign the artifact when a signing key is configured. The signature
+    // covers `artifact_hash`, which already binds every spec, route, and plugin
+    // WASM hash, so a tampered artifact fails verification on load.
+    sign_manifest_from_env(&mut manifest)?;
 
     let manifest_json = serde_json::to_string_pretty(&manifest)?;
 
@@ -809,6 +824,126 @@ fn compute_artifact_hash(
         hasher.update(format!("{}={}\n", key, value).as_bytes());
     }
     format!("sha256:{}", hex::encode(hasher.finalize()))
+}
+
+// ---------------------------------------------------------------------------
+// AR-1: artifact integrity & Ed25519 signing
+// ---------------------------------------------------------------------------
+
+/// Errors from artifact integrity / signature verification.
+#[derive(Debug, thiserror::Error)]
+pub enum IntegrityError {
+    #[error("artifact hash mismatch: manifest claims {expected}, recomputed {actual}")]
+    ArtifactHashMismatch { expected: String, actual: String },
+    #[error("plugin '{name}' checksum mismatch: manifest {expected}, actual {actual}")]
+    PluginChecksumMismatch {
+        name: String,
+        expected: String,
+        actual: String,
+    },
+    #[error("plugin '{name}' is not listed in the manifest")]
+    UnknownPlugin { name: String },
+    #[error("artifact is unsigned but a trusted public key is configured")]
+    MissingSignature,
+    #[error("invalid key/signature material: {0}")]
+    InvalidMaterial(String),
+    #[error("artifact signature verification failed")]
+    BadSignature,
+}
+
+/// Decode a hex string into bytes (the local `hex` module only encodes).
+fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
+    let s = s.trim();
+    if !s.len().is_multiple_of(2) {
+        return Err("odd-length hex string".to_string());
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map_err(|e| e.to_string()))
+        .collect()
+}
+
+/// Recompute the combined artifact hash from the manifest's recorded inputs.
+pub fn recompute_artifact_hash(manifest: &Manifest) -> String {
+    compute_artifact_hash(&manifest.source_specs, &manifest.checksums)
+}
+
+/// Verify the manifest's `artifact_hash` is internally consistent with its
+/// recorded spec/route/plugin checksums.
+pub fn verify_artifact_hash(manifest: &Manifest) -> Result<(), IntegrityError> {
+    let actual = recompute_artifact_hash(manifest);
+    if actual != manifest.artifact_hash {
+        return Err(IntegrityError::ArtifactHashMismatch {
+            expected: manifest.artifact_hash.clone(),
+            actual,
+        });
+    }
+    Ok(())
+}
+
+/// Verify that a plugin's actual WASM bytes match the SHA-256 recorded in the
+/// manifest (detects a swapped/tampered plugin binary).
+pub fn verify_plugin_checksum(
+    manifest: &Manifest,
+    name: &str,
+    wasm_bytes: &[u8],
+) -> Result<(), IntegrityError> {
+    let expected = manifest
+        .plugins
+        .iter()
+        .find(|p| p.name == name)
+        .map(|p| p.sha256.clone())
+        .ok_or_else(|| IntegrityError::UnknownPlugin {
+            name: name.to_string(),
+        })?;
+    let actual = compute_sha256(wasm_bytes);
+    if actual != expected {
+        return Err(IntegrityError::PluginChecksumMismatch {
+            name: name.to_string(),
+            expected,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+/// Verify the artifact's Ed25519 signature over `artifact_hash` against a pinned
+/// trusted public key (hex-encoded). Fails closed if the artifact is unsigned.
+pub fn verify_artifact_signature(
+    manifest: &Manifest,
+    trusted_public_key_hex: &str,
+) -> Result<(), IntegrityError> {
+    let signature_hex = manifest
+        .signature
+        .as_ref()
+        .ok_or(IntegrityError::MissingSignature)?;
+    let signature = decode_hex(signature_hex)
+        .map_err(|e| IntegrityError::InvalidMaterial(format!("signature hex: {e}")))?;
+    let public_key = decode_hex(trusted_public_key_hex.trim())
+        .map_err(|e| IntegrityError::InvalidMaterial(format!("trusted public key hex: {e}")))?;
+
+    ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, public_key)
+        .verify(manifest.artifact_hash.as_bytes(), &signature)
+        .map_err(|_| IntegrityError::BadSignature)
+}
+
+/// Sign the manifest's `artifact_hash` when `BARBACANE_SIGNING_KEY` (a path to a
+/// PKCS#8 Ed25519 private key) is set. No-op when unset (unsigned artifact).
+fn sign_manifest_from_env(manifest: &mut Manifest) -> Result<(), CompileError> {
+    use ring::signature::KeyPair;
+
+    let key_path = match std::env::var_os("BARBACANE_SIGNING_KEY") {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+    let pkcs8 = std::fs::read(&key_path)
+        .map_err(|e| CompileError::Signing(format!("reading BARBACANE_SIGNING_KEY: {e}")))?;
+    let key_pair = ring::signature::Ed25519KeyPair::from_pkcs8(&pkcs8)
+        .map_err(|e| CompileError::Signing(format!("invalid PKCS#8 Ed25519 key: {e}")))?;
+    let signature = key_pair.sign(manifest.artifact_hash.as_bytes());
+    manifest.signature = Some(hex::encode(signature.as_ref()));
+    manifest.signing_public_key = Some(hex::encode(key_pair.public_key().as_ref()));
+    Ok(())
 }
 
 /// Add a file to a tar archive from bytes.
@@ -2695,5 +2830,116 @@ paths:
         };
         let (enabled, _) = resolve_mcp_config(&root, None);
         assert!(enabled.is_none());
+    }
+
+    // --- AR-1: artifact integrity & signing ---
+
+    fn integrity_test_manifest() -> Manifest {
+        let mut checksums = BTreeMap::new();
+        checksums.insert("routes.json".to_string(), "routehash".to_string());
+        checksums.insert(
+            "plugins/jwt-auth.wasm".to_string(),
+            compute_sha256(b"wasm-bytes"),
+        );
+        let source_specs = vec![SourceSpec {
+            file: "api.yaml".to_string(),
+            sha256: compute_sha256(b"spec"),
+            spec_type: "openapi".to_string(),
+            version: "1.0.0".to_string(),
+        }];
+        let artifact_hash = compute_artifact_hash(&source_specs, &checksums);
+        Manifest {
+            barbacane_artifact_version: ARTIFACT_VERSION,
+            compiled_at: "1970-01-01T00:00:00Z".to_string(),
+            compiler_version: COMPILER_VERSION.to_string(),
+            source_specs,
+            routes_count: 1,
+            checksums,
+            plugins: vec![BundledPlugin {
+                name: "jwt-auth".to_string(),
+                version: "0.1.0".to_string(),
+                plugin_type: "middleware".to_string(),
+                wasm_path: "plugins/jwt-auth.wasm".to_string(),
+                sha256: compute_sha256(b"wasm-bytes"),
+                capabilities: PluginCapabilities::default(),
+            }],
+            artifact_hash,
+            provenance: Provenance::default(),
+            mcp: McpConfig::default(),
+            signature: None,
+            signing_public_key: None,
+        }
+    }
+
+    fn sign_for_test(manifest: &mut Manifest) -> String {
+        use ring::signature::KeyPair;
+        let rng = ring::rand::SystemRandom::new();
+        let pkcs8 = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+        let kp = ring::signature::Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap();
+        let sig = kp.sign(manifest.artifact_hash.as_bytes());
+        manifest.signature = Some(super::hex::encode(sig.as_ref()));
+        let pubkey_hex = super::hex::encode(kp.public_key().as_ref());
+        manifest.signing_public_key = Some(pubkey_hex.clone());
+        pubkey_hex
+    }
+
+    #[test]
+    fn artifact_hash_verifies_and_detects_tampering() {
+        let mut manifest = integrity_test_manifest();
+        assert!(verify_artifact_hash(&manifest).is_ok());
+
+        // Tampered checksum (a swapped plugin) breaks the hash consistency.
+        manifest
+            .checksums
+            .insert("plugins/jwt-auth.wasm".to_string(), "deadbeef".to_string());
+        assert!(matches!(
+            verify_artifact_hash(&manifest),
+            Err(IntegrityError::ArtifactHashMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn plugin_checksum_detects_swapped_wasm() {
+        let manifest = integrity_test_manifest();
+        assert!(verify_plugin_checksum(&manifest, "jwt-auth", b"wasm-bytes").is_ok());
+        assert!(matches!(
+            verify_plugin_checksum(&manifest, "jwt-auth", b"evil-bytes"),
+            Err(IntegrityError::PluginChecksumMismatch { .. })
+        ));
+        assert!(matches!(
+            verify_plugin_checksum(&manifest, "ghost", b"x"),
+            Err(IntegrityError::UnknownPlugin { .. })
+        ));
+    }
+
+    #[test]
+    fn signature_roundtrip_and_rejection() {
+        let mut manifest = integrity_test_manifest();
+
+        // Unsigned artifact fails closed when a trusted key is configured.
+        assert!(matches!(
+            verify_artifact_signature(&manifest, "00"),
+            Err(IntegrityError::MissingSignature)
+        ));
+
+        let pubkey = sign_for_test(&mut manifest);
+        // Valid signature under the correct key.
+        assert!(verify_artifact_signature(&manifest, &pubkey).is_ok());
+
+        // Tampered artifact_hash → signature no longer matches.
+        let mut tampered = manifest.clone();
+        tampered.artifact_hash = "sha256:0000".to_string();
+        assert!(matches!(
+            verify_artifact_signature(&tampered, &pubkey),
+            Err(IntegrityError::BadSignature)
+        ));
+
+        // Wrong (attacker) key → rejected.
+        let mut other = integrity_test_manifest();
+        let _ = sign_for_test(&mut other);
+        assert!(matches!(
+            verify_artifact_signature(&manifest, other.signing_public_key.as_ref().unwrap()),
+            Err(IntegrityError::BadSignature)
+        ));
     }
 }

--- a/crates/barbacane-compiler/src/error.rs
+++ b/crates/barbacane-compiler/src/error.rs
@@ -74,4 +74,8 @@ pub enum CompileError {
     /// JSON serialization error.
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
+
+    /// Artifact signing failed (bad/missing signing key).
+    #[error("artifact signing error: {0}")]
+    Signing(String),
 }

--- a/crates/barbacane-compiler/src/lib.rs
+++ b/crates/barbacane-compiler/src/lib.rs
@@ -12,9 +12,10 @@ pub mod spec_parser;
 
 pub use artifact::{
     compile, compile_with_manifest, load_manifest, load_plugins, load_routes, load_specs,
-    BundledPlugin, CompileOptions, CompileResult, CompiledOperation, CompiledRoutes, LoadedPlugin,
-    Manifest, McpConfig, PluginBundle, PluginCapabilities, Provenance, SourceSpec,
-    ARTIFACT_VERSION, COMPILER_VERSION,
+    recompute_artifact_hash, verify_artifact_hash, verify_artifact_signature,
+    verify_plugin_checksum, BundledPlugin, CompileOptions, CompileResult, CompiledOperation,
+    CompiledRoutes, IntegrityError, LoadedPlugin, Manifest, McpConfig, PluginBundle,
+    PluginCapabilities, Provenance, SourceSpec, ARTIFACT_VERSION, COMPILER_VERSION,
 };
 pub use error::{CompileError, CompileWarning};
 pub use manifest::{

--- a/crates/barbacane-compiler/src/manifest.rs
+++ b/crates/barbacane-compiler/src/manifest.rs
@@ -33,6 +33,8 @@ struct PluginMeta {
 struct PluginTomlCapabilities {
     #[serde(default)]
     body_access: bool,
+    #[serde(default)]
+    host_functions: Vec<String>,
 }
 
 /// Plugin metadata extracted from plugin.toml.
@@ -40,6 +42,7 @@ struct PluginMetadata {
     version: String,
     plugin_type: String,
     body_access: bool,
+    host_functions: Vec<String>,
 }
 
 /// Parse plugin metadata from TOML content.
@@ -49,6 +52,7 @@ fn parse_plugin_metadata(content: &str) -> Option<PluginMetadata> {
         version: parsed.plugin.version,
         plugin_type: parsed.plugin.plugin_type,
         body_access: parsed.capabilities.body_access,
+        host_functions: parsed.capabilities.host_functions,
     })
 }
 
@@ -120,6 +124,10 @@ fn resolve_plugin(
         version: metadata.as_ref().map(|m| m.version.clone()),
         plugin_type: metadata.as_ref().map(|m| m.plugin_type.clone()),
         body_access: metadata.as_ref().is_some_and(|m| m.body_access),
+        host_functions: metadata
+            .as_ref()
+            .map(|m| m.host_functions.clone())
+            .unwrap_or_default(),
     })
 }
 
@@ -241,6 +249,8 @@ pub struct ResolvedPlugin {
     pub plugin_type: Option<String>,
     /// Whether this plugin needs the request body in `on_request`.
     pub body_access: bool,
+    /// Declared capability host-function names from plugin.toml.
+    pub host_functions: Vec<String>,
 }
 
 impl ProjectManifest {

--- a/crates/barbacane-control/src/api/auth.rs
+++ b/crates/barbacane-control/src/api/auth.rs
@@ -1,0 +1,106 @@
+//! Admin authentication for the control-plane API.
+//!
+//! The control plane is an administrative surface: every mutating route can
+//! create projects, upload plugin WASM, deploy artifacts, and mint data-plane
+//! API keys. It must never be reachable without a credential.
+//!
+//! A single shared admin bearer token is required on all routes except
+//! `/health` (liveness) and `/ws/data-plane` (which authenticates with its own
+//! per-data-plane API key). The token is supplied via the
+//! `BARBACANE_CONTROL_ADMIN_TOKEN` environment variable; the server refuses to
+//! start without it (fail-closed). Comparison is done over SHA-256 digests so
+//! request handling does not leak the token through timing.
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{header::AUTHORIZATION, Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use sha2::{Digest, Sha256};
+
+use crate::error::ProblemDetails;
+
+/// Authentication policy applied to protected control-plane routes.
+#[derive(Clone)]
+pub enum AdminAuth {
+    /// Require a bearer token whose SHA-256 digest matches this value.
+    Token(Arc<[u8; 32]>),
+    /// Authentication disabled. **Test only** — the production binary never
+    /// constructs this variant; `barbacane-control serve` always uses
+    /// [`AdminAuth::from_token`] and fails to start without a token. Only
+    /// reachable from `#[cfg(test)]` harnesses, hence the scoped allow.
+    #[cfg_attr(not(test), allow(dead_code))]
+    Disabled,
+}
+
+impl AdminAuth {
+    /// Build a policy that requires the given token.
+    pub fn from_token(token: &str) -> Self {
+        AdminAuth::Token(Arc::new(sha256(token.as_bytes())))
+    }
+
+    /// Whether `presented` is an acceptable credential under this policy.
+    fn accepts(&self, presented: &str) -> bool {
+        match self {
+            AdminAuth::Disabled => true,
+            AdminAuth::Token(expected) => ct_eq(&sha256(presented.as_bytes()), expected),
+        }
+    }
+}
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+/// Constant-time comparison of two fixed-size digests.
+fn ct_eq(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    let mut diff = 0u8;
+    for i in 0..32 {
+        diff |= a[i] ^ b[i];
+    }
+    diff == 0
+}
+
+/// Axum middleware enforcing the admin bearer token.
+pub async fn require_admin(
+    State(auth): State<AdminAuth>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    if let AdminAuth::Disabled = auth {
+        return next.run(req).await;
+    }
+
+    let authorized = req
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(|token| auth.accepts(token))
+        .unwrap_or(false);
+
+    if authorized {
+        next.run(req).await
+    } else {
+        let mut response = ProblemDetails {
+            error_type: "urn:barbacane:error:unauthorized".into(),
+            title: "Unauthorized".into(),
+            status: StatusCode::UNAUTHORIZED.as_u16(),
+            detail: Some("a valid admin bearer token is required".into()),
+            instance: None,
+            errors: vec![],
+        }
+        .into_response();
+        response.headers_mut().insert(
+            axum::http::header::WWW_AUTHENTICATE,
+            axum::http::HeaderValue::from_static("Bearer"),
+        );
+        response
+    }
+}

--- a/crates/barbacane-control/src/api/mod.rs
+++ b/crates/barbacane-control/src/api/mod.rs
@@ -2,6 +2,7 @@
 
 mod api_keys;
 mod artifacts;
+mod auth;
 mod compilations;
 mod data_planes;
 mod health;
@@ -15,6 +16,7 @@ mod router;
 mod specs;
 pub mod ws;
 
+pub use auth::AdminAuth;
 pub use router::create_router;
 pub use ws::ConnectionManager;
 

--- a/crates/barbacane-control/src/api/router.rs
+++ b/crates/barbacane-control/src/api/router.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use axum::{
-    http::{header, HeaderValue, StatusCode},
+    http::{header, HeaderValue, Method, StatusCode},
     response::{Html, IntoResponse},
     routing::{delete, get, patch, post, put},
     Router,
@@ -11,7 +11,7 @@ use axum::{
 use sqlx::PgPool;
 use tokio::sync::mpsc;
 use tower_http::{
-    cors::{Any, CorsLayer},
+    cors::{AllowOrigin, CorsLayer},
     set_header::SetResponseHeaderLayer,
     trace::TraceLayer,
 };
@@ -19,6 +19,7 @@ use uuid::Uuid;
 
 use scalar_api_reference::scalar_html_default;
 
+use super::auth::{require_admin, AdminAuth};
 use super::ws::ConnectionManager;
 use super::{
     api_keys, artifacts, compilations, data_planes, health, init, operations, plugins,
@@ -65,11 +66,41 @@ async fn api_docs() -> Html<String> {
     Html(scalar_html_default(&config))
 }
 
+/// Build a CORS layer from the `BARBACANE_CONTROL_ALLOWED_ORIGINS` environment
+/// variable (a comma-separated allowlist of origins). When unset or empty, no
+/// cross-origin requests are permitted — the admin API is same-origin by
+/// default. Credentials are never combined with a wildcard origin.
+fn cors_layer() -> CorsLayer {
+    let origins: Vec<HeaderValue> = std::env::var("BARBACANE_CONTROL_ALLOWED_ORIGINS")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| HeaderValue::from_str(s).ok())
+        .collect();
+
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::list(origins))
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+        ])
+        .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE])
+}
+
 /// Create the API router with all routes.
+///
+/// `admin_auth` is enforced on every route except `/health` and the data-plane
+/// WebSocket (`/ws/data-plane`), which authenticates with its own per-data-plane
+/// API key.
 pub fn create_router(
     pool: PgPool,
     compilation_tx: Option<mpsc::Sender<Uuid>>,
     connection_manager: Arc<ConnectionManager>,
+    admin_auth: AdminAuth,
 ) -> Router {
     let state = AppState {
         pool,
@@ -77,12 +108,18 @@ pub fn create_router(
         connection_manager,
     };
 
-    Router::new()
+    // Public routes: liveness, and the data-plane WebSocket (which performs its
+    // own API-key authentication inside the handler).
+    let public = Router::new()
+        .route("/health", get(health::health_check))
+        // WebSocket for data plane connections
+        .route("/ws/data-plane", get(ws::ws_handler));
+
+    // Protected routes: everything else requires the admin bearer token.
+    let protected = Router::new()
         // OpenAPI spec and documentation
         .route("/openapi", get(openapi_spec))
         .route("/docs", get(api_docs))
-        // Health
-        .route("/health", get(health::health_check))
         // Init
         .route("/init", post(init::init_project))
         // Specs
@@ -194,16 +231,18 @@ pub fn create_router(
             "/projects/{id}/deploy",
             post(data_planes::deploy_to_data_planes),
         )
-        // WebSocket for data plane connections
-        .route("/ws/data-plane", get(ws::ws_handler))
-        // Middleware
+        // Admin authentication on every protected route.
+        .layer(axum::middleware::from_fn_with_state(
+            admin_auth,
+            require_admin,
+        ));
+
+    Router::new()
+        .merge(public)
+        .merge(protected)
+        // Middleware applied to all routes
         .layer(TraceLayer::new_for_http())
-        .layer(
-            CorsLayer::new()
-                .allow_origin(Any)
-                .allow_methods(Any)
-                .allow_headers(Any),
-        )
+        .layer(cors_layer())
         // API versioning: set Content-Type to versioned media type for JSON responses
         .layer(SetResponseHeaderLayer::if_not_present(
             axum::http::header::CONTENT_TYPE,

--- a/crates/barbacane-control/src/api/tests.rs
+++ b/crates/barbacane-control/src/api/tests.rs
@@ -37,7 +37,12 @@ async fn make_app() -> Option<Router> {
     crate::db::run_migrations(&pool).await.ok()?;
 
     let conn_mgr = Arc::new(crate::api::ConnectionManager::new());
-    Some(crate::api::create_router(pool, None, conn_mgr))
+    Some(crate::api::create_router(
+        pool,
+        None,
+        conn_mgr,
+        crate::api::AdminAuth::Disabled,
+    ))
 }
 
 /// Send one request through the router and return the status + body bytes.

--- a/crates/barbacane-control/src/compiler/worker.rs
+++ b/crates/barbacane-control/src/compiler/worker.rs
@@ -262,8 +262,12 @@ async fn resolve_project_plugins(
             version: plugin_with_binary.version.clone(),
             plugin_type: plugin_with_binary.plugin_type.clone(),
             wasm_bytes: plugin_with_binary.wasm_binary,
-            // TODO: read body_access from DB once the plugins table has a capabilities column
+            // TODO: read body_access + host_functions from the registry once the
+            // plugins table persists capabilities. Until then the control plane
+            // compiles capability-less (non-authoritative) artifacts, so the data
+            // plane loads them without capability enforcement (WA-1).
             body_access: false,
+            host_functions: vec![],
         });
     }
 

--- a/crates/barbacane-control/src/main.rs
+++ b/crates/barbacane-control/src/main.rs
@@ -117,6 +117,20 @@ fn main() -> ExitCode {
 }
 
 async fn run_server(listen: SocketAddr, database_url: &str, migrate: bool) -> anyhow::Result<()> {
+    // Admin authentication is mandatory: the control plane can mint API keys,
+    // upload plugin WASM, and deploy artifacts, so it must never run without a
+    // credential. Fail closed if the token is not configured.
+    let admin_token = std::env::var("BARBACANE_CONTROL_ADMIN_TOKEN")
+        .ok()
+        .filter(|t| !t.trim().is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "BARBACANE_CONTROL_ADMIN_TOKEN must be set to a non-empty value; \
+                 the control-plane API refuses to start unauthenticated"
+            )
+        })?;
+    let admin_auth = api::AdminAuth::from_token(&admin_token);
+
     // Create database pool
     let pool = db::create_pool(database_url).await?;
 
@@ -129,6 +143,7 @@ async fn run_server(listen: SocketAddr, database_url: &str, migrate: bool) -> an
     server::run(server::ServerConfig {
         listen_addr: listen,
         pool,
+        admin_auth,
     })
     .await
 }

--- a/crates/barbacane-control/src/server.rs
+++ b/crates/barbacane-control/src/server.rs
@@ -8,7 +8,7 @@ use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use crate::api::{create_router, ConnectionManager};
+use crate::api::{create_router, AdminAuth, ConnectionManager};
 use crate::db::DataPlanesRepository;
 
 /// How often to check for stale data planes (seconds).
@@ -21,6 +21,7 @@ const STALE_THRESHOLD_MINUTES: i64 = 2;
 pub struct ServerConfig {
     pub listen_addr: SocketAddr,
     pub pool: PgPool,
+    pub admin_auth: AdminAuth,
 }
 
 /// Run the control plane server.
@@ -56,7 +57,7 @@ pub async fn run(config: ServerConfig) -> anyhow::Result<()> {
     let connection_manager = Arc::new(ConnectionManager::new());
 
     // Create router
-    let app = create_router(config.pool, Some(tx), connection_manager);
+    let app = create_router(config.pool, Some(tx), connection_manager, config.admin_auth);
 
     // Bind and serve
     let listener = TcpListener::bind(config.listen_addr).await?;

--- a/crates/barbacane-test/Cargo.toml
+++ b/crates/barbacane-test/Cargo.toml
@@ -22,6 +22,10 @@ tokio-tungstenite = { workspace = true }
 futures-util = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
+# Used by the security suite (artifact_integrity) to rebuild a .bca archive with
+# a single tampered byte. Same crates the compiler uses for the .bca format.
+flate2 = { workspace = true }
+tar = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/barbacane-test/SECURITY-TESTING.md
+++ b/crates/barbacane-test/SECURITY-TESTING.md
@@ -1,0 +1,21 @@
+# Security testing
+
+The adversarial security suite for Barbacane lives in this crate under
+`tests/security.rs` + `tests/security/` (one module per threat category), with
+fixtures in `../../tests/fixtures/security/`.
+
+Full documentation — threat model, finding IDs, how to run (incl. the Docker /
+PostgreSQL requirements), how to run the cargo-fuzz targets in `../../fuzz/`,
+and how to add a new security test — is in:
+
+> **[docs/contributing/security-testing.md](../../docs/contributing/security-testing.md)**
+
+Quick start:
+
+```bash
+# Compile-only (no services needed):
+cargo test -p barbacane-test --test security --no-run
+
+# Run (RED until findings are fixed — that is intended):
+make security-test
+```

--- a/crates/barbacane-test/tests/security.rs
+++ b/crates/barbacane-test/tests/security.rs
@@ -1,0 +1,93 @@
+//! Adversarial security test suite (Layer 1 of the security testing framework).
+//!
+//! This single test binary aggregates every security category as a submodule
+//! (files under `tests/security/`) so they can share the helpers defined here.
+//! Each category file asserts the SECURE / hardened behaviour, so the test is
+//! RED today and turns GREEN as the corresponding finding is fixed. Every red
+//! test carries a comment of the form
+//! `// EXPECTED TO FAIL until <FINDING-ID> is fixed`.
+//!
+//! Findings covered (see docs/contributing/security-testing.md for the full
+//! threat model):
+//!
+//! | Finding         | Category            | File                            |
+//! |-----------------|---------------------|---------------------------------|
+//! | BARB-SEC-001    | authz / IDOR        | security/authz.rs               |
+//! | BARB-SEC-002    | SSRF                | security/ssrf.rs                |
+//! | BARB-SEC-003    | DoS / resource caps | security/dos.rs                 |
+//! | BARB-SEC-004    | sandbox / capability| security/sandbox.rs             |
+//! | BARB-SEC-005    | crypto / auth       | security/crypto_auth.rs         |
+//! | BARB-SEC-006    | artifact integrity  | security/artifact_integrity.rs  |
+//!
+//! Run with: `cargo test -p barbacane-test --test security`
+//!
+//! Most categories boot the data-plane gateway (and BARB-SEC-001 boots the
+//! control-plane binary), which requires the relevant services to be available.
+//! See the docs for the Docker / Postgres requirements.
+
+// Shared helpers live here at the test-binary root; category modules reach them
+// via `super::`.
+#![allow(dead_code)] // Helpers are shared across category modules; not all are used by every module.
+
+use std::path::PathBuf;
+
+mod security {
+    pub mod artifact_integrity;
+    pub mod authz;
+    pub mod crypto_auth;
+    pub mod dos;
+    pub mod sandbox;
+    pub mod ssrf;
+}
+
+/// Absolute path to a fixture under `tests/fixtures/`.
+///
+/// Identical to the `fixture()` helper duplicated across the existing test
+/// files, hoisted here so the security modules can share it.
+pub fn fixture(name: &str) -> String {
+    fixtures_dir().join(name).display().to_string()
+}
+
+/// Absolute path to the shared `tests/fixtures` directory.
+pub fn fixtures_dir() -> PathBuf {
+    // CARGO_MANIFEST_DIR = .../crates/barbacane-test
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/")
+        .parent()
+        .expect("workspace root")
+        .join("tests/fixtures")
+}
+
+/// Absolute path to the security-specific fixtures directory
+/// (`tests/fixtures/security/`).
+pub fn security_fixture(name: &str) -> String {
+    fixtures_dir()
+        .join("security")
+        .join(name)
+        .display()
+        .to_string()
+}
+
+/// Current Unix timestamp in seconds.
+pub fn now_timestamp() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is after the Unix epoch")
+        .as_secs()
+}
+
+/// Build an unsigned JWT (`header.payload.signature`) from the given header and
+/// claims JSON. Used to forge `alg:none`, expired, and tampered tokens.
+pub fn encode_jwt(
+    header: &serde_json::Value,
+    claims: &serde_json::Value,
+    signature: &[u8],
+) -> String {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    let header_b64 = URL_SAFE_NO_PAD.encode(header.to_string().as_bytes());
+    let claims_b64 = URL_SAFE_NO_PAD.encode(claims.to_string().as_bytes());
+    let sig_b64 = URL_SAFE_NO_PAD.encode(signature);
+    format!("{}.{}.{}", header_b64, claims_b64, sig_b64)
+}

--- a/crates/barbacane-test/tests/security/artifact_integrity.rs
+++ b/crates/barbacane-test/tests/security/artifact_integrity.rs
@@ -1,0 +1,314 @@
+//! BARB-SEC-006 — Artifact integrity (hash + signature verification on load).
+//!
+//! Threat: `Gateway::load` (`crates/barbacane/src/main.rs`) reads the manifest,
+//! routes, specs, and plugin WASM out of the `.bca` archive but NEVER verifies
+//! them against the per-file `checksums` / `artifact_hash` recorded in
+//! `manifest.json`, and there is no signature at all. An attacker who can modify
+//! an artifact at rest (or in transit to a data plane) can swap in a malicious
+//! plugin, rewrite routes, or alter the manifest, and the gateway will load it.
+//!
+//! The fix:
+//!   * verify each archive entry's SHA-256 against `manifest.checksums` and the
+//!     combined `artifact_hash` at load time (reject on mismatch), and
+//!   * verify an Ed25519 signature over the artifact against a trusted public
+//!     key provided via `BARBACANE_TRUSTED_PUBKEY` (reject if missing/invalid).
+//!
+//! ## How these tests work
+//!
+//! We compile a real `.bca` via `barbacane-compiler`, then rebuild the gzip+tar
+//! archive flipping exactly one byte inside a chosen member (plugin WASM, routes,
+//! or manifest) — leaving the gzip/tar framing intact so the corruption is
+//! *content* corruption, not a parse error. We then ask the actual `barbacane`
+//! binary to `serve` the tampered artifact and assert it REFUSES TO START.
+//!
+//! Today there is no verification, so a content-tampered artifact loads and the
+//! gateway comes up healthy → RED. Once hash/signature verification lands, the
+//! load fails fast → GREEN.
+
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use barbacane_compiler::{compile_with_manifest, CompileOptions, ProjectManifest};
+use tempfile::TempDir;
+
+use crate::fixtures_dir;
+
+/// Compile `minimal.yaml` (uses only the `mock` plugin) into a `.bca` in `dir`.
+fn compile_minimal_artifact(dir: &Path) -> PathBuf {
+    let fixtures = fixtures_dir();
+    let spec = fixtures.join("minimal.yaml");
+    let manifest_path = fixtures.join("barbacane.yaml");
+
+    let project_manifest =
+        ProjectManifest::load(&manifest_path).expect("load fixtures barbacane.yaml manifest");
+
+    let artifact = dir.join("artifact.bca");
+    let options = CompileOptions {
+        allow_plaintext: true,
+        ..CompileOptions::default()
+    };
+    compile_with_manifest(
+        &[spec.as_path()],
+        &project_manifest,
+        &fixtures,
+        &artifact,
+        &options,
+    )
+    .expect("compile minimal.yaml");
+    artifact
+}
+
+/// Read all entries of a gzip+tar `.bca` into (path, bytes), preserving order.
+fn read_archive(path: &Path) -> Vec<(String, Vec<u8>)> {
+    let file = std::fs::File::open(path).expect("open artifact");
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+
+    let mut entries = Vec::new();
+    for entry in archive.entries().expect("read entries") {
+        let mut entry = entry.expect("entry");
+        let name = entry
+            .path()
+            .expect("entry path")
+            .to_string_lossy()
+            .into_owned();
+        let mut bytes = Vec::new();
+        entry.read_to_end(&mut bytes).expect("read entry bytes");
+        entries.push((name, bytes));
+    }
+    entries
+}
+
+/// Rewrite a gzip+tar `.bca` from the given (path, bytes) entries.
+fn write_archive(path: &Path, entries: &[(String, Vec<u8>)]) {
+    let file = std::fs::File::create(path).expect("create tampered artifact");
+    let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+    let mut builder = tar::Builder::new(encoder);
+
+    for (name, bytes) in entries {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, name, bytes.as_slice())
+            .expect("append entry");
+    }
+    let encoder = builder.into_inner().expect("finish tar");
+    encoder.finish().expect("finish gzip");
+}
+
+/// Compile an artifact, flip one byte inside the first entry whose path matches
+/// `predicate`, and write the result to a new `.bca`. Returns its path.
+fn tamper_artifact(dir: &Path, predicate: impl Fn(&str) -> bool) -> PathBuf {
+    let original = compile_minimal_artifact(dir);
+    let mut entries = read_archive(&original);
+
+    let target = entries
+        .iter_mut()
+        .find(|(name, bytes)| predicate(name) && !bytes.is_empty())
+        .expect("found an entry matching the tamper predicate");
+
+    // Flip one byte in the middle of the chosen member.
+    let idx = target.1.len() / 2;
+    target.1[idx] ^= 0xFF;
+
+    let tampered = dir.join("tampered.bca");
+    write_archive(&tampered, &entries);
+    tampered
+}
+
+/// Free TCP port for the gateway under test.
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    let p = l.local_addr().expect("local addr").port();
+    drop(l);
+    p
+}
+
+/// Locate the built `barbacane` data-plane binary.
+fn find_barbacane_binary() -> Option<PathBuf> {
+    [
+        "target/debug/barbacane",
+        "target/release/barbacane",
+        "../target/debug/barbacane",
+        "../target/release/barbacane",
+        "../../target/debug/barbacane",
+        "../../target/release/barbacane",
+    ]
+    .iter()
+    .map(PathBuf::from)
+    .find(|p| p.exists())
+}
+
+/// Boot `barbacane serve` against `artifact` and report whether the gateway
+/// becomes healthy. `true` = loaded & serving (verification did NOT reject);
+/// `false` = the process refused to start / never became healthy.
+async fn gateway_loads_artifact(artifact: &Path) -> bool {
+    let Some(binary) = find_barbacane_binary() else {
+        // Caller treats `None`-equivalent as skip; surface via panic-free path.
+        eprintln!("skip: barbacane binary not built (run `cargo build -p barbacane`)");
+        // Returning `false` here would masquerade as "rejected"; instead we make
+        // the caller skip by checking the binary separately. See callers.
+        return false;
+    };
+
+    let port = free_port();
+    let admin_port = free_port();
+
+    let mut child = Command::new(&binary)
+        .arg("serve")
+        .arg("--artifact")
+        .arg(artifact)
+        .arg("--listen")
+        .arg(format!("127.0.0.1:{}", port))
+        .arg("--admin-bind")
+        .arg(format!("127.0.0.1:{}", admin_port))
+        .arg("--dev")
+        .arg("--allow-plaintext-upstream")
+        .env("BARBACANE_TRUSTED_PUBKEY", "") // no trusted key configured
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn barbacane serve");
+
+    let client = reqwest::Client::new();
+    let health = format!("http://127.0.0.1:{}/__barbacane/health", port);
+
+    let mut healthy = false;
+    for _ in 0..50 {
+        if let Ok(resp) = client.get(&health).send().await {
+            if resp.status().is_success() {
+                healthy = true;
+                break;
+            }
+        }
+        if let Ok(Some(_)) = child.try_wait() {
+            // Process exited before becoming healthy → load rejected.
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    healthy
+}
+
+/// Tampering a bundled plugin's WASM bytes must make the load FAIL.
+#[tokio::test]
+async fn tampered_plugin_wasm_is_rejected() {
+    // EXPECTED TO FAIL until BARB-SEC-006 is fixed (Gateway::load does not verify
+    // archive-entry hashes against manifest.checksums or any signature).
+    if find_barbacane_binary().is_none() {
+        eprintln!("skip: barbacane binary not built (run `cargo build -p barbacane`)");
+        return;
+    }
+    let dir = TempDir::new().expect("temp dir");
+    let tampered = tamper_artifact(dir.path(), |name| name.ends_with(".wasm"));
+
+    let loaded = gateway_loads_artifact(&tampered).await;
+    assert!(
+        !loaded,
+        "gateway must refuse to load an artifact whose bundled plugin WASM was \
+         tampered (hash mismatch / signature invalid)"
+    );
+}
+
+/// Tampering `routes.json` must make the load FAIL.
+#[tokio::test]
+async fn tampered_routes_is_rejected() {
+    // EXPECTED TO FAIL until BARB-SEC-006 is fixed.
+    if find_barbacane_binary().is_none() {
+        eprintln!("skip: barbacane binary not built (run `cargo build -p barbacane`)");
+        return;
+    }
+    let dir = TempDir::new().expect("temp dir");
+    let tampered = tamper_artifact(dir.path(), |name| name == "routes.json");
+
+    let loaded = gateway_loads_artifact(&tampered).await;
+    assert!(
+        !loaded,
+        "gateway must refuse to load an artifact whose routes.json was tampered"
+    );
+}
+
+/// Tampering the `manifest.json` itself must make the load FAIL — verification
+/// must not trust the manifest's own recorded hash blindly; a real signature
+/// over the manifest is what makes this detectable.
+#[tokio::test]
+async fn tampered_manifest_is_rejected() {
+    // EXPECTED TO FAIL until BARB-SEC-006 is fixed (no signature over the
+    // manifest; an attacker can edit manifest.json and its self-described hash).
+    if find_barbacane_binary().is_none() {
+        eprintln!("skip: barbacane binary not built (run `cargo build -p barbacane`)");
+        return;
+    }
+    let dir = TempDir::new().expect("temp dir");
+
+    // For the manifest we corrupt a recorded checksum value so that, under the
+    // fix, the per-entry hash check (or the signature) fails. We rewrite the
+    // manifest JSON rather than flipping a random byte so the JSON still parses.
+    let original = compile_minimal_artifact(dir.path());
+    let mut entries = read_archive(&original);
+    for (name, bytes) in entries.iter_mut() {
+        if name == "manifest.json" {
+            let mut manifest: serde_json::Value =
+                serde_json::from_slice(bytes).expect("parse manifest.json");
+            // Corrupt one recorded checksum to a plausible-but-wrong value.
+            if let Some(checksums) = manifest
+                .get_mut("checksums")
+                .and_then(|c| c.as_object_mut())
+            {
+                let mut replacement = BTreeMap::new();
+                for (k, _v) in checksums.iter() {
+                    replacement.insert(
+                        k.clone(),
+                        "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                            .to_string(),
+                    );
+                }
+                for (k, v) in replacement {
+                    checksums.insert(k, serde_json::Value::String(v));
+                }
+            }
+            *bytes = serde_json::to_vec(&manifest).expect("reserialize manifest");
+        }
+    }
+    let tampered = dir.path().join("tampered.bca");
+    write_archive(&tampered, &entries);
+
+    let loaded = gateway_loads_artifact(&tampered).await;
+    assert!(
+        !loaded,
+        "gateway must refuse to load an artifact whose manifest checksums were \
+         tampered (or whose signature does not cover/validate the manifest)"
+    );
+}
+
+/// Sanity / positive control: the UNtampered freshly-compiled artifact loads
+/// fine. This guards against the tamper helpers being so destructive that every
+/// artifact fails to load (which would make the RED tests above meaningless).
+///
+/// NOTE: once BARB-SEC-006 lands and load requires a valid `BARBACANE_TRUSTED_PUBKEY`
+/// signature, this control will need the signing key wired in; until then a
+/// pristine artifact must load.
+#[tokio::test]
+async fn untampered_artifact_loads() {
+    if find_barbacane_binary().is_none() {
+        eprintln!("skip: barbacane binary not built (run `cargo build -p barbacane`)");
+        return;
+    }
+    let dir = TempDir::new().expect("temp dir");
+    let artifact = compile_minimal_artifact(dir.path());
+
+    let loaded = gateway_loads_artifact(&artifact).await;
+    assert!(
+        loaded,
+        "a pristine, untampered artifact must load and the gateway must become healthy"
+    );
+}

--- a/crates/barbacane-test/tests/security/authz.rs
+++ b/crates/barbacane-test/tests/security/authz.rs
@@ -1,0 +1,324 @@
+//! BARB-SEC-001 — Control-plane authorization & project-scoped IDOR.
+//!
+//! Threat: the control plane is the administrative surface — it can create
+//! projects, upload plugin WASM, deploy artifacts, and mint data-plane API
+//! keys. Today every route is reachable with no credential, and global
+//! `/specs/{id}` / `/artifacts/{id}` reads perform no project-ownership check.
+//!
+//! The fix (per the hardening plan):
+//!   * Require a Bearer token on every route except `/health` and
+//!     `/ws/data-plane`. The token is read from `BARBACANE_CONTROL_ADMIN_TOKEN`
+//!     and the server fails to start without it.
+//!   * Enforce project ownership so project A's credential cannot read or
+//!     mutate project B's specs / artifacts / api-keys (IDOR).
+//!
+//! The `require_admin` middleware already exists in
+//! `crates/barbacane-control/src/api/auth.rs` but is NOT yet wired into
+//! `create_router`, so these tests are RED.
+//!
+//! ## Why these tests boot a subprocess
+//!
+//! `barbacane-control` is a **binary-only** crate (no `src/lib.rs`) and
+//! `barbacane-test` does not depend on it, so we cannot drive its Axum router
+//! in-process. We therefore boot the `barbacane-control` binary the same way
+//! `TestGateway` boots the data plane. This requires:
+//!   * a reachable PostgreSQL (`DATABASE_URL`, see docs), and
+//!   * the `barbacane-control` binary to be built (`cargo build -p barbacane-control`).
+//!
+//! When either is missing the harness returns `None` and the test SKIPS (prints
+//! a `skip:` line and returns) rather than failing spuriously — matching the
+//! pattern in `crates/barbacane-control/src/api/tests.rs`. The security
+//! assertions only run when the control plane is actually up, so they are RED
+//! against a running-but-unhardened control plane and GREEN once the fix lands.
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+/// A booted control-plane process for authz testing.
+struct TestControlPlane {
+    child: Child,
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl Drop for TestControlPlane {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl TestControlPlane {
+    /// Boot the control plane with the given admin token in the environment.
+    ///
+    /// Returns `None` (test should SKIP) when prerequisites are unavailable:
+    /// no `DATABASE_URL`, no built binary, or the server never becomes healthy.
+    async fn boot(admin_token: Option<&str>) -> Option<Self> {
+        let database_url = std::env::var("DATABASE_URL").ok()?;
+        let binary = find_control_binary()?;
+        let port = free_port()?;
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        let mut cmd = Command::new(&binary);
+        cmd.arg("serve")
+            .arg("--listen")
+            .arg(format!("127.0.0.1:{}", port))
+            .arg("--database-url")
+            .arg(&database_url)
+            .env("DATABASE_URL", &database_url)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        match admin_token {
+            Some(tok) => {
+                cmd.env("BARBACANE_CONTROL_ADMIN_TOKEN", tok);
+            }
+            None => {
+                cmd.env_remove("BARBACANE_CONTROL_ADMIN_TOKEN");
+            }
+        }
+
+        let child = cmd.spawn().ok()?;
+        let client = reqwest::Client::new();
+
+        let mut cp = TestControlPlane {
+            child,
+            base_url,
+            client,
+        };
+
+        // Poll /health until ready (or give up → skip).
+        let health = format!("{}/health", cp.base_url);
+        for _ in 0..100 {
+            if let Ok(resp) = cp.client.get(&health).send().await {
+                if resp.status().is_success() {
+                    return Some(cp);
+                }
+            }
+            if let Ok(Some(_)) = cp.child.try_wait() {
+                // Process exited before becoming healthy (e.g. fail-closed on a
+                // missing admin token, or no DB) — treat as skip.
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        None
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+}
+
+/// Locate the built `barbacane-control` binary.
+fn find_control_binary() -> Option<PathBuf> {
+    let candidates = [
+        "target/debug/barbacane-control",
+        "target/release/barbacane-control",
+        "../target/debug/barbacane-control",
+        "../target/release/barbacane-control",
+        "../../target/debug/barbacane-control",
+        "../../target/release/barbacane-control",
+    ];
+    candidates
+        .iter()
+        .map(PathBuf::from)
+        .find(|p| Path::new(p).exists())
+}
+
+/// Grab an OS-assigned free TCP port.
+fn free_port() -> Option<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").ok()?;
+    let port = listener.local_addr().ok()?.port();
+    drop(listener);
+    Some(port)
+}
+
+const ADMIN_TOKEN: &str = "test-admin-token-do-not-use-in-prod";
+
+/// Every mutating control-plane route must reject an unauthenticated request
+/// with 401. We exercise a representative set spanning projects, specs,
+/// plugins, artifacts, compilations, and api-keys.
+#[tokio::test]
+async fn mutating_routes_require_admin_token() {
+    // EXPECTED TO FAIL until BARB-SEC-001 is fixed (require_admin not yet wired
+    // into create_router; mutating routes are currently reachable unauthenticated).
+    let Some(cp) = TestControlPlane::boot(Some(ADMIN_TOKEN)).await else {
+        eprintln!("skip: control plane unavailable (need DATABASE_URL + built barbacane-control)");
+        return;
+    };
+
+    // (method, path, json-body) — one per mutating handler family.
+    let mutating: &[(reqwest::Method, &str, &str)] = &[
+        (reqwest::Method::POST, "/projects", r#"{"name":"x"}"#),
+        (
+            reqwest::Method::PUT,
+            "/projects/00000000-0000-0000-0000-000000000001",
+            r#"{"name":"y"}"#,
+        ),
+        (
+            reqwest::Method::DELETE,
+            "/projects/00000000-0000-0000-0000-000000000001",
+            "",
+        ),
+        (
+            reqwest::Method::POST,
+            "/specs",
+            r#"{"name":"x","content":"openapi: 3.1.0"}"#,
+        ),
+        (
+            reqwest::Method::DELETE,
+            "/specs/00000000-0000-0000-0000-000000000002",
+            "",
+        ),
+        (
+            reqwest::Method::POST,
+            "/specs/00000000-0000-0000-0000-000000000002/compile",
+            "{}",
+        ),
+        (
+            reqwest::Method::POST,
+            "/plugins",
+            r#"{"name":"x","version":"0.1.0"}"#,
+        ),
+        (reqwest::Method::DELETE, "/plugins/x/0.1.0", ""),
+        (
+            reqwest::Method::DELETE,
+            "/artifacts/00000000-0000-0000-0000-000000000003",
+            "",
+        ),
+        (
+            reqwest::Method::DELETE,
+            "/compilations/00000000-0000-0000-0000-000000000004",
+            "",
+        ),
+        (
+            reqwest::Method::POST,
+            "/projects/00000000-0000-0000-0000-000000000001/api-keys",
+            "{}",
+        ),
+        (
+            reqwest::Method::POST,
+            "/projects/00000000-0000-0000-0000-000000000001/deploy",
+            "{}",
+        ),
+    ];
+
+    for (method, path, body) in mutating {
+        let resp = cp
+            .client
+            .request(method.clone(), cp.url(path))
+            .header("content-type", "application/json")
+            .body(body.to_string())
+            .send()
+            .await
+            .expect("request to control plane failed");
+        assert_eq!(
+            resp.status(),
+            401,
+            "{} {} must require an admin token (got {})",
+            method,
+            path,
+            resp.status()
+        );
+    }
+}
+
+/// With a valid admin token, a representative mutating route is accepted
+/// (i.e. the auth layer is gating, not blanket-denying). We assert the status
+/// is anything other than 401 — the request reaches the handler.
+#[tokio::test]
+async fn valid_admin_token_is_accepted() {
+    // EXPECTED TO FAIL until BARB-SEC-001 is fixed.
+    let Some(cp) = TestControlPlane::boot(Some(ADMIN_TOKEN)).await else {
+        eprintln!("skip: control plane unavailable (need DATABASE_URL + built barbacane-control)");
+        return;
+    };
+
+    let resp = cp
+        .client
+        .post(cp.url("/projects"))
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {}", ADMIN_TOKEN))
+        .body(r#"{"name":"authz-smoke-test"}"#.to_string())
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_ne!(
+        resp.status(),
+        401,
+        "a valid admin token must not be rejected as unauthorized"
+    );
+}
+
+/// `/health` must remain reachable WITHOUT a token (it is the liveness probe
+/// and is explicitly excluded from the admin-auth requirement).
+#[tokio::test]
+async fn health_is_exempt_from_auth() {
+    // This is a positive control: it should pass both before and after the fix.
+    let Some(cp) = TestControlPlane::boot(Some(ADMIN_TOKEN)).await else {
+        eprintln!("skip: control plane unavailable (need DATABASE_URL + built barbacane-control)");
+        return;
+    };
+
+    let resp = cp
+        .client
+        .get(cp.url("/health"))
+        .send()
+        .await
+        .expect("request failed");
+    assert!(
+        resp.status().is_success(),
+        "/health must be reachable without an admin token"
+    );
+}
+
+/// The server must fail-closed: starting `serve` with no
+/// `BARBACANE_CONTROL_ADMIN_TOKEN` set must refuse to start (so an operator
+/// cannot accidentally expose an unauthenticated control plane).
+#[tokio::test]
+async fn server_refuses_to_start_without_admin_token() {
+    // EXPECTED TO FAIL until BARB-SEC-001 is fixed (serve currently starts with
+    // no token configured).
+    //
+    // We assert via `boot(None)` returning None *because the process exited*.
+    // To distinguish "exited (good)" from "no DB / no binary (skip)", we first
+    // require the prerequisites to exist, then assert boot fails.
+    if std::env::var("DATABASE_URL").is_err() || find_control_binary().is_none() {
+        eprintln!("skip: control plane unavailable (need DATABASE_URL + built barbacane-control)");
+        return;
+    }
+
+    let booted = TestControlPlane::boot(None).await;
+    assert!(
+        booted.is_none(),
+        "control plane must fail-closed and refuse to serve without BARBACANE_CONTROL_ADMIN_TOKEN"
+    );
+}
+
+/// Project-scoped IDOR: a credential scoped to project A must not be able to
+/// read project B's spec / artifact / api-keys.
+///
+/// NOTE: per-project credentials do not exist yet in the model (only a single
+/// shared admin token is planned for the first hardening pass), and the global
+/// `/specs/{id}` / `/artifacts/{id}` routes carry no project scoping at all.
+/// This test documents the intended end-state and is parked behind `#[ignore]`
+/// until the ownership model lands.
+#[tokio::test]
+#[ignore = "BLOCKED: per-project credentials + ownership checks on global /specs/{id} and /artifacts/{id} not implemented (BARB-SEC-001 phase 2)"]
+async fn project_scoped_idor_is_blocked() {
+    // EXPECTED TO FAIL until BARB-SEC-001 (phase 2) is fixed.
+    let Some(cp) = TestControlPlane::boot(Some(ADMIN_TOKEN)).await else {
+        eprintln!("skip: control plane unavailable");
+        return;
+    };
+
+    // Intent: create project A and project B, mint a project-A-scoped token,
+    // upload a spec under B, then assert A's token gets 403/404 reading B's
+    // resources. Wiring this requires the per-project token API, which is not
+    // yet present, hence #[ignore]. The shared-token boot above keeps the test
+    // compiling against the current binary surface.
+    let _ = cp.url("/projects");
+}

--- a/crates/barbacane-test/tests/security/crypto_auth.rs
+++ b/crates/barbacane-test/tests/security/crypto_auth.rs
@@ -1,0 +1,218 @@
+//! BARB-SEC-005 — Crypto / auth: JWT validation and trust of forged client IPs.
+//!
+//! Two threat families, end-to-end through the gateway:
+//!
+//!   * **JWT validation** — `alg:none`, expired `exp`, wrong `aud`, and a
+//!     tampered signature must all be rejected; a validly-signed token must be
+//!     accepted. (`jwt-auth` rejects `alg:none`/HMAC and enforces exp/aud
+//!     today, but real signature verification is not yet implemented — so the
+//!     "validly-signed token is accepted" assertion is RED.)
+//!
+//!   * **Forged `X-Forwarded-For`** — a client-supplied XFF header must not let
+//!     a request bypass `ip-restriction` or steer `rate-limit` partitioning.
+//!     Today `ip-restriction::extract_client_ip` trusts the first XFF value
+//!     unconditionally, so a forged header changes the effective client IP. The
+//!     fix only trusts XFF from configured trusted proxies and otherwise uses
+//!     the real peer address.
+
+use barbacane_test::TestGateway;
+
+use crate::{encode_jwt, fixture, now_timestamp, security_fixture};
+
+// ---------------------------------------------------------------------------
+// JWT validation — regression locks (should pass today) + the RED signature case
+// ---------------------------------------------------------------------------
+
+/// A token with `alg: none` must be rejected. (Regression lock: jwt-auth
+/// already rejects `none`; this keeps it that way.)
+#[tokio::test]
+async fn jwt_alg_none_is_rejected() {
+    let gw = TestGateway::from_spec(&fixture("jwt-auth.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    let header = serde_json::json!({"alg": "none", "typ": "JWT"});
+    let claims = serde_json::json!({
+        "sub": "attacker",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": now_timestamp() + 3600,
+    });
+    // alg:none tokens conventionally carry an empty signature.
+    let token = encode_jwt(&header, &claims, b"");
+
+    let resp = gw
+        .request_builder(reqwest::Method::GET, "/protected")
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401, "alg:none must be rejected");
+}
+
+/// An expired token must be rejected. (Regression lock.)
+#[tokio::test]
+async fn jwt_expired_is_rejected() {
+    let gw = TestGateway::from_spec(&fixture("jwt-auth.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    let header = serde_json::json!({"alg": "RS256", "typ": "JWT"});
+    let claims = serde_json::json!({
+        "sub": "user",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": now_timestamp() - 120, // 2 min ago, beyond 60s skew
+    });
+    let token = encode_jwt(&header, &claims, b"sig");
+
+    let resp = gw
+        .request_builder(reqwest::Method::GET, "/protected")
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401, "expired exp must be rejected");
+}
+
+/// A token with the wrong audience must be rejected. (Regression lock.)
+#[tokio::test]
+async fn jwt_wrong_audience_is_rejected() {
+    let gw = TestGateway::from_spec(&fixture("jwt-auth.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    let header = serde_json::json!({"alg": "RS256", "typ": "JWT"});
+    let claims = serde_json::json!({
+        "sub": "user",
+        "iss": "test-issuer",
+        "aud": "WRONG-audience",
+        "exp": now_timestamp() + 3600,
+    });
+    let token = encode_jwt(&header, &claims, b"sig");
+
+    let resp = gw
+        .request_builder(reqwest::Method::GET, "/protected")
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401, "wrong aud must be rejected");
+}
+
+/// A token with a tampered signature must be rejected when signature validation
+/// is enforced. (This already holds since jwt-auth fails closed when it cannot
+/// verify — but it must KEEP holding once real verification lands.)
+#[tokio::test]
+async fn jwt_tampered_signature_is_rejected() {
+    let gw = TestGateway::from_spec(&security_fixture("jwt-verify.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    let header = serde_json::json!({"alg": "RS256", "typ": "JWT"});
+    let claims = serde_json::json!({
+        "sub": "user",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": now_timestamp() + 3600,
+    });
+    let token = encode_jwt(&header, &claims, b"this-is-not-a-valid-signature");
+
+    let resp = gw
+        .request_builder(reqwest::Method::GET, "/protected")
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        401,
+        "a token with an invalid signature must be rejected"
+    );
+}
+
+/// A validly-signed token must be ACCEPTED when signature validation is enforced.
+///
+/// This is the discriminating case: today jwt-auth has no real signature
+/// verification (it fails closed for every token when `skip_signature_validation`
+/// is false), so even a correctly-signed token is rejected. The BARB-SEC-005 fix
+/// implements verification against `public_key_pem`, after which a properly
+/// signed token is accepted.
+#[tokio::test]
+#[ignore = "BLOCKED: requires real RS256 signature verification (public_key_pem) in jwt-auth, plus a matching private key in the fixture to sign with. See BARB-SEC-005."]
+async fn jwt_valid_signature_is_accepted() {
+    // EXPECTED TO FAIL until BARB-SEC-005 is fixed (signature verification
+    // unimplemented; fixture also needs a real RSA keypair so the test can sign).
+    let gw = TestGateway::from_spec(&security_fixture("jwt-verify.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    // Once verification exists, sign these claims with the private key matching
+    // the fixture's public_key_pem and assert 200.
+    let _ = &gw;
+}
+
+// ---------------------------------------------------------------------------
+// Forged X-Forwarded-For
+// ---------------------------------------------------------------------------
+
+/// A forged `X-Forwarded-For` must not let a request masquerade as a
+/// denylisted IP — and, by the same token, must not let an external client
+/// masquerade as an allowlisted one. The real test client is 127.0.0.1, which
+/// `ip-restriction.yaml`'s `/denylist` (deny 10.0.0.0/8, 192.168.0.0/16) allows.
+/// Forging `X-Forwarded-For: 10.0.0.5` currently flips the effective client IP
+/// into the denied range (→ 403). With the fix, untrusted XFF is ignored and the
+/// real peer (127.0.0.1) is used (→ 200).
+#[tokio::test]
+async fn forged_xff_does_not_bypass_ip_restriction() {
+    // EXPECTED TO FAIL until BARB-SEC-005 is fixed (ip-restriction trusts
+    // client-supplied X-Forwarded-For unconditionally).
+    let gw = TestGateway::from_spec(&fixture("ip-restriction.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    let resp = gw
+        .request_builder(reqwest::Method::GET, "/denylist")
+        .header("X-Forwarded-For", "10.0.0.5")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "a forged X-Forwarded-For must be ignored; the real peer (127.0.0.1) is \
+         not denylisted so the request must succeed"
+    );
+}
+
+/// A forged `X-Forwarded-For` must not partition the rate-limit buckets — an
+/// attacker must not be able to dodge their own rate limit by rotating the XFF
+/// header. With `partition_key: client_ip` and untrusted XFF ignored, all the
+/// requests below share one bucket and the (n+1)th is limited regardless of XFF.
+#[tokio::test]
+async fn forged_xff_does_not_reset_rate_limit_bucket() {
+    // EXPECTED TO FAIL until BARB-SEC-005 is fixed (client IP, and thus the
+    // rate-limit partition key, is derived from spoofable XFF).
+    let gw = TestGateway::from_spec(&security_fixture("xff-rate-limit.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    // Exhaust the quota (3) while rotating XFF on every request.
+    let mut last_status = 0u16;
+    for i in 0..5 {
+        let resp = gw
+            .request_builder(reqwest::Method::GET, "/limited")
+            .header("X-Forwarded-For", format!("203.0.113.{}", i))
+            .send()
+            .await
+            .unwrap();
+        last_status = resp.status().as_u16();
+    }
+
+    assert_eq!(
+        last_status, 429,
+        "rotating X-Forwarded-For must not create fresh rate-limit buckets; \
+         the 4th+ request must still be limited"
+    );
+}

--- a/crates/barbacane-test/tests/security/dos.rs
+++ b/crates/barbacane-test/tests/security/dos.rs
@@ -1,0 +1,139 @@
+//! BARB-SEC-003 — Denial of service / resource limits.
+//!
+//! Three sub-areas:
+//!
+//!   1. **Oversized chunked body** — a `Transfer-Encoding: chunked` request with
+//!      an over-limit body must be rejected with 413, and the gateway must not
+//!      buffer the whole body before deciding (it should bail as soon as the
+//!      streamed size crosses the cap).
+//!
+//!   2. **Slowloris / missing read timeout** — documented; hard to assert
+//!      deterministically without flaky wall-clock timing. See the `#[ignore]`
+//!      test below for the intended shape.
+//!
+//!   3. **404-flood metric cardinality** — a flood of unique unmatched paths must
+//!      NOT create one Prometheus series per raw path. The router currently
+//!      records `record_request_metrics(&method, &path, ...)` with the *raw*
+//!      request path on the `RouteMatch::NotFound` arm
+//!      (`crates/barbacane/src/main.rs`), so an attacker can blow up metric
+//!      cardinality (memory DoS) and exfiltrate scanned paths. The fix replaces
+//!      the label with a sentinel such as `<not_found>`.
+
+use barbacane_test::TestGateway;
+
+use crate::{fixture, security_fixture};
+
+// ---------------------------------------------------------------------------
+// 1. Oversized chunked body -> 413
+// ---------------------------------------------------------------------------
+
+/// A chunked request whose body exceeds the configured limit must get 413.
+///
+/// `request-size-limit.yaml` caps `/limited` at 100 bytes. We send ~64 KiB with
+/// `Transfer-Encoding: chunked` (reqwest streams a body of unknown length as
+/// chunked). The hardened gateway rejects it with 413.
+#[tokio::test]
+async fn oversized_chunked_body_rejected_with_413() {
+    // EXPECTED TO FAIL until BARB-SEC-003 is fixed (chunked bodies without a
+    // Content-Length must be size-capped while streaming, not buffered then
+    // checked / accepted).
+    let gw = TestGateway::from_spec(&fixture("request-size-limit.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    // A 64 KiB payload (limit is 100 bytes). Using a streaming body forces
+    // chunked transfer-encoding (no Content-Length).
+    let big = vec![b'a'; 64 * 1024];
+    let body = reqwest::Body::wrap_stream(futures_util::stream::once(async move {
+        Ok::<_, std::io::Error>(big)
+    }));
+
+    let resp = gw
+        .request_builder(reqwest::Method::POST, "/limited")
+        .header("content-type", "application/json")
+        .body(body)
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(
+        resp.status(),
+        413,
+        "oversized chunked body must be rejected with 413 Payload Too Large"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Slowloris / missing timeout (documented, non-deterministic)
+// ---------------------------------------------------------------------------
+
+/// Slowloris: a client that opens a connection and dribbles bytes (or never
+/// finishes the body) must be timed out so it cannot pin a worker indefinitely.
+///
+/// This is inherently timing-dependent and would require holding a socket open
+/// and measuring that the server closes it within a header/body read deadline.
+/// Asserting that deterministically (without sleeps that make CI flaky) needs a
+/// configurable, observable read timeout we can drive from the test. Parked
+/// until the gateway exposes a read/header timeout knob we can set low and a
+/// signal we can assert on.
+#[tokio::test]
+#[ignore = "BLOCKED: needs a configurable+observable read/header timeout to assert slowloris defence without flaky wall-clock sleeps (BARB-SEC-003)"]
+async fn slowloris_connection_is_timed_out() {
+    // EXPECTED TO FAIL until BARB-SEC-003 (slowloris) is addressed.
+    //
+    // Intended shape: open a raw TCP socket to the gateway, send a partial
+    // request ("GET /health HTTP/1.1\r\nHost: x\r\n") and then stop, and assert
+    // the server closes the connection within N seconds rather than waiting
+    // forever. Requires a deterministic timeout to assert against.
+}
+
+// ---------------------------------------------------------------------------
+// 3. 404-flood metric cardinality
+// ---------------------------------------------------------------------------
+
+/// Flooding unique unmatched paths must not create a distinct Prometheus series
+/// per raw path. We hit many random 404 paths, then scrape `/metrics` and
+/// assert (a) none of the raw flood paths appear as label values, and (b) a
+/// `<not_found>` sentinel label is present instead.
+#[tokio::test]
+async fn not_found_flood_does_not_explode_metric_cardinality() {
+    // EXPECTED TO FAIL until BARB-SEC-003 is fixed (RouteMatch::NotFound records
+    // the raw request path as a metric label; should use a `<not_found>`
+    // sentinel).
+    let gw = TestGateway::from_spec(&security_fixture("metrics.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    // Flood unique 404 paths.
+    let unique_paths: Vec<String> = (0..50)
+        .map(|i| format!("/nonexistent-scan-{}-{}", std::process::id(), i))
+        .collect();
+    for p in &unique_paths {
+        let resp = gw.get(p).await.unwrap();
+        assert_eq!(resp.status(), 404, "{} should be a 404", p);
+    }
+
+    // Scrape the Prometheus metrics from the admin port.
+    let metrics = gw
+        .admin_get("/metrics")
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    // (a) No raw flood path may appear as a metric label value.
+    for p in &unique_paths {
+        assert!(
+            !metrics.contains(p.as_str()),
+            "raw 404 path {} leaked into Prometheus labels (unbounded cardinality DoS)",
+            p
+        );
+    }
+
+    // (b) Unmatched requests should collapse to a sentinel label.
+    assert!(
+        metrics.contains("<not_found>"),
+        "expected a `<not_found>` sentinel label for unmatched requests"
+    );
+}

--- a/crates/barbacane-test/tests/security/sandbox.rs
+++ b/crates/barbacane-test/tests/security/sandbox.rs
@@ -1,0 +1,63 @@
+//! BARB-SEC-004 — Plugin sandbox / capability confinement.
+//!
+//! Threat: the WASM linker registers ALL host functions
+//! (`add_host_functions` in `crates/barbacane-wasm/src/instance.rs`) regardless
+//! of what a plugin's manifest grants. A plugin whose manifest declares only the
+//! `log` capability can therefore still *import and call* `host_get_secret`,
+//! `host_http_call`, etc. — capability declarations are advisory at link time.
+//!
+//! Today the only enforcement is `validate_imports`
+//! (`crates/barbacane-wasm/src/validate.rs`), which rejects a module whose
+//! imports are not covered by its declared capabilities. That is load-time
+//! import validation, not a per-plugin linker. The hardening goal is a
+//! per-plugin, default-deny linker: a plugin only gets host functions for the
+//! capabilities it was granted, so even a module that smuggles an import past
+//! validation has nothing to call.
+//!
+//! ## Why this is expressed but `#[ignore]`d
+//!
+//! Asserting default-deny end-to-end requires either:
+//!   * a purpose-built adversarial WASM plugin that declares `log` only but
+//!     attempts `host_http_call` / `host_get_secret` (not present in the repo,
+//!     and building wasm in the integration harness is out of scope), or
+//!   * driving `barbacane-wasm` internals directly — but `barbacane-test` does
+//!     not (and per the additive constraint must not be made to) depend on
+//!     `barbacane-wasm`, and the linker entry points are private.
+//!
+//! So we document the intent and leave the test `#[ignore]`d with a precise
+//! note on what the maintainer must expose / build. The `validate_imports`
+//! positive control below *can* run today if exposed; it is also gated because
+//! the crate dependency is missing.
+
+/// A plugin granted only `log` must not be able to reach any other host
+/// function. With a per-plugin default-deny linker, an adversarial module that
+/// declares `capabilities = [log]` but imports `host_http_call` must fail to
+/// instantiate (or the call must trap), never silently succeed.
+#[tokio::test]
+#[ignore = "BLOCKED: needs (a) an adversarial fixture plugin declaring only `log` but importing host_http_call, and (b) a per-plugin default-deny linker in barbacane-wasm (currently add_host_functions registers ALL host fns). See BARB-SEC-004."]
+async fn log_only_plugin_cannot_call_other_host_functions() {
+    // EXPECTED TO FAIL until BARB-SEC-004 is fixed.
+    //
+    // Intended shape (once the adversarial plugin + per-plugin linker exist):
+    //   1. Compile a spec that bundles the `log-only-but-calls-http` plugin.
+    //   2. Boot the gateway; route a request through that plugin.
+    //   3. Assert the host call is denied — the plugin's attempt to invoke
+    //      host_http_call must trap/error, not perform the outbound request.
+}
+
+/// Load-time positive control: a module whose imports exceed its declared
+/// capabilities must be rejected by `validate_imports`.
+#[tokio::test]
+#[ignore = "BLOCKED: barbacane-test does not depend on barbacane-wasm; to run this, the maintainer must add barbacane-wasm as a dev-dependency and keep validate::validate_imports public. See BARB-SEC-004."]
+async fn imports_exceeding_declared_capabilities_are_rejected() {
+    // EXPECTED TO FAIL TO COMPILE without the barbacane-wasm dev-dependency.
+    //
+    // Intended body:
+    //   let module = Module::new(&engine, adversarial_wasm)?;
+    //   let result = barbacane_wasm::validate::validate_imports(
+    //       &module,
+    //       &["log".to_string()], // declares only `log`
+    //   );
+    //   assert!(result.is_err(), "module importing host_http_call under a
+    //           log-only manifest must be rejected");
+}

--- a/crates/barbacane-test/tests/security/ssrf.rs
+++ b/crates/barbacane-test/tests/security/ssrf.rs
@@ -1,0 +1,100 @@
+//! BARB-SEC-002 — Server-Side Request Forgery via the WASM host HTTP client.
+//!
+//! Threat: a plugin (or plugin *config*, which a spec author or a compromised
+//! control plane controls) can make the host issue outbound HTTP to an
+//! arbitrary URL. Without an egress policy, a plugin can reach the cloud
+//! instance-metadata service (169.254.169.254), loopback services, or internal
+//! RFC1918 hosts — classic SSRF.
+//!
+//! The fix: the host HTTP client
+//! (`crates/barbacane-wasm/src/http_client.rs`) must resolve the target host
+//! and refuse to connect when the resolved IP is loopback / link-local /
+//! private / metadata, INCLUDING after following redirects (so a public URL
+//! that 30x-redirects to 169.254.169.254 is still blocked).
+//!
+//! ## How these tests observe SSRF
+//!
+//! We drive the `opa-authz` middleware, whose `opa_url` is a plugin-controlled
+//! outbound call. The fixture mock dispatcher returns HTTP 200 only if the
+//! middleware *allows* the request, which only happens if the host call
+//! succeeds and the (non-existent) OPA endpoint returns an allow decision.
+//!
+//! The security invariant is therefore: **a request whose `opa_url` points at a
+//! blocked address must never return 200** (the protected upstream must never be
+//! reached). Today the host does not enforce an egress denylist, so a request
+//! pointed at, e.g., a co-located metadata mock could succeed — hence RED. Once
+//! the denylist lands, the host refuses the connection and the middleware
+//! fails closed (403/503), which is what we assert.
+
+use barbacane_test::TestGateway;
+
+use crate::security_fixture;
+
+/// Boot a gateway from the SSRF fixture.
+async fn ssrf_gateway() -> TestGateway {
+    TestGateway::from_spec(&security_fixture("ssrf.yaml"))
+        .await
+        .expect("ssrf fixture failed to compile/start")
+}
+
+/// The protected response (200 "reached") must never be returned for an
+/// `opa_url` pointing at the instance-metadata service.
+#[tokio::test]
+async fn metadata_endpoint_is_blocked() {
+    // EXPECTED TO FAIL until BARB-SEC-002 is fixed (host HTTP client has no
+    // resolved-IP denylist for link-local / metadata addresses).
+    let gw = ssrf_gateway().await;
+    let resp = gw.get("/ssrf-metadata").await.unwrap();
+    assert_ne!(
+        resp.status(),
+        200,
+        "host must refuse outbound HTTP to 169.254.169.254 (metadata SSRF); \
+         the protected upstream must never be reached"
+    );
+}
+
+/// Loopback targets must be blocked.
+#[tokio::test]
+async fn loopback_is_blocked() {
+    // EXPECTED TO FAIL until BARB-SEC-002 is fixed.
+    let gw = ssrf_gateway().await;
+    let resp = gw.get("/ssrf-loopback").await.unwrap();
+    assert_ne!(
+        resp.status(),
+        200,
+        "host must refuse outbound HTTP to 127.0.0.0/8 (loopback SSRF)"
+    );
+}
+
+/// RFC1918 private addresses must be blocked.
+#[tokio::test]
+async fn private_rfc1918_is_blocked() {
+    // EXPECTED TO FAIL until BARB-SEC-002 is fixed.
+    let gw = ssrf_gateway().await;
+    let resp = gw.get("/ssrf-private").await.unwrap();
+    assert_ne!(
+        resp.status(),
+        200,
+        "host must refuse outbound HTTP to 10.0.0.0/8 (private-network SSRF)"
+    );
+}
+
+/// A hostname that resolves to a metadata/link-local IP must be blocked after
+/// DNS resolution (the denylist must operate on the *resolved* IP, not the
+/// literal string). `metadata.google.internal` resolves to 169.254.169.254 in
+/// GCP; in CI it typically does not resolve, so this also covers the
+/// redirect-to-metadata shape: in either case the protected upstream must not
+/// be reached.
+#[tokio::test]
+async fn dns_resolved_metadata_is_blocked() {
+    // EXPECTED TO FAIL until BARB-SEC-002 is fixed (resolve-then-check, incl.
+    // redirect targets).
+    let gw = ssrf_gateway().await;
+    let resp = gw.get("/ssrf-dns-metadata").await.unwrap();
+    assert_ne!(
+        resp.status(),
+        200,
+        "host must resolve the hostname and refuse link-local / metadata IPs, \
+         including via redirects"
+    );
+}

--- a/crates/barbacane-wasm/src/chain.rs
+++ b/crates/barbacane-wasm/src/chain.rs
@@ -347,10 +347,14 @@ pub fn parse_middleware_output(
             let data = serde_json::to_vec(&parsed.data)
                 .map_err(|e| WasmError::InitFailed(format!("failed to serialize output: {}", e)))?;
 
-            if parsed.action == 0 || result_code == 0 {
-                Ok(OnRequestResult::Continue(data))
-            } else {
+            // Fail safe: short-circuit if EITHER the structured action or the
+            // ABI result code signals it. Continue only when both agree, so a
+            // deny-intent middleware (action != 0) is never downgraded to
+            // Continue just because its return code happened to be 0.
+            if parsed.action != 0 || result_code != 0 {
                 Ok(OnRequestResult::ShortCircuit(data))
+            } else {
+                Ok(OnRequestResult::Continue(data))
             }
         }
         Err(_) => {
@@ -426,6 +430,20 @@ mod tests {
         .unwrap();
 
         let result = parse_middleware_output(&output, 1).unwrap();
+        assert!(matches!(result, OnRequestResult::ShortCircuit(_)));
+    }
+
+    #[test]
+    fn parse_deny_action_not_downgraded_when_result_code_zero() {
+        // WA-10 regression: a deny-intent middleware (action != 0) must
+        // short-circuit even if its ABI return code is 0 — never fail open.
+        let output = serde_json::to_vec(&json!({
+            "action": 1,
+            "data": {"status": 403, "body": "Forbidden"}
+        }))
+        .unwrap();
+
+        let result = parse_middleware_output(&output, 0).unwrap();
         assert!(matches!(result, OnRequestResult::ShortCircuit(_)));
     }
 

--- a/crates/barbacane-wasm/src/http_client.rs
+++ b/crates/barbacane-wasm/src/http_client.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 use std::path::PathBuf;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use parking_lot::RwLock;
@@ -231,7 +231,7 @@ impl HttpClient {
             .to_string();
 
         // SSRF guard: reject internal/loopback/link-local/metadata targets.
-        ssrf_guard(&url).await?;
+        ssrf_guard(&url, self.base_config.allow_internal_egress).await?;
 
         let circuit_state = self.get_circuit_state(&host);
         if circuit_state == crate::circuit_breaker::CircuitState::Open {
@@ -293,7 +293,7 @@ impl HttpClient {
             .to_string();
 
         // SSRF guard: reject internal/loopback/link-local/metadata targets.
-        ssrf_guard(&url).await?;
+        ssrf_guard(&url, self.base_config.allow_internal_egress).await?;
 
         // Check circuit breaker
         let circuit_state = self.get_circuit_state(&host);
@@ -401,22 +401,6 @@ impl HttpClient {
     }
 }
 
-/// Whether plugins may reach internal/loopback/link-local/metadata targets.
-///
-/// SSRF protection is on by default. Operators with legitimate internal
-/// upstreams can opt out with `BARBACANE_ALLOW_INTERNAL_EGRESS=1`.
-fn internal_egress_allowed() -> bool {
-    static ALLOW: OnceLock<bool> = OnceLock::new();
-    *ALLOW.get_or_init(|| {
-        matches!(
-            std::env::var("BARBACANE_ALLOW_INTERNAL_EGRESS")
-                .ok()
-                .as_deref(),
-            Some("1" | "true" | "TRUE" | "yes")
-        )
-    })
-}
-
 /// Whether an IP address points at an internal / non-routable / metadata range
 /// that an untrusted plugin must not be able to reach.
 fn ip_is_internal(ip: &IpAddr) -> bool {
@@ -456,8 +440,8 @@ fn ip_is_internal(ip: &IpAddr) -> bool {
 /// Note: a separate connect-time resolution still occurs inside reqwest, so a
 /// rebinding attacker could in theory return a different address; pinning the
 /// vetted IP via a custom resolver is tracked as follow-up hardening.
-async fn ssrf_guard(url: &reqwest::Url) -> Result<(), HttpClientError> {
-    if internal_egress_allowed() {
+async fn ssrf_guard(url: &reqwest::Url, allow_internal: bool) -> Result<(), HttpClientError> {
+    if allow_internal {
         return Ok(());
     }
 
@@ -508,6 +492,10 @@ pub struct HttpClientConfig {
     pub default_timeout: Duration,
     /// Allow plaintext HTTP (development only).
     pub allow_plaintext: bool,
+    /// Allow plugin egress to internal/loopback/link-local/metadata targets,
+    /// disabling the SSRF guard. Off by default; operators opt in for trusted
+    /// internal upstreams.
+    pub allow_internal_egress: bool,
 }
 
 impl Default for HttpClientConfig {
@@ -518,6 +506,7 @@ impl Default for HttpClientConfig {
             connect_timeout: Duration::from_secs(10),
             default_timeout: Duration::from_secs(30),
             allow_plaintext: false,
+            allow_internal_egress: false,
         }
     }
 }
@@ -650,11 +639,11 @@ mod tests {
             "192.168.1.1",
             "172.16.0.1",
             "0.0.0.0",
-            "100.64.0.1",          // CGNAT
-            "::1",                 // IPv6 loopback
-            "fc00::1",             // IPv6 ULA
-            "fe80::1",             // IPv6 link-local
-            "::ffff:127.0.0.1",    // IPv4-mapped loopback
+            "100.64.0.1",       // CGNAT
+            "::1",              // IPv6 loopback
+            "fc00::1",          // IPv6 ULA
+            "fe80::1",          // IPv6 link-local
+            "::ffff:127.0.0.1", // IPv4-mapped loopback
             "::ffff:169.254.169.254",
         ];
         for s in blocked {
@@ -662,7 +651,12 @@ mod tests {
             assert!(ip_is_internal(&ip), "{s} should be classified internal");
         }
 
-        let allowed = ["8.8.8.8", "1.1.1.1", "93.184.216.34", "2606:4700:4700::1111"];
+        let allowed = [
+            "8.8.8.8",
+            "1.1.1.1",
+            "93.184.216.34",
+            "2606:4700:4700::1111",
+        ];
         for s in allowed {
             let ip: IpAddr = s.parse().unwrap();
             assert!(!ip_is_internal(&ip), "{s} should be classified external");
@@ -678,12 +672,15 @@ mod tests {
             "http://10.1.2.3/",
         ] {
             let parsed = url.parse::<reqwest::Url>().unwrap();
-            let err = ssrf_guard(&parsed).await.unwrap_err();
+            let err = ssrf_guard(&parsed, false).await.unwrap_err();
             assert!(
                 matches!(err, HttpClientError::BlockedTarget(_)),
                 "{url} should be blocked, got {err:?}"
             );
         }
+        // With internal egress allowed, the same targets pass the guard.
+        let parsed = "http://127.0.0.1:8081/".parse::<reqwest::Url>().unwrap();
+        assert!(ssrf_guard(&parsed, true).await.is_ok());
     }
 
     #[test]
@@ -846,6 +843,7 @@ mod tests {
     async fn stream_raw_rejects_invalid_method() {
         let config = HttpClientConfig {
             allow_plaintext: true,
+            allow_internal_egress: true,
             ..Default::default()
         };
         let client = HttpClient::new(config).expect("client");
@@ -866,6 +864,7 @@ mod tests {
     async fn stream_raw_connection_refused() {
         let config = HttpClientConfig {
             allow_plaintext: true,
+            allow_internal_egress: true,
             ..Default::default()
         };
         let client = HttpClient::new(config).expect("client");
@@ -896,6 +895,7 @@ mod tests {
 
         let config = HttpClientConfig {
             allow_plaintext: true,
+            allow_internal_egress: true,
             ..Default::default()
         };
         let client = HttpClient::new(config).expect("client");
@@ -935,6 +935,7 @@ mod tests {
 
         let config = HttpClientConfig {
             allow_plaintext: true,
+            allow_internal_egress: true,
             ..Default::default()
         };
         let client = HttpClient::new(config).expect("client");

--- a/crates/barbacane-wasm/src/http_client.rs
+++ b/crates/barbacane-wasm/src/http_client.rs
@@ -4,8 +4,9 @@
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
+use std::net::IpAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use parking_lot::RwLock;
@@ -112,6 +113,9 @@ impl HttpClient {
             .pool_idle_timeout(config.pool_idle_timeout)
             .connect_timeout(config.connect_timeout)
             .timeout(config.default_timeout)
+            // Disable redirect following: a permitted host could otherwise 3xx
+            // to an internal/metadata target, bypassing the SSRF guard below.
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .map_err(HttpClientError::BuildError)?;
 
@@ -160,7 +164,8 @@ impl HttpClient {
             .pool_max_idle_per_host(self.base_config.pool_max_idle_per_host)
             .pool_idle_timeout(self.base_config.pool_idle_timeout)
             .connect_timeout(self.base_config.connect_timeout)
-            .timeout(self.base_config.default_timeout);
+            .timeout(self.base_config.default_timeout)
+            .redirect(reqwest::redirect::Policy::none());
 
         // Add client certificate (mTLS)
         if let (Some(cert_path), Some(key_path)) = (&tls_config.client_cert, &tls_config.client_key)
@@ -225,6 +230,9 @@ impl HttpClient {
             .ok_or_else(|| HttpClientError::InvalidUrl("missing host".into()))?
             .to_string();
 
+        // SSRF guard: reject internal/loopback/link-local/metadata targets.
+        ssrf_guard(&url).await?;
+
         let circuit_state = self.get_circuit_state(&host);
         if circuit_state == crate::circuit_breaker::CircuitState::Open {
             return Err(HttpClientError::CircuitOpen(host));
@@ -283,6 +291,9 @@ impl HttpClient {
             .host_str()
             .ok_or_else(|| HttpClientError::InvalidUrl("missing host".into()))?
             .to_string();
+
+        // SSRF guard: reject internal/loopback/link-local/metadata targets.
+        ssrf_guard(&url).await?;
 
         // Check circuit breaker
         let circuit_state = self.get_circuit_state(&host);
@@ -390,6 +401,100 @@ impl HttpClient {
     }
 }
 
+/// Whether plugins may reach internal/loopback/link-local/metadata targets.
+///
+/// SSRF protection is on by default. Operators with legitimate internal
+/// upstreams can opt out with `BARBACANE_ALLOW_INTERNAL_EGRESS=1`.
+fn internal_egress_allowed() -> bool {
+    static ALLOW: OnceLock<bool> = OnceLock::new();
+    *ALLOW.get_or_init(|| {
+        matches!(
+            std::env::var("BARBACANE_ALLOW_INTERNAL_EGRESS")
+                .ok()
+                .as_deref(),
+            Some("1" | "true" | "TRUE" | "yes")
+        )
+    })
+}
+
+/// Whether an IP address points at an internal / non-routable / metadata range
+/// that an untrusted plugin must not be able to reach.
+fn ip_is_internal(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local() // 169.254.0.0/16, incl. 169.254.169.254 cloud metadata
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_multicast()
+                || v4.octets()[0] == 0 // 0.0.0.0/8
+                || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64) // 100.64.0.0/10 CGNAT
+        }
+        IpAddr::V6(v6) => {
+            // Unwrap IPv4-in-IPv6 forms and apply the v4 rules.
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return ip_is_internal(&IpAddr::V4(mapped));
+            }
+            if let Some(compat) = v6.to_ipv4() {
+                return ip_is_internal(&IpAddr::V4(compat));
+            }
+            let seg = v6.segments();
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || (seg[0] & 0xfe00) == 0xfc00 // fc00::/7 unique-local
+                || (seg[0] & 0xffc0) == 0xfe80 // fe80::/10 link-local
+        }
+    }
+}
+
+/// Reject requests whose target resolves to an internal address. Hostnames are
+/// resolved and rejected if *any* resolved address is internal, defending
+/// against a public name that points at an internal IP.
+///
+/// Note: a separate connect-time resolution still occurs inside reqwest, so a
+/// rebinding attacker could in theory return a different address; pinning the
+/// vetted IP via a custom resolver is tracked as follow-up hardening.
+async fn ssrf_guard(url: &reqwest::Url) -> Result<(), HttpClientError> {
+    if internal_egress_allowed() {
+        return Ok(());
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| HttpClientError::InvalidUrl("missing host".into()))?;
+    let host_clean = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+
+    if let Ok(ip) = host_clean.parse::<IpAddr>() {
+        if ip_is_internal(&ip) {
+            return Err(HttpClientError::BlockedTarget(host.to_string()));
+        }
+        return Ok(());
+    }
+
+    let port = url.port_or_known_default().unwrap_or(0);
+    let mut saw_any = false;
+    let addrs = tokio::net::lookup_host((host_clean, port))
+        .await
+        .map_err(|e| HttpClientError::ConnectionFailed(e.to_string()))?;
+    for addr in addrs {
+        saw_any = true;
+        if ip_is_internal(&addr.ip()) {
+            return Err(HttpClientError::BlockedTarget(host.to_string()));
+        }
+    }
+    if !saw_any {
+        return Err(HttpClientError::ConnectionFailed(format!(
+            "no DNS records for {host}"
+        )));
+    }
+    Ok(())
+}
+
 /// Configuration for the HTTP client.
 #[derive(Debug, Clone)]
 pub struct HttpClientConfig {
@@ -489,6 +594,9 @@ pub enum HttpClientError {
     #[error("circuit breaker open for host: {0}")]
     CircuitOpen(String),
 
+    #[error("target blocked by SSRF policy: {0}")]
+    BlockedTarget(String),
+
     #[error("request timeout")]
     Timeout,
 
@@ -532,6 +640,51 @@ mod option_duration_serde {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ssrf_classifier_blocks_internal_targets() {
+        let blocked = [
+            "127.0.0.1",
+            "169.254.169.254", // cloud metadata
+            "10.0.0.5",
+            "192.168.1.1",
+            "172.16.0.1",
+            "0.0.0.0",
+            "100.64.0.1",          // CGNAT
+            "::1",                 // IPv6 loopback
+            "fc00::1",             // IPv6 ULA
+            "fe80::1",             // IPv6 link-local
+            "::ffff:127.0.0.1",    // IPv4-mapped loopback
+            "::ffff:169.254.169.254",
+        ];
+        for s in blocked {
+            let ip: IpAddr = s.parse().unwrap();
+            assert!(ip_is_internal(&ip), "{s} should be classified internal");
+        }
+
+        let allowed = ["8.8.8.8", "1.1.1.1", "93.184.216.34", "2606:4700:4700::1111"];
+        for s in allowed {
+            let ip: IpAddr = s.parse().unwrap();
+            assert!(!ip_is_internal(&ip), "{s} should be classified external");
+        }
+    }
+
+    #[tokio::test]
+    async fn ssrf_guard_rejects_ip_literals_to_metadata_and_loopback() {
+        for url in [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://127.0.0.1:8081/",
+            "https://[::1]/",
+            "http://10.1.2.3/",
+        ] {
+            let parsed = url.parse::<reqwest::Url>().unwrap();
+            let err = ssrf_guard(&parsed).await.unwrap_err();
+            assert!(
+                matches!(err, HttpClientError::BlockedTarget(_)),
+                "{url} should be blocked, got {err:?}"
+            );
+        }
+    }
 
     #[test]
     fn test_config_default() {

--- a/crates/barbacane-wasm/src/manifest.rs
+++ b/crates/barbacane-wasm/src/manifest.rs
@@ -154,6 +154,8 @@ const KNOWN_CAPABILITIES: &[&str] = &[
     "generate_uuid",
     "verify_signature",
     "ws_upgrade",
+    "cache",
+    "rate_limit",
 ];
 
 /// Check if a capability name is known.
@@ -169,9 +171,11 @@ pub fn capability_to_imports(capability: &str) -> &'static [&'static str] {
         "context_set" => &["host_context_set"],
         "clock_now" => &["host_clock_now"],
         "get_secret" => &["host_get_secret", "host_secret_read_result"],
-        "http_call" => &["host_http_call", "host_http_read_result"],
+        "http_call" => &["host_http_call", "host_http_read_result", "host_http_stream"],
         "kafka_publish" => &["host_kafka_publish"],
         "nats_publish" => &["host_nats_publish"],
+        "cache" => &["host_cache_get", "host_cache_set", "host_cache_read_result"],
+        "rate_limit" => &["host_rate_limit_check", "host_rate_limit_read_result"],
         "telemetry" => &[
             "host_metric_counter_inc",
             "host_metric_histogram_observe",

--- a/crates/barbacane-wasm/src/manifest.rs
+++ b/crates/barbacane-wasm/src/manifest.rs
@@ -169,11 +169,21 @@ pub fn capability_to_imports(capability: &str) -> &'static [&'static str] {
         "log" => &["host_log"],
         "context_get" => &["host_context_get", "host_context_read_result"],
         "context_set" => &["host_context_set"],
-        "clock_now" => &["host_clock_now"],
+        // clock_now: canonical + the time aliases the host still exposes.
+        "clock_now" => &["host_clock_now", "host_time_now", "host_get_unix_timestamp"],
         "get_secret" => &["host_get_secret", "host_secret_read_result"],
-        "http_call" => &["host_http_call", "host_http_read_result", "host_http_stream"],
-        "kafka_publish" => &["host_kafka_publish"],
-        "nats_publish" => &["host_nats_publish"],
+        // http_call also covers the outbound-body side-channel functions.
+        "http_call" => &[
+            "host_http_call",
+            "host_http_read_result",
+            "host_http_stream",
+            "host_http_request_body_set",
+            "host_http_response_body_len",
+            "host_http_response_body_read",
+        ],
+        // Broker dispatchers read async results via the shared broker channel.
+        "kafka_publish" => &["host_kafka_publish", "host_broker_read_result"],
+        "nats_publish" => &["host_nats_publish", "host_broker_read_result"],
         "cache" => &["host_cache_get", "host_cache_set", "host_cache_read_result"],
         "rate_limit" => &["host_rate_limit_check", "host_rate_limit_read_result"],
         "telemetry" => &[

--- a/crates/barbacane-wasm/src/secrets.rs
+++ b/crates/barbacane-wasm/src/secrets.rs
@@ -78,9 +78,9 @@ fn confine_secret_path(path: &str) -> Result<std::path::PathBuf, SecretsError> {
             "file:// secret references require BARBACANE_SECRETS_DIR to be set".to_string(),
         )
     })?;
-    let base = std::path::Path::new(&base).canonicalize().map_err(|e| {
-        SecretsError::FileReadError(format!("invalid BARBACANE_SECRETS_DIR: {e}"))
-    })?;
+    let base = std::path::Path::new(&base)
+        .canonicalize()
+        .map_err(|e| SecretsError::FileReadError(format!("invalid BARBACANE_SECRETS_DIR: {e}")))?;
 
     let requested = std::path::Path::new(path);
     let joined = if requested.is_absolute() {

--- a/crates/barbacane-wasm/src/secrets.rs
+++ b/crates/barbacane-wasm/src/secrets.rs
@@ -64,6 +64,46 @@ impl SecretsStore {
     }
 }
 
+/// Confine a `file://` secret path to the operator-configured secrets
+/// directory (`BARBACANE_SECRETS_DIR`).
+///
+/// Without this, `file://` is an arbitrary-file-read primitive
+/// (`file:///etc/shadow`, `file:///proc/self/environ`). We require an explicit
+/// base directory and verify, after canonicalization (which resolves symlinks
+/// and `..`), that the target stays inside it. Fails closed when the base dir
+/// is not configured.
+fn confine_secret_path(path: &str) -> Result<std::path::PathBuf, SecretsError> {
+    let base = std::env::var_os("BARBACANE_SECRETS_DIR").ok_or_else(|| {
+        SecretsError::FileReadError(
+            "file:// secret references require BARBACANE_SECRETS_DIR to be set".to_string(),
+        )
+    })?;
+    let base = std::path::Path::new(&base).canonicalize().map_err(|e| {
+        SecretsError::FileReadError(format!("invalid BARBACANE_SECRETS_DIR: {e}"))
+    })?;
+
+    let requested = std::path::Path::new(path);
+    let joined = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        base.join(requested)
+    };
+    let canonical = joined.canonicalize().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            SecretsError::FileNotFound(path.to_string())
+        } else {
+            SecretsError::FileReadError(format!("{}: {}", path, e))
+        }
+    })?;
+
+    if !canonical.starts_with(&base) {
+        return Err(SecretsError::FileReadError(format!(
+            "secret path '{path}' escapes BARBACANE_SECRETS_DIR"
+        )));
+    }
+    Ok(canonical)
+}
+
 /// Check if a string value is a secret reference.
 pub fn is_secret_reference(value: &str) -> bool {
     value.starts_with("env://")
@@ -77,12 +117,14 @@ pub fn is_secret_reference(value: &str) -> bool {
 ///
 /// Currently supports:
 /// - `env://VAR_NAME` - Environment variable
-/// - `file:///path/to/secret` - File content (trimmed)
+/// - `file:///path/to/secret` - File content (trimmed), confined to the
+///   directory named by `BARBACANE_SECRETS_DIR`
 pub fn resolve_secret(reference: &str) -> Result<String, SecretsError> {
     if let Some(var_name) = reference.strip_prefix("env://") {
         std::env::var(var_name).map_err(|_| SecretsError::EnvNotFound(var_name.to_string()))
     } else if let Some(path) = reference.strip_prefix("file://") {
-        std::fs::read_to_string(path)
+        let resolved = confine_secret_path(path)?;
+        std::fs::read_to_string(&resolved)
             .map(|s| s.trim().to_string())
             .map_err(|e| {
                 if e.kind() == std::io::ErrorKind::NotFound {
@@ -235,22 +277,42 @@ mod tests {
         assert!(matches!(result, Err(SecretsError::EnvNotFound(_))));
     }
 
+    // All `file://` assertions live in one test: they mutate the shared
+    // BARBACANE_SECRETS_DIR env var, so keeping them sequential avoids the
+    // cross-thread race that separate parallel tests would introduce.
     #[test]
-    fn test_resolve_file_secret() {
+    fn test_resolve_file_secret_confinement() {
         use std::io::Write;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("secret.txt");
         let mut file = std::fs::File::create(&path).unwrap();
         writeln!(file, "file-secret-value").unwrap();
 
-        let result = resolve_secret(&format!("file://{}", path.display()));
-        assert_eq!(result.unwrap(), "file-secret-value");
-    }
+        // Fail closed when no secrets dir is configured.
+        std::env::remove_var("BARBACANE_SECRETS_DIR");
+        assert!(matches!(
+            resolve_secret(&format!("file://{}", path.display())),
+            Err(SecretsError::FileReadError(_))
+        ));
 
-    #[test]
-    fn test_resolve_file_not_found() {
-        let result = resolve_secret("file:///nonexistent/path/to/secret");
-        assert!(matches!(result, Err(SecretsError::FileNotFound(_))));
+        // Confined read succeeds inside the configured dir.
+        std::env::set_var("BARBACANE_SECRETS_DIR", dir.path());
+        assert_eq!(
+            resolve_secret(&format!("file://{}", path.display())).unwrap(),
+            "file-secret-value"
+        );
+
+        // Absolute path outside the dir is rejected.
+        assert!(resolve_secret("file:///etc/hostname").is_err());
+
+        // Missing file inside the dir → FileNotFound.
+        let missing = dir.path().join("nope.txt");
+        assert!(matches!(
+            resolve_secret(&format!("file://{}", missing.display())),
+            Err(SecretsError::FileNotFound(_))
+        ));
+
+        std::env::remove_var("BARBACANE_SECRETS_DIR");
     }
 
     #[test]

--- a/crates/barbacane-wasm/src/validate.rs
+++ b/crates/barbacane-wasm/src/validate.rs
@@ -49,8 +49,18 @@ pub fn validate_imports(
     // Build the set of allowed imports
     let mut allowed: HashSet<&str> = HashSet::new();
 
-    // host_set_output is always allowed (not a capability)
-    allowed.insert("host_set_output");
+    // Core ABI functions are always allowed — they are part of the plugin
+    // contract (output + the request/response body side-channel governed by the
+    // manifest `body_access` flag), not capability-gated host functions.
+    for core in [
+        "host_set_output",
+        "host_body_len",
+        "host_body_read",
+        "host_body_set",
+        "host_body_clear",
+    ] {
+        allowed.insert(core);
+    }
 
     // Add imports for each declared capability
     for capability in declared_capabilities {
@@ -209,5 +219,35 @@ mod tests {
     fn unknown_capability_returns_empty() {
         let imports = capability_to_imports("unknown");
         assert!(imports.is_empty());
+    }
+
+    fn module_with_import(import: &str) -> wasmtime::Module {
+        let engine = wasmtime::Engine::default();
+        let wat = format!(
+            r#"(module
+                 (import "barbacane" "{import}" (func (param i32 i32)))
+                 (memory (export "memory") 1))"#
+        );
+        let wasm = wat::parse_str(&wat).expect("valid wat");
+        wasmtime::Module::new(&engine, &wasm).expect("valid module")
+    }
+
+    #[test]
+    fn validate_imports_rejects_undeclared_capability() {
+        // A plugin that declares only `log` must not be able to import
+        // host_http_call (the http_call capability) — default-deny.
+        let module = module_with_import("host_http_call");
+        let declared = vec!["log".to_string()];
+        let err = validate_imports(&module, &declared).unwrap_err();
+        assert!(matches!(err, WasmError::UndeclaredImport(name) if name == "host_http_call"));
+    }
+
+    #[test]
+    fn validate_imports_allows_declared_capability_and_core_abi() {
+        // host_log is covered by the declared `log` capability...
+        assert!(validate_imports(&module_with_import("host_log"), &["log".to_string()]).is_ok());
+        // ...and the core body ABI is always allowed regardless of capabilities.
+        assert!(validate_imports(&module_with_import("host_body_read"), &[]).is_ok());
+        assert!(validate_imports(&module_with_import("host_set_output"), &[]).is_ok());
     }
 }

--- a/crates/barbacane/src/admin.rs
+++ b/crates/barbacane/src/admin.rs
@@ -183,6 +183,8 @@ mod tests {
                 source: Some("ci/github-actions".to_string()),
             },
             mcp: barbacane_compiler::McpConfig::default(),
+            signature: None,
+            signing_public_key: None,
         }
     }
 
@@ -279,6 +281,8 @@ mod tests {
             artifact_hash: "sha256:test".to_string(),
             provenance: barbacane_compiler::Provenance::default(),
             mcp: barbacane_compiler::McpConfig::default(),
+            signature: None,
+            signing_public_key: None,
         };
         let state = Arc::new(AdminState {
             manifest: Arc::new(ArcSwap::new(Arc::new(manifest))),
@@ -317,6 +321,8 @@ mod tests {
             artifact_hash: "sha256:test".to_string(),
             provenance: barbacane_compiler::Provenance::default(),
             mcp: barbacane_compiler::McpConfig::default(),
+            signature: None,
+            signing_public_key: None,
         };
         let state = Arc::new(AdminState {
             manifest: Arc::new(ArcSwap::new(Arc::new(manifest))),

--- a/crates/barbacane/src/admin.rs
+++ b/crates/barbacane/src/admin.rs
@@ -185,6 +185,7 @@ mod tests {
             mcp: barbacane_compiler::McpConfig::default(),
             signature: None,
             signing_public_key: None,
+            capabilities_enforced: false,
         }
     }
 
@@ -283,6 +284,7 @@ mod tests {
             mcp: barbacane_compiler::McpConfig::default(),
             signature: None,
             signing_public_key: None,
+            capabilities_enforced: false,
         };
         let state = Arc::new(AdminState {
             manifest: Arc::new(ArcSwap::new(Arc::new(manifest))),
@@ -323,6 +325,7 @@ mod tests {
             mcp: barbacane_compiler::McpConfig::default(),
             signature: None,
             signing_public_key: None,
+            capabilities_enforced: false,
         };
         let state = Arc::new(AdminState {
             manifest: Arc::new(ArcSwap::new(Arc::new(manifest))),

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -44,6 +44,12 @@ use uuid::Uuid;
 /// Server version for the Server header.
 const SERVER_VERSION: &str = concat!("barbacane/", env!("CARGO_PKG_VERSION"));
 
+/// Metric `path` label used for requests that never matched a declared route
+/// (unmatched, method-not-allowed, or rejected before routing). Using a fixed
+/// sentinel instead of the raw request path keeps Prometheus series cardinality
+/// bounded — a scanner hitting random URLs cannot create unbounded time-series.
+const UNMATCHED_ROUTE_LABEL: &str = "<unmatched>";
+
 use barbacane_telemetry::MetricsRegistry;
 use std::collections::HashMap;
 
@@ -718,6 +724,29 @@ impl Gateway {
             tracing::warn!("no plugins bundled in artifact - ensure barbacane.yaml manifest was used during compilation");
         }
 
+        // AR-1: verify artifact integrity before instantiating any plugin.
+        // The hash/checksum checks always run (detect tampering or corruption);
+        // an Ed25519 signature is additionally required when a trusted public
+        // key is pinned via BARBACANE_TRUSTED_PUBKEY.
+        barbacane_compiler::verify_artifact_hash(&manifest)
+            .map_err(|e| format!("artifact integrity check failed: {}", e))?;
+        for (name, loaded) in &bundled_plugins {
+            barbacane_compiler::verify_plugin_checksum(&manifest, name, &loaded.wasm_bytes)
+                .map_err(|e| format!("artifact integrity check failed: {}", e))?;
+        }
+        match std::env::var("BARBACANE_TRUSTED_PUBKEY") {
+            Ok(pubkey) if !pubkey.trim().is_empty() => {
+                barbacane_compiler::verify_artifact_signature(&manifest, &pubkey)
+                    .map_err(|e| format!("artifact signature verification failed: {}", e))?;
+                tracing::info!("artifact Ed25519 signature verified");
+            }
+            _ => {
+                tracing::warn!(
+                    "artifact signature verification disabled; set BARBACANE_TRUSTED_PUBKEY to require a valid Ed25519 signature"
+                );
+            }
+        }
+
         // Compile all plugin modules first (we'll register them after creating the final pool)
         let mut compiled_modules = Vec::new();
         for (name, loaded) in bundled_plugins {
@@ -897,15 +926,18 @@ impl Gateway {
     ) -> Response<B> {
         let headers = response.headers_mut();
 
-        // Observability headers
+        // Observability headers. `request_id`/`trace_id` may originate from
+        // client-supplied headers, so never panic on a value that isn't a legal
+        // header value — fall back to a placeholder instead.
         headers.insert("server", HeaderValue::from_static(SERVER_VERSION));
         headers.insert(
             "x-request-id",
-            HeaderValue::from_str(request_id).expect("uuid is valid ASCII"),
+            HeaderValue::from_str(request_id)
+                .unwrap_or_else(|_| HeaderValue::from_static("invalid")),
         );
         headers.insert(
             "x-trace-id",
-            HeaderValue::from_str(trace_id).expect("uuid is valid ASCII"),
+            HeaderValue::from_str(trace_id).unwrap_or_else(|_| HeaderValue::from_static("invalid")),
         );
 
         // Security headers (enabled by default)
@@ -953,11 +985,14 @@ impl Gateway {
         let method = req.method().clone();
         let method_str = method.as_str().to_string();
 
-        // Generate or extract request ID (from incoming header or new UUID)
+        // Generate or extract request ID (from incoming header or new UUID).
+        // Only accept a client-supplied id if it is a legal, non-empty header
+        // value; otherwise generate one (prevents header-injection / panics).
         let request_id = req
             .headers()
             .get("x-request-id")
             .and_then(|v| v.to_str().ok())
+            .filter(|s| !s.is_empty() && HeaderValue::from_str(s).is_ok())
             .map(|s| s.to_string())
             .unwrap_or_else(|| Uuid::new_v4().to_string());
 
@@ -982,7 +1017,8 @@ impl Gateway {
             let response = self.validation_error_response(&[e]);
             self.record_request_metrics(
                 &method_str,
-                &path,
+                // Bounded label: raw paths would let a scanner explode metric cardinality.
+                UNMATCHED_ROUTE_LABEL,
                 response.status().as_u16(),
                 0,
                 0,
@@ -1025,7 +1061,7 @@ impl Gateway {
             let response = self.validation_error_response(&[e]);
             self.record_request_metrics(
                 &method_str,
-                &path,
+                UNMATCHED_ROUTE_LABEL,
                 response.status().as_u16(),
                 0,
                 0,
@@ -1045,7 +1081,7 @@ impl Gateway {
                     let response = self.validation_error_response(&[e]);
                     self.record_request_metrics(
                         &method_str,
-                        &path,
+                        UNMATCHED_ROUTE_LABEL,
                         response.status().as_u16(),
                         0,
                         0,
@@ -1212,7 +1248,7 @@ impl Gateway {
                                     .await;
                                 self.record_request_metrics(
                                     &method_str,
-                                    &path,
+                                    UNMATCHED_ROUTE_LABEL,
                                     response.status().as_u16(),
                                     0,
                                     0,
@@ -1228,7 +1264,7 @@ impl Gateway {
                 let response = self.method_not_allowed_response(allowed, &method_str, &path);
                 self.record_request_metrics(
                     &method_str,
-                    &path,
+                    UNMATCHED_ROUTE_LABEL,
                     response.status().as_u16(),
                     0,
                     0,
@@ -1244,7 +1280,7 @@ impl Gateway {
                 let response = self.not_found_response();
                 self.record_request_metrics(
                     &method_str,
-                    &path,
+                    UNMATCHED_ROUTE_LABEL,
                     response.status().as_u16(),
                     0,
                     0,

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -694,9 +694,18 @@ impl Gateway {
         let specs =
             load_specs(artifact_path).map_err(|e| format!("failed to load specs: {}", e))?;
 
-        // Initialize HTTP client for upstream requests and plugin outbound calls
+        // Initialize HTTP client for upstream requests and plugin outbound calls.
+        // SSRF guard is on by default; operators opt out for trusted internal
+        // upstreams via BARBACANE_ALLOW_INTERNAL_EGRESS.
+        let allow_internal_egress = matches!(
+            std::env::var("BARBACANE_ALLOW_INTERNAL_EGRESS")
+                .ok()
+                .as_deref(),
+            Some("1" | "true" | "TRUE" | "yes")
+        );
         let http_client_config = HttpClientConfig {
             allow_plaintext: allow_plaintext_upstream,
+            allow_internal_egress,
             ..Default::default()
         };
         let http_client = HttpClient::new(http_client_config)
@@ -747,6 +756,17 @@ impl Gateway {
             }
         }
 
+        // WA-1: capability enforcement only applies to artifacts whose per-plugin
+        // capabilities are authoritative (compiled from plugin.toml). Artifacts
+        // built without them (e.g. via the control-plane registry, which does
+        // not yet persist capabilities) are loaded without enforcement.
+        let enforce_capabilities = manifest.capabilities_enforced;
+        if !enforce_capabilities {
+            tracing::warn!(
+                "plugin capability enforcement disabled: artifact has no authoritative capabilities"
+            );
+        }
+
         // Compile all plugin modules first (we'll register them after creating the final pool)
         let mut compiled_modules = Vec::new();
         for (name, loaded) in bundled_plugins {
@@ -758,6 +778,26 @@ impl Gateway {
                     loaded.body_access,
                 )
                 .map_err(|e| format!("failed to compile plugin '{}': {}", name, e))?;
+
+            // WA-1: enforce the capability contract. The plugin may only import
+            // host functions covered by the capabilities it declared in
+            // plugin.toml (carried in the artifact manifest); anything else is a
+            // hard load failure (default-deny).
+            if enforce_capabilities {
+                let declared = manifest
+                    .plugins
+                    .iter()
+                    .find(|p| p.name == name)
+                    .map(|p| p.capabilities.host_functions.clone())
+                    .unwrap_or_default();
+                barbacane_wasm::validate_imports(module.module(), &declared).map_err(|e| {
+                    format!(
+                        "plugin '{}' violates its declared capabilities: {}",
+                        name, e
+                    )
+                })?;
+            }
+
             compiled_modules.push((name, loaded.version, module));
         }
 

--- a/crates/barbacane/src/mcp/mod.rs
+++ b/crates/barbacane/src/mcp/mod.rs
@@ -108,20 +108,22 @@ impl McpServer {
 
         let is_notification = req.id.is_none();
 
-        // Session validation for non-initialize, non-notification requests
+        // Session validation for non-initialize, non-notification requests.
+        // Fail closed: a missing session header is rejected exactly like an
+        // invalid one. Otherwise a client could skip the check entirely (and
+        // reach `tools/list` / `tools/call`) simply by omitting `Mcp-Session-Id`.
         if req.method != "initialize" && !is_notification {
-            if let Some(sid) = session_id {
-                if !self.session_store.touch(sid) {
-                    let resp = JsonRpcResponse::error(
-                        req.id,
-                        INVALID_REQUEST,
-                        "invalid or expired session",
-                    );
-                    return McpResult::Response {
-                        body: serde_json::to_vec(&resp).unwrap_or_default(),
-                        session_id: None,
-                    };
-                }
+            let session_ok = session_id.is_some_and(|sid| self.session_store.touch(sid));
+            if !session_ok {
+                let resp = JsonRpcResponse::error(
+                    req.id,
+                    INVALID_REQUEST,
+                    "missing, invalid, or expired session; call initialize first",
+                );
+                return McpResult::Response {
+                    body: serde_json::to_vec(&resp).unwrap_or_default(),
+                    session_id: None,
+                };
             }
         }
 
@@ -361,8 +363,9 @@ mod tests {
     #[test]
     fn tools_list_returns_mcp_enabled_tools() {
         let server = make_server();
+        let sid = server.session_store.create(None);
         let body = br#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#;
-        match server.handle_request(body, None) {
+        match server.handle_request(body, Some(&sid)) {
             McpResult::Response {
                 body: resp_body, ..
             } => {
@@ -379,9 +382,10 @@ mod tests {
     #[test]
     fn tools_call_returns_needs_dispatch() {
         let server = make_server();
+        let sid = server.session_store.create(None);
         let body =
             br#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"getHealth"}}"#;
-        match server.handle_request(body, None) {
+        match server.handle_request(body, Some(&sid)) {
             McpResult::NeedsDispatch {
                 operation_index,
                 path,
@@ -397,9 +401,10 @@ mod tests {
     #[test]
     fn tools_call_unknown_tool() {
         let server = make_server();
+        let sid = server.session_store.create(None);
         let body =
             br#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"nonexistent"}}"#;
-        match server.handle_request(body, None) {
+        match server.handle_request(body, Some(&sid)) {
             McpResult::Response {
                 body: resp_body, ..
             } => {
@@ -414,8 +419,9 @@ mod tests {
     #[test]
     fn unknown_method_returns_error() {
         let server = make_server();
+        let sid = server.session_store.create(None);
         let body = br#"{"jsonrpc":"2.0","id":4,"method":"resources/list"}"#;
-        match server.handle_request(body, None) {
+        match server.handle_request(body, Some(&sid)) {
             McpResult::Response {
                 body: resp_body, ..
             } => {
@@ -440,8 +446,9 @@ mod tests {
     #[test]
     fn ping_returns_empty_result() {
         let server = make_server();
+        let sid = server.session_store.create(None);
         let body = br#"{"jsonrpc":"2.0","id":5,"method":"ping"}"#;
-        match server.handle_request(body, None) {
+        match server.handle_request(body, Some(&sid)) {
             McpResult::Response {
                 body: resp_body, ..
             } => {
@@ -450,6 +457,27 @@ mod tests {
                 assert_eq!(json["result"], serde_json::json!({}));
             }
             _ => panic!("expected Response"),
+        }
+    }
+
+    #[test]
+    fn non_initialize_without_session_is_rejected() {
+        // DP-1 regression: omitting the session must NOT bypass validation.
+        let server = make_server();
+        for body in [
+            &br#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#[..],
+            &br#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"getHealth"}}"#[..],
+        ] {
+            match server.handle_request(body, None) {
+                McpResult::Response {
+                    body: resp_body, ..
+                } => {
+                    let json: serde_json::Value =
+                        serde_json::from_slice(&resp_body).expect("valid json");
+                    assert_eq!(json["error"]["code"], INVALID_REQUEST);
+                }
+                _ => panic!("expected session-rejection Response"),
+            }
         }
     }
 
@@ -532,8 +560,9 @@ mod tests {
     #[test]
     fn tools_call_missing_name_field() {
         let server = make_server();
+        let sid = server.session_store.create(None);
         let body = br#"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{}}"#;
-        match server.handle_request(body, None) {
+        match server.handle_request(body, Some(&sid)) {
             McpResult::Response {
                 body: resp_body, ..
             } => {
@@ -585,9 +614,10 @@ mod tests {
             server_version: None,
         };
         let server = McpServer::new(&ops, &config);
+        let sid = server.session_store.create(None);
 
         let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"getUser","arguments":{"id":"123"}}}"#;
-        match server.handle_request(body, None) {
+        match server.handle_request(body, Some(&sid)) {
             McpResult::NeedsDispatch {
                 operation_index,
                 path,

--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,5 @@
 # cargo-deny configuration
 # https://embarkstudios.github.io/cargo-deny/
-#
-# Run all gates with: cargo deny check
-# (CI should run `cargo deny check`, not only `check advisories`.)
 
 [advisories]
 ignore = [
@@ -12,41 +9,3 @@ ignore = [
     # instant crate unmaintained — pinned by notify 7.x (transitive via notify-types), no safe upgrade
     "RUSTSEC-2024-0384",
 ]
-
-# Barbacane is AGPL-3.0-only (+ commercial). Dependencies must carry a
-# permissive (or weak-copyleft) license; a transitively-pulled strong-copyleft
-# crate would impose obligations and must be caught here.
-[licenses]
-allow = [
-    "MIT",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "ISC",
-    "Zlib",
-    "MPL-2.0",
-    "Unicode-DFS-2016",
-    "Unicode-3.0",
-    "CC0-1.0",
-    "BSL-1.0",
-    "OpenSSL",
-]
-confidence-threshold = 0.9
-# Add specific crate exceptions here if a vendored crate needs a license not in
-# the allow list, e.g.:
-# exceptions = [{ allow = ["Zlib"], crate = "foo" }]
-
-[bans]
-# Surface accidental dependency bloat / version skew (e.g. the duplicate axum
-# and tower versions noted in review). Warn rather than deny to avoid blocking
-# on transitive duplicates that can't be resolved immediately.
-multiple-versions = "warn"
-wildcards = "deny"
-
-[sources]
-# Only allow dependencies from crates.io. An accidental git/path dependency
-# from an untrusted source is a supply-chain risk and must be explicit.
-unknown-registry = "deny"
-unknown-git = "deny"
-allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,8 @@
 # cargo-deny configuration
 # https://embarkstudios.github.io/cargo-deny/
+#
+# Run all gates with: cargo deny check
+# (CI should run `cargo deny check`, not only `check advisories`.)
 
 [advisories]
 ignore = [
@@ -9,3 +12,41 @@ ignore = [
     # instant crate unmaintained — pinned by notify 7.x (transitive via notify-types), no safe upgrade
     "RUSTSEC-2024-0384",
 ]
+
+# Barbacane is AGPL-3.0-only (+ commercial). Dependencies must carry a
+# permissive (or weak-copyleft) license; a transitively-pulled strong-copyleft
+# crate would impose obligations and must be caught here.
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "MPL-2.0",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "CC0-1.0",
+    "BSL-1.0",
+    "OpenSSL",
+]
+confidence-threshold = 0.9
+# Add specific crate exceptions here if a vendored crate needs a license not in
+# the allow list, e.g.:
+# exceptions = [{ allow = ["Zlib"], crate = "foo" }]
+
+[bans]
+# Surface accidental dependency bloat / version skew (e.g. the duplicate axum
+# and tower versions noted in review). Warn rather than deny to avoid blocking
+# on transitive duplicates that can't be resolved immediately.
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+# Only allow dependencies from crates.io. An accidental git/path dependency
+# from an untrusted source is a supply-chain risk and must be explicit.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -27,6 +27,7 @@
 # Reference
 
 - [CLI reference](reference/cli.md)
+- [Configuration & environment variables](reference/configuration.md)
 - [Spec Extensions](reference/extensions.md)
 - [Artifact Format](reference/artifact.md)
 - [Reserved Endpoints](reference/endpoints.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -36,3 +36,4 @@
 - [Architecture](contributing/architecture.md)
 - [Development setup](contributing/development.md)
 - [WASM plugin development](contributing/plugins.md)
+- [Security testing](contributing/security-testing.md)

--- a/docs/contributing/security-testing.md
+++ b/docs/contributing/security-testing.md
@@ -1,0 +1,169 @@
+# Security testing
+
+Barbacane ships a dedicated security testing framework with three layers:
+
+1. an **adversarial integration suite** that both regression-locks known
+   findings and helps discover new ones,
+2. a set of **cargo-fuzz targets** for the highest-value parser / loader /
+   memory surfaces, and
+3. this documentation plus a `make security-test` entry point.
+
+The suite is designed to be **red today, green as fixes land**: every test
+asserts the *secure* (hardened) behaviour, so a failing test is a real, tracked
+security gap. Each red test carries a comment of the form
+`// EXPECTED TO FAIL until <FINDING-ID> is fixed`.
+
+## Threat model categories
+
+| Finding      | Category              | What it locks down |
+|--------------|-----------------------|--------------------|
+| BARB-SEC-001 | Authz / IDOR          | Every mutating control-plane route requires an admin Bearer token (`BARBACANE_CONTROL_ADMIN_TOKEN`); `/health` and `/ws/data-plane` are exempt. Project A cannot read/mutate project B's resources. |
+| BARB-SEC-002 | SSRF                  | The WASM host HTTP client refuses to connect to loopback / link-local / private / metadata IPs, including after redirects (resolve-then-check). |
+| BARB-SEC-003 | DoS / resource limits | Oversized chunked bodies → 413 without full buffering; slowloris read-timeout; 404 floods do not create one Prometheus series per raw path (sentinel `<not_found>`). |
+| BARB-SEC-004 | Sandbox / capability  | A plugin granted only `log` cannot call other host functions — the linker is per-plugin / default-deny. |
+| BARB-SEC-005 | Crypto / auth         | JWT `alg:none`, expired `exp`, tampered signature, and wrong `aud` are rejected; a forged `X-Forwarded-For` does not bypass `ip-restriction` or reset rate-limit buckets. |
+| BARB-SEC-006 | Artifact integrity    | The `.bca` load path verifies per-entry SHA-256 against the manifest and an Ed25519 signature against `BARBACANE_TRUSTED_PUBKEY`; a single flipped byte fails the load. |
+
+## Layer 1 — Adversarial integration suite
+
+The suite lives under `crates/barbacane-test/tests/`:
+
+```
+crates/barbacane-test/tests/
+  security.rs                       # test-binary root + shared helpers
+  security/
+    authz.rs                        # BARB-SEC-001
+    ssrf.rs                         # BARB-SEC-002
+    dos.rs                          # BARB-SEC-003
+    sandbox.rs                      # BARB-SEC-004
+    crypto_auth.rs                  # BARB-SEC-005
+    artifact_integrity.rs           # BARB-SEC-006
+```
+
+Fixtures specific to security tests live in `tests/fixtures/security/` (with
+their own `barbacane.yaml` manifest).
+
+### Running it
+
+```bash
+# Build the binaries the harness drives as subprocesses.
+cargo build -p barbacane        # data plane (most categories)
+cargo build -p barbacane-control # control plane (BARB-SEC-001)
+
+# Build WASM plugins (the data-plane fixtures bundle them).
+make plugins
+
+# Run just the security suite.
+cargo test -p barbacane-test --test security
+```
+
+**Docker / service requirements** (the same as the rest of the integration
+suite — see [Development setup](development.md)):
+
+- Most categories boot the **data plane** (`barbacane serve`) as a subprocess.
+  They need the `barbacane` binary built and the fixture WASM plugins present.
+- **BARB-SEC-001** boots the **control plane** (`barbacane-control serve`),
+  which needs PostgreSQL. Start it with `make db-up` and export `DATABASE_URL`.
+  When PostgreSQL or the binary is unavailable the authz tests **skip** (they
+  print a `skip:` line and return) rather than fail spuriously.
+
+It is expected that security tests **fail at runtime today** — that is the
+point. They turn green as each finding is fixed. A handful are `#[ignore]`d
+because they need an src-side change first (see below); each carries a
+`// BLOCKED: …` comment explaining exactly what.
+
+### What needs to be exposed for the parked tests
+
+A few tests are `#[ignore]`d with a precise blocker:
+
+- **Sandbox (BARB-SEC-004)** — needs (a) an adversarial fixture plugin that
+  declares only `log` but imports `host_http_call`, and (b) a per-plugin
+  default-deny linker in `barbacane-wasm` (today `add_host_functions` registers
+  *all* host functions). The load-time positive control additionally needs
+  `barbacane-wasm` added as a dev-dependency of `barbacane-test` so
+  `validate::validate_imports` can be called directly.
+- **Crypto (BARB-SEC-005)** — the "validly-signed JWT is accepted" case needs
+  real RS256 signature verification (`public_key_pem`) in the `jwt-auth` plugin
+  plus a matching private key in the fixture to sign with.
+- **DoS slowloris (BARB-SEC-003)** — needs a configurable + observable
+  read/header timeout to assert against without flaky wall-clock sleeps.
+- **Authz IDOR phase 2 (BARB-SEC-001)** — needs per-project credentials and
+  ownership checks on the global `/specs/{id}` and `/artifacts/{id}` routes.
+
+## Layer 2 — Fuzz targets (cargo-fuzz)
+
+The fuzz crate is a **standalone** crate at the repo root (`fuzz/`). It uses the
+empty-`[workspace]`-table trick so it is *not* part of the parent Cargo
+workspace — no edit to the root `Cargo.toml` `exclude` list is needed, and
+`cargo build` at the repo root never pulls it in.
+
+```
+fuzz/
+  Cargo.toml
+  fuzz_targets/
+    spec_parser.rs       # barbacane_compiler::parse_spec  — hostile OpenAPI/AsyncAPI
+    artifact_loader.rs   # .bca gzip/tar loaders — decompression bombs / malformed archives
+    jsonrpc.rs           # MCP JsonRpcRequest deserialization
+    validator.rs         # OperationValidator::validate_request (+ percent-decoder)
+    wasm_host_memory.rs  # guest-slice bounds — BLOCKED, see below
+```
+
+### Prerequisites and running
+
+```bash
+rustup toolchain install nightly
+cargo install cargo-fuzz
+
+# From the fuzz/ directory:
+cd fuzz
+cargo +nightly fuzz run spec_parser
+cargo +nightly fuzz run artifact_loader
+cargo +nightly fuzz run jsonrpc
+cargo +nightly fuzz run validator
+# cargo +nightly fuzz run wasm_host_memory   # currently inert — see below
+```
+
+> Note: `cargo-fuzz` and a nightly toolchain are required to actually *fuzz*.
+> The targets also build on stable (`cd fuzz && cargo build --bins`), which is
+> what CI / pre-push uses to ensure they don't bit-rot.
+
+### Maintainer actions to sharpen the targets
+
+- **`validator`** reaches the percent-decoder *indirectly* through
+  `validate_request` because `urlencoding_decode` is private in
+  `crates/barbacane/src/validator.rs`. For a tighter, faster target, expose a
+  thin wrapper:
+  ```rust
+  pub fn fuzz_urldecode(s: &str) -> String { urlencoding_decode(s) }
+  ```
+- **`artifact_loader`** writes fuzz bytes to a temp file because the loaders take
+  `&Path`. A `pub fn load_*_from_reader<R: Read>(r: R)` (or a
+  `decompress_artifact<R: Read>(r) -> …`) in
+  `crates/barbacane-compiler/src/artifact.rs` would let the target fuzz
+  in-memory.
+- **`wasm_host_memory`** is currently an inert stub. The guest-slice bounds
+  check is duplicated inline in every host-function closure in
+  `crates/barbacane-wasm/src/instance.rs` and is not reachable as a pure
+  function. Extract it, e.g.:
+  ```rust
+  pub fn guest_slice_bounds(ptr: i32, len: i32, mem_len: usize)
+      -> Result<(usize, usize), GuestMemoryError>;
+  ```
+  then add `barbacane-wasm` to `fuzz/Cargo.toml` and call it from the target
+  (the intended body is sketched in the target's module docs).
+
+## Adding a new security test
+
+1. Pick (or open) a finding ID, e.g. `BARB-SEC-007`.
+2. Add the test to the matching category file under
+   `crates/barbacane-test/tests/security/`, or create a new category module and
+   register it in the `mod security { … }` block in `tests/security.rs`.
+3. Assert the **secure** behaviour. Add the marker comment:
+   `// EXPECTED TO FAIL until BARB-SEC-007 is fixed`.
+4. If the test cannot compile/run against current APIs, mark it `#[ignore]` with
+   a `// BLOCKED: needs <X> exposed` comment rather than leaving it broken.
+5. Put any new fixtures under `tests/fixtures/security/` and declare the plugins
+   they use in `tests/fixtures/security/barbacane.yaml`.
+6. Keep tests deterministic — avoid wall-clock sleeps; note any that are
+   unavoidable.
+7. Update the threat-model table above.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,64 @@
+# Configuration & environment variables
+
+Barbacane is configured through CLI flags (see the [CLI reference](cli.md)) and a
+small set of environment variables. The security-related variables below were
+introduced by the security hardening pass and several change default behavior in
+breaking but deliberate ways — Barbacane fails closed rather than running
+insecurely.
+
+## Security environment variables
+
+| Variable | Component | Default | Effect |
+|----------|-----------|---------|--------|
+| `BARBACANE_CONTROL_ADMIN_TOKEN` | Control plane | _unset_ | **Required.** Bearer token that must accompany every control-plane API request (except `GET /health` and the data-plane WebSocket). The server refuses to start if unset. |
+| `BARBACANE_CONTROL_ALLOWED_ORIGINS` | Control plane | _unset (no cross-origin)_ | Comma-separated CORS allowlist of browser origins permitted to call the API, e.g. `https://ui.example.com`. |
+| `BARBACANE_TRUSTED_PUBKEY` | Data plane | _unset_ | Hex-encoded Ed25519 public key. When set, the data plane requires every loaded `.bca` artifact to carry a valid signature produced by the matching private key; load fails otherwise. When unset, the artifact's content hashes are still verified, but signature checking is skipped (a startup warning is logged). |
+| `BARBACANE_SIGNING_KEY` | Compiler | _unset_ | Path to a PKCS#8 Ed25519 private key. When set, `barbacane compile` signs the artifact's content hash. When unset, the artifact is built unsigned. |
+| `BARBACANE_SECRETS_DIR` | Data plane | _unset_ | Base directory that `file://` secret references are confined to. **Required to use `file://` secrets** — references are rejected when it is unset, and any path resolving outside this directory (after symlink/`..` resolution) is rejected. |
+| `BARBACANE_ALLOW_INTERNAL_EGRESS` | Data plane | `false` | Set to `1`/`true` to disable the plugin SSRF guard and allow plugin HTTP calls to internal/loopback/link-local/cloud-metadata addresses. Leave off unless you have legitimate internal upstreams. |
+
+## Breaking-by-design defaults
+
+These changes are intentional secure defaults. Adopt them as follows:
+
+1. **The control plane will not start without `BARBACANE_CONTROL_ADMIN_TOKEN`.**
+   Generate a strong random token and pass it to every client as
+   `Authorization: Bearer <token>`. Previously the API was unauthenticated.
+
+2. **`file://` secrets require `BARBACANE_SECRETS_DIR`.** If you reference
+   secrets like `file:///run/secrets/api-key`, set
+   `BARBACANE_SECRETS_DIR=/run/secrets`. `env://` references are unaffected.
+
+3. **MCP clients must initialize a session.** Non-`initialize` MCP requests
+   (`tools/list`, `tools/call`, …) without a valid `Mcp-Session-Id` are now
+   rejected; call `initialize` first and reuse the returned session id.
+
+4. **Plugin HTTP calls to internal addresses are blocked by default.** If a
+   plugin legitimately calls an internal upstream, set
+   `BARBACANE_ALLOW_INTERNAL_EGRESS=1` (or prefer an explicit allowlist when one
+   is available).
+
+5. **Plugins may only use their declared capabilities.** A plugin whose WASM
+   imports a host function outside the capabilities declared in its
+   `plugin.toml` fails to load. Official plugins already declare the correct
+   capabilities; custom plugins must list theirs under
+   `[capabilities] host_functions = [...]`.
+
+## Artifact signing quickstart
+
+```bash
+# 1. Generate a dev keypair (PKCS#8 Ed25519). Any tool that emits PKCS#8 works;
+#    keep the private key secret and distribute only the public key.
+
+# 2. Sign at compile time:
+BARBACANE_SIGNING_KEY=/path/to/ed25519.pk8 \
+  barbacane compile -m barbacane.yaml -o api.bca
+
+# 3. Require verification on the data plane (pin the public key):
+BARBACANE_TRUSTED_PUBKEY=<hex-public-key> \
+  barbacane serve --artifact api.bca --listen 0.0.0.0:8080
+```
+
+The signature covers the artifact's content hash, which binds every spec, route,
+and plugin WASM checksum, so any tampering with the artifact fails verification
+on load.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -56,12 +56,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,7 +91,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,60 +102,38 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "assert_cmd"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
-dependencies = [
- "anstyle",
- "bstr",
- "libc",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -183,7 +155,7 @@ dependencies = [
  "nuid",
  "pin-project",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "ring",
  "rustls-native-certs",
@@ -239,15 +211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,40 +218,25 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "aws-lc-fips-sys"
-version = "0.13.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "regex",
-]
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
- "aws-lc-fips-sys",
  "aws-lc-sys",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -303,14 +251,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -321,43 +269,6 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
-dependencies = [
- "axum-core 0.5.6",
- "base64",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit 0.8.4",
- "memchr",
- "mime",
- "multer",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sha1",
- "sync_wrapper",
- "tokio",
- "tokio-tungstenite",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -381,25 +292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "barbacane"
 version = "0.7.0"
 dependencies = [
@@ -409,7 +301,6 @@ dependencies = [
  "barbacane-wasm",
  "bytes",
  "clap",
- "criterion",
  "futures-util",
  "hex",
  "http-body-util",
@@ -439,54 +330,30 @@ name = "barbacane-compiler"
 version = "0.7.0"
 dependencies = [
  "chrono",
- "criterion",
  "flate2",
  "hex",
  "home",
  "reqwest",
- "ring",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2",
  "tar",
- "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
  "tracing",
 ]
 
 [[package]]
-name = "barbacane-control"
-version = "0.7.0"
+name = "barbacane-fuzz"
+version = "0.0.0"
 dependencies = [
- "anyhow",
- "axum 0.8.8",
+ "arbitrary",
+ "barbacane",
  "barbacane-compiler",
- "base64-simd",
- "bytes",
- "chrono",
- "clap",
- "dashmap",
- "futures-util",
- "hex",
- "http-body-util",
- "jsonschema",
- "rand 0.9.4",
- "scalar_api_reference",
- "serde",
+ "libfuzzer-sys",
  "serde_json",
- "serde_yaml",
- "sha2",
- "sqlx",
  "tempfile",
- "tokio",
- "toml 0.8.23",
- "tower 0.5.3",
- "tower-http",
- "tracing",
- "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]
@@ -504,16 +371,6 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
- "serde_json",
-]
-
-[[package]]
-name = "barbacane-sigv4"
-version = "0.7.0"
-dependencies = [
- "hex",
- "hmac",
- "sha2",
 ]
 
 [[package]]
@@ -531,29 +388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "barbacane-test"
-version = "0.7.0"
-dependencies = [
- "assert_cmd",
- "barbacane-compiler",
- "base64",
- "flate2",
- "futures-util",
- "predicates",
- "rcgen",
- "reqwest",
- "rustls",
- "serde_json",
- "serde_yaml",
- "tar",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite",
- "wiremock",
-]
-
-[[package]]
 name = "barbacane-wasm"
 version = "0.7.0"
 dependencies = [
@@ -564,7 +398,6 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
- "criterion",
  "dashmap",
  "futures-util",
  "hex",
@@ -578,7 +411,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
@@ -586,7 +418,6 @@ dependencies = [
  "tracing",
  "uuid",
  "wasmtime",
- "wat",
 ]
 
 [[package]]
@@ -596,40 +427,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
-
-[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.10.5",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
 
 [[package]]
 name = "bit-set"
@@ -654,12 +455,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-dependencies = [
- "serde_core",
-]
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitmaps"
@@ -686,21 +484,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 dependencies = [
  "allocator-api2",
 ]
@@ -712,45 +499,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -767,9 +533,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -780,48 +546,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -841,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -883,9 +611,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
@@ -894,18 +622,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "const-oid"
@@ -1090,21 +809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "948865622f87f30907bb46fbb081b235ae63c1896a99a83c26a003305c1fa82d"
 
 [[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
 name = "crc32c"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,42 +824,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1178,25 +846,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1236,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1250,27 +903,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
-name = "deadpool"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
-dependencies = [
- "deadpool-runtime",
- "lazy_static",
- "num_cpus",
- "tokio",
-]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "debugid"
@@ -1298,15 +933,19 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
+name = "derive_arbitrary"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "digest"
@@ -1315,7 +954,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1343,20 +981,14 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "dotenvy"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
@@ -1394,12 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-dependencies = [
- "serde",
-]
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email_address"
@@ -1444,29 +1073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1494,13 +1101,12 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1526,15 +1132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fluent-uri"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,27 +1143,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1585,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
@@ -1651,17 +1231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-intrusive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
-dependencies = [
- "futures-core",
- "lock_api",
- "parking_lot",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,7 +1282,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "debugid",
  "rustc-hash",
  "serde",
@@ -1760,15 +1329,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1791,9 +1358,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1806,17 +1373,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
 ]
 
 [[package]]
@@ -1833,40 +1389,20 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
-]
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1875,25 +1411,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
 
 [[package]]
 name = "hmac"
@@ -1915,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1960,9 +1481,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1982,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -1993,7 +1514,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -2026,7 +1547,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2157,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2196,7 +1717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2243,40 +1764,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2325,13 +1816,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2362,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -2372,11 +1862,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -2385,9 +1875,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -2397,18 +1884,18 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
+name = "libfuzzer-sys"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
- "cfg-if",
- "windows-link",
+ "arbitrary",
+ "cc",
 ]
 
 [[package]]
@@ -2419,24 +1906,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
- "plain",
- "redox_syscall 0.7.4",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
-dependencies = [
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2462,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2516,26 +1990,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
-]
-
-[[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memfd"
@@ -2553,12 +2011,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,31 +2022,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -2608,25 +2043,9 @@ dependencies = [
  "ed25519-dalek",
  "getrandom 0.2.17",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "signatory",
 ]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
@@ -2634,7 +2053,7 @@ version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -2662,7 +2081,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2671,7 +2090,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2699,22 +2118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-cmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2773,17 +2176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -2809,12 +2201,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -2893,7 +2279,7 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -2906,12 +2292,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2931,7 +2311,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2943,16 +2323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
 ]
 
 [[package]]
@@ -2982,18 +2352,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3005,17 +2375,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
 
 [[package]]
 name = "pkcs8"
@@ -3032,40 +2391,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -3107,46 +2432,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "predicates"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
-dependencies = [
- "anstyle",
- "difflib",
- "float-cmp",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -3198,7 +2483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -3229,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3240,7 +2525,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3249,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -3277,16 +2562,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3305,9 +2590,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3392,34 +2677,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rcgen"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
-dependencies = [
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "yasna",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3468,13 +2731,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "log",
  "rustc-hash",
  "smallvec",
@@ -3482,9 +2745,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3511,9 +2774,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3554,7 +2817,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3572,26 +2835,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rsasl"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3601,7 +2844,7 @@ dependencies = [
  "digest",
  "hmac",
  "pbkdf2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -3623,47 +2866,13 @@ dependencies = [
  "integer-encoding",
  "lz4",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsasl",
  "snap",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
  "zstd",
-]
-
-[[package]]
-name = "rust-embed"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
-dependencies = [
- "sha2",
- "walkdir",
 ]
 
 [[package]]
@@ -3693,18 +2902,18 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3718,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3739,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3781,17 +2990,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scalar_api_reference"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eac3f009b73e27213aa1ca3dee1c3bcb698beb104bb90d1eb2102623f39d62d"
-dependencies = [
- "rust-embed",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3812,7 +3010,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3871,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3889,17 +3087,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -3989,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4049,9 +3236,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -4074,21 +3261,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4099,202 +3277,6 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "sqlx"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
-dependencies = [
- "sqlx-core",
- "sqlx-macros",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
-]
-
-[[package]]
-name = "sqlx-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
-dependencies = [
- "base64",
- "bytes",
- "chrono",
- "crc",
- "crossbeam-queue",
- "either",
- "event-listener",
- "futures-core",
- "futures-intrusive",
- "futures-io",
- "futures-util",
- "hashbrown 0.15.5",
- "hashlink",
- "indexmap 2.14.0",
- "log",
- "memchr",
- "once_cell",
- "percent-encoding",
- "serde",
- "serde_json",
- "sha2",
- "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "sqlx-macros"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
-dependencies = [
- "proc-macro2",
- "quote",
- "sqlx-core",
- "sqlx-macros-core",
- "syn",
-]
-
-[[package]]
-name = "sqlx-macros-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
-dependencies = [
- "dotenvy",
- "either",
- "heck",
- "hex",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "sha2",
- "sqlx-core",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
- "syn",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "sqlx-mysql"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
-dependencies = [
- "atoi",
- "base64",
- "bitflags 2.11.0",
- "byteorder",
- "bytes",
- "chrono",
- "crc",
- "digest",
- "dotenvy",
- "either",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "percent-encoding",
- "rand 0.8.5",
- "rsa",
- "serde",
- "sha1",
- "sha2",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror 2.0.18",
- "tracing",
- "uuid",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-postgres"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
-dependencies = [
- "atoi",
- "base64",
- "bitflags 2.11.0",
- "byteorder",
- "chrono",
- "crc",
- "dotenvy",
- "etcetera",
- "futures-channel",
- "futures-core",
- "futures-util",
- "hex",
- "hkdf",
- "hmac",
- "home",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "sha2",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror 2.0.18",
- "tracing",
- "uuid",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-sqlite"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
-dependencies = [
- "atoi",
- "chrono",
- "flume",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-intrusive",
- "futures-util",
- "libsqlite3-sys",
- "log",
- "percent-encoding",
- "serde",
- "serde_urlencoded",
- "sqlx-core",
- "thiserror 2.0.18",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -4328,9 +3310,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4359,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -4381,10 +3363,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4395,12 +3377,6 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -4453,12 +3429,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4468,15 +3443,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4490,16 +3465,6 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4519,9 +3484,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4529,7 +3494,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4607,7 +3572,7 @@ dependencies = [
  "futures-sink",
  "http",
  "httparse",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ring",
  "rustls-pki-types",
  "tokio",
@@ -4681,7 +3646,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4704,7 +3669,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64",
  "bytes",
  "h2",
@@ -4737,7 +3702,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -4759,31 +3724,29 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
- "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4804,7 +3767,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4910,9 +3872,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-bidi"
@@ -4997,11 +3959,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5025,12 +3987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5041,15 +3997,6 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"
@@ -5078,33 +4025,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5115,9 +4047,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5125,9 +4057,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5135,9 +4067,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5148,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -5178,16 +4110,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
@@ -5198,24 +4120,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.246.2"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.246.2",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -5233,23 +4143,11 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "semver",
@@ -5258,11 +4156,11 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.246.2"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "semver",
 ]
@@ -5286,7 +4184,7 @@ checksum = "efb1ed5899dde98357cfdcf647a4614498798719793898245b4b34e663addabf"
 dependencies = [
  "addr2line",
  "async-trait",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -5394,7 +4292,7 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.245.1",
+ "wit-parser",
 ]
 
 [[package]]
@@ -5428,7 +4326,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "object",
  "pulley-interpreter",
@@ -5529,39 +4427,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2192a77a00b9a67800c2b4e1c70fb6abca79d6b529e53a2ef9dcdcc36090330d"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "heck",
  "indexmap 2.14.0",
- "wit-parser 0.245.1",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wast"
-version = "246.0.2"
+version = "252.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.246.2",
+ "wasm-encoder 0.252.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.246.2"
+version = "1.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5583,26 +4481,16 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "whoami"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
 ]
 
 [[package]]
@@ -5627,7 +4515,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5716,15 +4604,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5748,21 +4627,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5800,12 +4664,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5818,12 +4676,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5833,12 +4685,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5866,12 +4712,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5881,12 +4721,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5902,12 +4736,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5917,12 +4745,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5947,120 +4769,15 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
-
-[[package]]
-name = "wiremock"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
-dependencies = [
- "assert-json-diff",
- "base64",
- "deadpool",
- "futures",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "tokio",
- "url",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser 0.244.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser 0.244.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-parser"
@@ -6098,19 +4815,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "yasna"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
-dependencies = [
- "time",
-]
-
-[[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6131,18 +4839,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6151,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -6172,9 +4880,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,84 @@
+# Standalone fuzz crate for Barbacane (Layer 2 of the security testing framework).
+#
+# This crate is deliberately NOT part of the parent Cargo workspace: the empty
+# `[workspace]` table below makes Cargo treat `fuzz/` as its own workspace root,
+# so `cargo build`/`cargo test` at the repo root never pulls it in (cargo-fuzz
+# and a nightly toolchain are only needed here). This is the recommended
+# cargo-fuzz layout and keeps the framework self-contained — no edit to the root
+# Cargo.toml `exclude` list is required.
+#
+# Build / run (requires nightly + cargo-fuzz):
+#   rustup toolchain install nightly
+#   cargo install cargo-fuzz
+#   cargo +nightly fuzz run spec_parser
+#
+# See docs/contributing/security-testing.md for the full runbook.
+
+[package]
+name = "barbacane-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+# Empty workspace table → standalone crate, excluded from the parent workspace.
+[workspace]
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Crates under test. Paths are relative to this fuzz/ directory.
+barbacane-compiler = { path = "../crates/barbacane-compiler" }
+# The data-plane crate exposes a library target named `barbacane_lib`
+# (see crates/barbacane/Cargo.toml `[lib] name = "barbacane_lib"`), which is how
+# we reach the validator and MCP JSON-RPC parser.
+barbacane = { path = "../crates/barbacane" }
+
+# Used by the artifact_loader target to materialise fuzz input as a temp .bca
+# (the loader API takes a &Path, not bytes).
+tempfile = "3"
+
+[profile.release]
+debug = 1
+
+# Each fuzz target is its own binary. `test = false` / `doc = false` keep
+# `cargo test` from trying to build them as ordinary tests.
+
+[[bin]]
+name = "spec_parser"
+path = "fuzz_targets/spec_parser.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "artifact_loader"
+path = "fuzz_targets/artifact_loader.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "jsonrpc"
+path = "fuzz_targets/jsonrpc.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "validator"
+path = "fuzz_targets/validator.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "wasm_host_memory"
+path = "fuzz_targets/wasm_host_memory.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/artifact_loader.rs
+++ b/fuzz/fuzz_targets/artifact_loader.rs
@@ -1,0 +1,51 @@
+//! Fuzz the `.bca` artifact load path (gzip + tar decompression).
+//!
+//! Targets the loader functions in
+//! `crates/barbacane-compiler/src/artifact.rs`:
+//!   * `load_manifest(&Path)`
+//!   * `load_routes(&Path)`
+//!   * `load_specs(&Path)`
+//!   * `load_plugins(&Path)`
+//!
+//! Each opens the file, wraps it in `flate2::read::GzDecoder` + `tar::Archive`,
+//! and walks entries. Hostile input we care about: decompression bombs
+//! (tiny gzip → huge expansion), malformed/oversized tar headers, path-traversal
+//! entry names, truncated streams. The invariant is: no panic, no unbounded
+//! memory blowup that OOM-kills the process for a small input.
+//!
+//! The loader API takes a `&Path` (there is no bytes/reader variant — see the
+//! "maintainer action" note in docs/contributing/security-testing.md), so we
+//! materialise the fuzz bytes to a temp file first. The libFuzzer max input size
+//! bounds the *compressed* size; a decompression bomb that explodes from a small
+//! seed is exactly what we want to surface.
+//!
+//! Run: `cargo +nightly fuzz run artifact_loader`
+
+#![no_main]
+
+use std::io::Write;
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Write the raw fuzz bytes as a candidate .bca and run every loader against
+    // it. We do NOT pre-validate gzip framing: malformed framing is part of the
+    // attack surface and must be handled gracefully by the loaders.
+    let Ok(mut tmp) = tempfile::NamedTempFile::new() else {
+        return;
+    };
+    if tmp.write_all(data).is_err() {
+        return;
+    }
+    if tmp.flush().is_err() {
+        return;
+    }
+    let path = tmp.path();
+
+    // All four loaders share the gzip+tar walk; fuzz each so manifest/routes/
+    // specs/plugins-specific JSON handling is also exercised.
+    let _ = barbacane_compiler::load_manifest(path);
+    let _ = barbacane_compiler::load_routes(path);
+    let _ = barbacane_compiler::load_specs(path);
+    let _ = barbacane_compiler::load_plugins(path);
+});

--- a/fuzz/fuzz_targets/jsonrpc.rs
+++ b/fuzz/fuzz_targets/jsonrpc.rs
@@ -1,0 +1,24 @@
+//! Fuzz the MCP JSON-RPC request parser.
+//!
+//! Target: deserialization of `barbacane_lib::mcp::jsonrpc::JsonRpcRequest`
+//! (`crates/barbacane/src/mcp/jsonrpc.rs`), which is the wire-format type the
+//! MCP endpoint parses every incoming request into via serde_json.
+//!
+//! The MCP endpoint accepts untrusted client JSON, so the parse step must never
+//! panic or hang regardless of input: deeply nested params, gigantic numbers,
+//! duplicate keys, non-UTF-8-escaped strings, etc.
+//!
+//! Invariant: parsing arbitrary bytes returns `Ok`/`Err`, never panics.
+//!
+//! Run: `cargo +nightly fuzz run jsonrpc`
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use barbacane_lib::mcp::jsonrpc::JsonRpcRequest;
+
+fuzz_target!(|data: &[u8]| {
+    // Parse exactly as the MCP endpoint does: serde_json over the raw bytes.
+    let _ = serde_json::from_slice::<JsonRpcRequest>(data);
+});

--- a/fuzz/fuzz_targets/spec_parser.rs
+++ b/fuzz/fuzz_targets/spec_parser.rs
@@ -1,0 +1,26 @@
+//! Fuzz the OpenAPI/AsyncAPI spec parser.
+//!
+//! Target: `barbacane_compiler::parse_spec(&str) -> Result<ApiSpec, ParseError>`
+//! (re-exported from `crates/barbacane-compiler/src/spec_parser/parser.rs`).
+//!
+//! Invariant: the parser must never panic, overflow the stack, or run away on
+//! hostile input — it must always return `Ok`/`Err` for any UTF-8 string.
+//! `parse_spec` runs serde_yaml + recursive path/channel walking, so deeply
+//! nested YAML, huge anchor expansions, and malformed extension blocks are the
+//! interesting cases.
+//!
+//! Run: `cargo +nightly fuzz run spec_parser`
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // The parser takes &str; only feed it valid UTF-8 (invalid UTF-8 is a
+    // separate, uninteresting rejection at the boundary).
+    if let Ok(input) = std::str::from_utf8(data) {
+        // We only care that this does not panic / hang / overflow. The Result is
+        // intentionally ignored.
+        let _ = barbacane_compiler::parse_spec(input);
+    }
+});

--- a/fuzz/fuzz_targets/validator.rs
+++ b/fuzz/fuzz_targets/validator.rs
@@ -1,0 +1,82 @@
+//! Fuzz request validation and the percent-decoder.
+//!
+//! Target: `barbacane_lib::validator::OperationValidator::validate_request`
+//! (`crates/barbacane/src/validator.rs`). `validate_request` walks path/query/
+//! header/body validation; the query path runs the private `urlencoding_decode`
+//! percent-decoder, so feeding arbitrary query strings fuzzes the decoder
+//! indirectly.
+//!
+//! Invariant: validation of arbitrary inputs never panics (notably the
+//! percent-decoder must handle truncated `%`, non-hex digits, and overlong
+//! sequences without panicking or slicing on a non-char-boundary).
+//!
+//! NOTE for the maintainer: the percent-decoder `urlencoding_decode` is
+//! `fn` (private) in `validator.rs`. To fuzz it *directly* (tighter, faster),
+//! expose a thin wrapper, e.g.:
+//!   `pub fn fuzz_urldecode(s: &str) -> String { urlencoding_decode(s) }`
+//! Until then this target reaches it through `validate_request`, which is fine
+//! but also exercises the surrounding validation machinery.
+//!
+//! Run: `cargo +nightly fuzz run validator`
+
+#![no_main]
+
+use std::collections::HashMap;
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use barbacane_compiler::{Parameter, RequestBody};
+use barbacane_lib::validator::OperationValidator;
+
+/// Structured fuzz input so libFuzzer can explore each field independently.
+#[derive(Debug, Arbitrary)]
+struct Input {
+    query_string: String,
+    body: Vec<u8>,
+    content_type: Option<String>,
+    // A few (name, value) header pairs.
+    headers: Vec<(String, String)>,
+    // Whether to attach a query parameter named after `param_name` so the
+    // query-decode path has a declared param to match.
+    declare_query_param: bool,
+    param_name: String,
+    require_body: bool,
+}
+
+fuzz_target!(|input: Input| {
+    // Build a validator with optional declared parameters / body so different
+    // validation branches (and the percent-decoder) are reachable.
+    let mut params: Vec<Parameter> = Vec::new();
+    if input.declare_query_param && !input.param_name.is_empty() {
+        params.push(Parameter {
+            name: input.param_name.clone(),
+            location: "query".to_string(),
+            required: false,
+            schema: None,
+        });
+    }
+
+    let request_body = if input.require_body {
+        Some(RequestBody {
+            required: true,
+            content: Default::default(),
+        })
+    } else {
+        None
+    };
+
+    let validator = OperationValidator::new(&params, request_body.as_ref());
+
+    let headers: HashMap<String, String> = input.headers.into_iter().collect();
+
+    // No path params; the interesting attacker-controlled surfaces are the query
+    // string (percent-decoder), headers, and body.
+    let _ = validator.validate_request(
+        &[],
+        Some(input.query_string.as_str()),
+        &headers,
+        input.content_type.as_deref(),
+        &input.body,
+    );
+});

--- a/fuzz/fuzz_targets/wasm_host_memory.rs
+++ b/fuzz/fuzz_targets/wasm_host_memory.rs
@@ -1,0 +1,61 @@
+//! Fuzz the WASM guest-slice read helper (ptr/len bounds checking).
+//!
+//! ## Status: BLOCKED — documented, intentionally inert.
+//!
+//! The guest-memory read pattern we want to fuzz lives INLINE inside every host
+//! function closure registered by `add_host_functions`
+//! (`crates/barbacane-wasm/src/instance.rs`), e.g.:
+//!
+//! ```ignore
+//! let memory = caller.get_export("memory").and_then(|e| e.into_memory())?;
+//! let data = memory.data(&caller);
+//! if end > data.len() { return -1; }      // <-- the bounds check
+//! let slice = &data[start..end];
+//! ```
+//!
+//! There is NO standalone, public `fn read_guest_slice(ptr, len, mem_len) -> ..`
+//! to call: the check is duplicated per host function and is only reachable with
+//! a live `wasmtime::Caller` + instantiated module + linear memory. Reaching it
+//! from a libFuzzer target would mean instantiating a full plugin instance per
+//! input, which is far too slow for fuzzing and pulls the entire runtime into
+//! the harness.
+//!
+//! ### Maintainer action to ENABLE this target
+//!
+//! Extract the bounds arithmetic into a pure, public, side-effect-free helper in
+//! `barbacane-wasm`, e.g.:
+//!
+//! ```ignore
+//! /// Returns the valid `[start, end)` range, or an error if out of bounds.
+//! pub fn guest_slice_bounds(ptr: i32, len: i32, mem_len: usize)
+//!     -> Result<(usize, usize), GuestMemoryError>;
+//! ```
+//!
+//! and have every host function call it. Then this target becomes:
+//!
+//! ```ignore
+//! use arbitrary::Arbitrary;
+//! #[derive(Arbitrary, Debug)]
+//! struct In { ptr: i32, len: i32, mem_len: u32 }
+//! fuzz_target!(|i: In| {
+//!     let _ = barbacane_wasm::guest_slice_bounds(i.ptr, i.len, i.mem_len as usize);
+//! });
+//! ```
+//!
+//! and `barbacane-wasm = { path = "../crates/barbacane-wasm" }` must be added to
+//! `fuzz/Cargo.toml`. Until that helper is exposed, this target compiles and
+//! runs but exercises nothing, so the framework stays buildable without an
+//! src-side change.
+//!
+//! Run: `cargo +nightly fuzz run wasm_host_memory` (currently a no-op).
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|_data: &[u8]| {
+    // Intentionally inert. See the module docs above: the guest-slice bounds
+    // check is not reachable as a pure function without an src change in
+    // barbacane-wasm. This stub keeps the fuzz crate building with all five
+    // targets declared while clearly flagging the blocker for the maintainer.
+});

--- a/plugins/acl/Cargo.lock
+++ b/plugins/acl/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/acl/plugin.toml
+++ b/plugins/acl/plugin.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 type = "middleware"
 description = "Access control list middleware — allow/deny by consumer and group"
 wasm = "acl.wasm"
+
+[capabilities]
+host_functions = []

--- a/plugins/ai-cost-tracker/Cargo.lock
+++ b/plugins/ai-cost-tracker/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/ai-cost-tracker/plugin.toml
+++ b/plugins/ai-cost-tracker/plugin.toml
@@ -6,6 +6,4 @@ description = "Records per-request LLM cost (USD) based on token usage and a con
 wasm = "ai-cost-tracker.wasm"
 
 [capabilities]
-log = true
-context_get = true
-telemetry = true
+host_functions = ["log", "context_get", "telemetry"]

--- a/plugins/ai-prompt-guard/Cargo.lock
+++ b/plugins/ai-prompt-guard/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/ai-prompt-guard/plugin.toml
+++ b/plugins/ai-prompt-guard/plugin.toml
@@ -6,6 +6,5 @@ description = "Validates and constrains LLM prompts before dispatch. Named profi
 wasm = "ai-prompt-guard.wasm"
 
 [capabilities]
-log = true
-context_get = true
+host_functions = ["log", "context_get"]
 body_access = true

--- a/plugins/ai-proxy/Cargo.lock
+++ b/plugins/ai-proxy/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/ai-proxy/plugin.toml
+++ b/plugins/ai-proxy/plugin.toml
@@ -6,9 +6,4 @@ description = "AI gateway dispatcher — routes to LLM providers (OpenAI, Anthro
 wasm = "ai-proxy.wasm"
 
 [capabilities]
-log = true
-context_get = true
-context_set = true
-http_call = true
-telemetry = true
-clock_now = true
+host_functions = ["log", "context_get", "context_set", "http_call", "telemetry", "clock_now"]

--- a/plugins/ai-response-guard/Cargo.lock
+++ b/plugins/ai-response-guard/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/ai-response-guard/plugin.toml
+++ b/plugins/ai-response-guard/plugin.toml
@@ -6,7 +6,5 @@ description = "Inspects LLM responses under a named policy profile (redact + blo
 wasm = "ai-response-guard.wasm"
 
 [capabilities]
-log = true
-context_get = true
+host_functions = ["log", "context_get", "telemetry"]
 body_access = true
-telemetry = true

--- a/plugins/ai-token-limit/Cargo.lock
+++ b/plugins/ai-token-limit/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/ai-token-limit/plugin.toml
+++ b/plugins/ai-token-limit/plugin.toml
@@ -6,7 +6,4 @@ description = "Token-based rate limiting for LLM endpoints (ADR-0024). Budget is
 wasm = "ai-token-limit.wasm"
 
 [capabilities]
-log = true
-context_get = true
-context_set = true
-rate_limit = true
+host_functions = ["log", "context_get", "context_set", "rate_limit"]

--- a/plugins/apikey-auth/Cargo.lock
+++ b/plugins/apikey-auth/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/apikey-auth/plugin.toml
+++ b/plugins/apikey-auth/plugin.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 type = "middleware"
 description = "API key authentication middleware for validating API keys from headers or query parameters"
 wasm = "apikey-auth.wasm"
+
+[capabilities]
+host_functions = []

--- a/plugins/basic-auth/Cargo.lock
+++ b/plugins/basic-auth/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/basic-auth/plugin.toml
+++ b/plugins/basic-auth/plugin.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 type = "middleware"
 description = "HTTP Basic authentication middleware (RFC 7617)"
 wasm = "basic-auth.wasm"
+
+[capabilities]
+host_functions = []

--- a/plugins/bot-detection/Cargo.lock
+++ b/plugins/bot-detection/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/bot-detection/plugin.toml
+++ b/plugins/bot-detection/plugin.toml
@@ -6,4 +6,4 @@ description = "Block requests from known bots and scrapers by User-Agent pattern
 wasm = "bot-detection.wasm"
 
 [capabilities]
-log = true
+host_functions = []

--- a/plugins/cache/Cargo.lock
+++ b/plugins/cache/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/cache/plugin.toml
+++ b/plugins/cache/plugin.toml
@@ -5,5 +5,4 @@ type = "middleware"
 description = "Response caching middleware with TTL support"
 
 [capabilities]
-cache = true
-log = true
+host_functions = ["log", "cache"]

--- a/plugins/cel/Cargo.lock
+++ b/plugins/cel/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/cel/plugin.toml
+++ b/plugins/cel/plugin.toml
@@ -6,6 +6,5 @@ description = "CEL policy evaluation middleware — inline expression-based acce
 wasm = "cel.wasm"
 
 [capabilities]
-log = true
-context_set = true
+host_functions = ["log", "context_set"]
 body_access = true

--- a/plugins/correlation-id/Cargo.lock
+++ b/plugins/correlation-id/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/correlation-id/plugin.toml
+++ b/plugins/correlation-id/plugin.toml
@@ -6,7 +6,4 @@ description = "Propagates or generates correlation IDs for distributed tracing"
 wasm = "correlation-id.wasm"
 
 [capabilities]
-log = true
-generate_uuid = true
-context_get = true
-context_set = true
+host_functions = ["log", "context_get", "context_set", "generate_uuid"]

--- a/plugins/cors/Cargo.lock
+++ b/plugins/cors/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/cors/plugin.toml
+++ b/plugins/cors/plugin.toml
@@ -6,4 +6,4 @@ description = "CORS middleware for cross-origin resource sharing"
 wasm = "cors.wasm"
 
 [capabilities]
-log = true
+host_functions = ["log"]

--- a/plugins/fire-and-forget/Cargo.lock
+++ b/plugins/fire-and-forget/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/fire-and-forget/plugin.toml
+++ b/plugins/fire-and-forget/plugin.toml
@@ -6,4 +6,4 @@ description = "Forwards request to upstream and returns an immediate static resp
 wasm = "fire-and-forget.wasm"
 
 [capabilities]
-host_functions = ["host_http_call", "host_log"]
+host_functions = ["log", "http_call"]

--- a/plugins/http-log/Cargo.lock
+++ b/plugins/http-log/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/http-log/plugin.toml
+++ b/plugins/http-log/plugin.toml
@@ -6,8 +6,4 @@ description = "HTTP logging middleware that sends request/response logs to an HT
 wasm = "http-log.wasm"
 
 [capabilities]
-log = true
-time = true
-context_get = true
-context_set = true
-host_functions = ["host_http_call"]
+host_functions = ["log", "context_get", "context_set", "http_call", "clock_now"]

--- a/plugins/http-upstream/Cargo.lock
+++ b/plugins/http-upstream/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/http-upstream/plugin.toml
+++ b/plugins/http-upstream/plugin.toml
@@ -5,4 +5,4 @@ type = "dispatcher"
 wasm = "http-upstream.wasm"
 
 [capabilities]
-host_functions = ["host_http_call", "host_log"]
+host_functions = ["http_call"]

--- a/plugins/ip-restriction/Cargo.lock
+++ b/plugins/ip-restriction/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/ip-restriction/plugin.toml
+++ b/plugins/ip-restriction/plugin.toml
@@ -6,4 +6,4 @@ description = "Allows or denies requests based on client IP address or CIDR rang
 wasm = "ip-restriction.wasm"
 
 [capabilities]
-log = true
+host_functions = []

--- a/plugins/jwt-auth/Cargo.lock
+++ b/plugins/jwt-auth/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/jwt-auth/config-schema.json
+++ b/plugins/jwt-auth/config-schema.json
@@ -21,12 +21,12 @@
     },
     "skip_signature_validation": {
       "type": "boolean",
-      "description": "Whether to skip signature validation (for testing only)",
+      "description": "Skip signature validation. TEST ONLY: ignored by the compiled plugin, so it cannot disable verification in production.",
       "default": false
     },
     "jwks_url": {
       "type": "string",
-      "description": "JWKS URL for fetching public keys (not yet implemented)",
+      "description": "JWKS URL. Not handled by jwt-auth; use the oidc-auth plugin for JWKS-based verification.",
       "format": "uri"
     },
     "groups_claim": {
@@ -35,7 +35,23 @@
     },
     "public_key_pem": {
       "type": "string",
-      "description": "Inline public key in PEM format for signature validation (not yet implemented)"
+      "description": "Inline public key in PEM format. Not handled by jwt-auth; supply public_key_jwk instead, or use oidc-auth."
+    },
+    "public_key_jwk": {
+      "type": "object",
+      "description": "Inline public key as a JWK, used to verify the token signature (RSA RS256/384/512, EC ES256/384). When set, every token must carry a valid signature under this key.",
+      "properties": {
+        "kty": { "type": "string", "enum": ["RSA", "EC"] },
+        "kid": { "type": "string" },
+        "alg": { "type": "string" },
+        "use": { "type": "string" },
+        "n": { "type": "string" },
+        "e": { "type": "string" },
+        "x": { "type": "string" },
+        "y": { "type": "string" },
+        "crv": { "type": "string" }
+      },
+      "required": ["kty"]
     }
   },
   "additionalProperties": false

--- a/plugins/jwt-auth/plugin.toml
+++ b/plugins/jwt-auth/plugin.toml
@@ -6,4 +6,4 @@ description = "JWT authentication middleware for validating Bearer tokens"
 wasm = "jwt-auth.wasm"
 
 [capabilities]
-host_functions = ["verify_signature"]
+host_functions = ["verify_signature", "clock_now"]

--- a/plugins/jwt-auth/src/lib.rs
+++ b/plugins/jwt-auth/src/lib.rs
@@ -31,19 +31,64 @@ pub struct JwtAuth {
     #[serde(default)]
     groups_claim: Option<String>,
 
-    /// Whether to skip signature validation (for testing only).
+    /// Skip signature validation. **Test only** — this flag is ignored in the
+    /// compiled WASM plugin (it is honored solely under `#[cfg(test)]`), so a
+    /// production deployment can never be configured to accept unsigned tokens.
     #[serde(default)]
     skip_signature_validation: bool,
 
-    /// JWKS URL for fetching public keys (not yet implemented).
+    /// JWKS URL for fetching public keys. Not handled by `jwt-auth`; use the
+    /// `oidc-auth` plugin for JWKS-based verification.
     #[allow(dead_code)]
     #[serde(default)]
     jwks_url: Option<String>,
 
-    /// Inline public key in PEM format for signature validation (not yet implemented).
+    /// Inline public key in PEM format. Not handled by `jwt-auth`; supply
+    /// `public_key_jwk` instead, or use `oidc-auth`.
     #[allow(dead_code)]
     #[serde(default)]
     public_key_pem: Option<String>,
+
+    /// Inline public key as a JWK, used to verify the token signature via the
+    /// host `verify_signature` capability. Supports RSA (`RS256/384/512`) and
+    /// EC (`ES256/384`) keys. When set, every token must carry a valid
+    /// signature under this key.
+    #[serde(default)]
+    public_key_jwk: Option<Jwk>,
+}
+
+/// A JSON Web Key (public part) accepted by the host `verify_signature`
+/// capability.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct Jwk {
+    kty: String,
+    #[serde(default)]
+    kid: Option<String>,
+    #[serde(default)]
+    alg: Option<String>,
+    #[serde(default, rename = "use")]
+    use_: Option<String>,
+    // RSA
+    #[serde(default)]
+    n: Option<String>,
+    #[serde(default)]
+    e: Option<String>,
+    // EC
+    #[serde(default)]
+    x: Option<String>,
+    #[serde(default)]
+    y: Option<String>,
+    #[serde(default)]
+    crv: Option<String>,
+}
+
+/// Request payload for the host `verify_signature` capability.
+#[derive(Serialize)]
+struct VerifyRequest {
+    algorithm: String,
+    jwk: serde_json::Value,
+    message: String,
+    signature: Vec<u8>,
 }
 
 fn default_clock_skew() -> u64 {
@@ -112,9 +157,7 @@ impl Audience {
 struct ParsedJwt {
     header: JwtHeader,
     claims: JwtClaims,
-    #[allow(dead_code)]
     signing_input: String,
-    #[allow(dead_code)]
     signature: Vec<u8>,
 }
 
@@ -239,8 +282,11 @@ impl JwtAuth {
         // Validate algorithm
         self.validate_algorithm(&parsed.header)?;
 
-        // Validate signature (if not skipped)
-        if !self.skip_signature_validation {
+        // Validate signature. `skip_signature_validation` is honored only in
+        // unit tests (`cfg!(test)`); in the compiled plugin it has no effect,
+        // so a forged/unsigned token is never accepted in production.
+        let skip = self.skip_signature_validation && cfg!(test);
+        if !skip {
             self.validate_signature(&parsed)?;
         }
 
@@ -308,19 +354,55 @@ impl JwtAuth {
         }
     }
 
-    /// Validate the JWT signature.
+    /// Validate the JWT signature using the host `verify_signature` capability.
     ///
-    /// NOTE: Cryptographic signature validation is not yet implemented.
-    /// When `skip_signature_validation` is false, this will always fail.
-    /// Use `skip_signature_validation: true` until JWKS support is added.
-    fn validate_signature(&self, _parsed: &ParsedJwt) -> Result<(), JwtError> {
-        // Signature validation requires either:
-        // 1. A host function for crypto (host_verify_signature) - not yet implemented
-        // 2. WASM-compatible crypto library - complex to integrate
-        //
-        // For now, signature validation always fails unless explicitly skipped.
-        // This is intentional: we don't want to silently accept unsigned tokens.
-        Err(JwtError::SignatureInvalid)
+    /// Requires `public_key_jwk` to be configured. JWKS-over-network and PEM
+    /// keys are intentionally not handled here — use the `oidc-auth` plugin for
+    /// those. Fails closed when no inline key is configured.
+    fn validate_signature(&self, parsed: &ParsedJwt) -> Result<(), JwtError> {
+        let jwk = self
+            .public_key_jwk
+            .as_ref()
+            .ok_or(JwtError::SignatureInvalid)?;
+
+        // Bind the key to the token algorithm (RFC 8725): a key tagged with a
+        // specific `alg`/`use` must match what the token claims, and the key
+        // type must match the algorithm family.
+        if let Some(key_alg) = &jwk.alg {
+            if key_alg != &parsed.header.alg {
+                return Err(JwtError::SignatureInvalid);
+            }
+        }
+        if let Some(use_) = &jwk.use_ {
+            if use_ != "sig" {
+                return Err(JwtError::SignatureInvalid);
+            }
+        }
+        let expected_kty = match parsed.header.alg.as_str() {
+            "RS256" | "RS384" | "RS512" => "RSA",
+            "ES256" | "ES384" | "ES512" => "EC",
+            other => return Err(JwtError::UnsupportedAlgorithm(other.to_string())),
+        };
+        if jwk.kty != expected_kty {
+            return Err(JwtError::SignatureInvalid);
+        }
+
+        let request = VerifyRequest {
+            algorithm: parsed.header.alg.clone(),
+            jwk: serde_json::to_value(jwk).map_err(|_| JwtError::SignatureInvalid)?,
+            message: parsed.signing_input.clone(),
+            signature: parsed.signature.clone(),
+        };
+        let request_json = serde_json::to_vec(&request).map_err(|_| JwtError::SignatureInvalid)?;
+
+        // SAFETY: passing a pointer/length into the host, which copies the bytes
+        // out of guest memory before returning.
+        let result =
+            unsafe { host_verify_signature(request_json.as_ptr() as i32, request_json.len() as i32) };
+        match result {
+            1 => Ok(()),
+            _ => Err(JwtError::SignatureInvalid),
+        }
     }
 
     /// Validate JWT claims.
@@ -388,13 +470,24 @@ impl JwtAuth {
     }
 }
 
+/// Host capability bindings (WASM).
+#[cfg(target_arch = "wasm32")]
+#[link(wasm_import_module = "barbacane")]
+extern "C" {
+    fn host_get_unix_timestamp() -> u64;
+    fn host_verify_signature(req_ptr: i32, req_len: i32) -> i32;
+}
+
+/// Non-WASM stub: signature verification is unavailable off-target, so it
+/// fails closed. Unit tests use `skip_signature_validation` instead.
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn host_verify_signature(_req_ptr: i32, _req_len: i32) -> i32 {
+    -1
+}
+
 /// Get current Unix timestamp (WASM version using host function).
 #[cfg(target_arch = "wasm32")]
 fn current_timestamp() -> u64 {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_get_unix_timestamp() -> u64;
-    }
     unsafe { host_get_unix_timestamp() }
 }
 
@@ -461,6 +554,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let req = create_test_request(Some("Bearer my.jwt.token"));
         let token = config.extract_token(&req).unwrap();
@@ -477,6 +571,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let req = create_test_request(Some("bearer my.jwt.token"));
         let token = config.extract_token(&req).unwrap();
@@ -493,6 +588,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let req = create_test_request(Some("Bearer  my.jwt.token  "));
         let token = config.extract_token(&req).unwrap();
@@ -509,6 +605,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let req = create_test_request(None);
         let result = config.extract_token(&req);
@@ -525,6 +622,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let req = create_test_request(Some("Basic dXNlcjpwYXNz"));
         let result = config.extract_token(&req);
@@ -541,6 +639,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let token = create_test_jwt(
             r#"{"alg":"RS256","typ":"JWT"}"#,
@@ -562,6 +661,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let result = config.parse_jwt("header.payload");
         assert!(matches!(result, Err(JwtError::MalformedToken)));
@@ -577,6 +677,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let result = config.parse_jwt("invalid!!!.payload.sig");
         assert!(matches!(result, Err(JwtError::InvalidBase64)));
@@ -592,6 +693,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let header_b64 = URL_SAFE_NO_PAD.encode(b"not json");
         let claims_b64 = URL_SAFE_NO_PAD.encode(b"{}");
@@ -610,6 +712,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let header = JwtHeader {
             alg: "RS256".to_string(),
@@ -629,6 +732,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let header = JwtHeader {
             alg: "ES256".to_string(),
@@ -648,6 +752,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let header = JwtHeader {
             alg: "none".to_string(),
@@ -668,6 +773,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let header = JwtHeader {
             alg: "HS256".to_string(),
@@ -689,6 +795,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let claims = JwtClaims {
             sub: Some("user123".to_string()),
@@ -714,6 +821,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let claims = JwtClaims {
             sub: None,
@@ -740,6 +848,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let claims = JwtClaims {
             sub: None,
@@ -766,6 +875,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let claims = JwtClaims {
             sub: None,
@@ -792,6 +902,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let claims = JwtClaims {
             sub: None,
@@ -819,6 +930,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let claims = JwtClaims {
             sub: None,
@@ -862,6 +974,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let error = JwtError::MissingAuthHeader;
         let response = config.unauthorized_response(&error);
@@ -922,6 +1035,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
 
         let token = create_test_jwt(
@@ -949,6 +1063,34 @@ mod tests {
     }
 
     #[test]
+    fn test_on_request_rejects_when_no_key_and_not_skipped() {
+        // Production-shaped config: signature validation is NOT skipped and no
+        // verification key is configured. A structurally valid, unexpired token
+        // must be rejected (fail closed) — this is the CR-1 regression guard
+        // proving the old "skip-or-bypass" hole is gone.
+        mock_time::set_mock_timestamp(1000);
+        let mut config = JwtAuth {
+            issuer: None,
+            audience: None,
+            clock_skew_seconds: 60,
+            groups_claim: None,
+            skip_signature_validation: false,
+            jwks_url: None,
+            public_key_pem: None,
+            public_key_jwk: None,
+        };
+        let token = create_test_jwt(
+            r#"{"alg":"RS256","typ":"JWT"}"#,
+            r#"{"sub":"attacker","exp":2000}"#,
+        );
+        let req = create_test_request(Some(&format!("Bearer {}", token)));
+        match config.on_request(req) {
+            Action::ShortCircuit(response) => assert_eq!(response.status, 401),
+            Action::Continue(_) => panic!("forged/unsigned token must be rejected"),
+        }
+    }
+
+    #[test]
     fn test_on_request_missing_token() {
         let mut config = JwtAuth {
             issuer: None,
@@ -958,6 +1100,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
 
         let req = create_test_request(None);
@@ -981,6 +1124,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
 
         let token = create_test_jwt(
@@ -1009,6 +1153,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
 
         let response = Response {
@@ -1032,6 +1177,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
         let mut headers = BTreeMap::new();
         headers.insert(
@@ -1062,6 +1208,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
 
         let token = create_test_jwt(
@@ -1090,6 +1237,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
 
         let token = create_test_jwt(
@@ -1121,6 +1269,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
 
         let token = create_test_jwt(
@@ -1152,6 +1301,7 @@ mod tests {
             skip_signature_validation: true,
             jwks_url: None,
             public_key_pem: None,
+            public_key_jwk: None,
         };
 
         // JWT has no "roles" claim

--- a/plugins/kafka/Cargo.lock
+++ b/plugins/kafka/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/lambda/Cargo.lock
+++ b/plugins/lambda/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/lambda/plugin.toml
+++ b/plugins/lambda/plugin.toml
@@ -5,4 +5,4 @@ type = "dispatcher"
 wasm = "lambda.wasm"
 
 [capabilities]
-host_functions = ["host_http_call", "host_log"]
+host_functions = ["http_call"]

--- a/plugins/mock/Cargo.lock
+++ b/plugins/mock/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/nats/Cargo.lock
+++ b/plugins/nats/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/oauth2-auth/Cargo.lock
+++ b/plugins/oauth2-auth/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/oauth2-auth/plugin.toml
+++ b/plugins/oauth2-auth/plugin.toml
@@ -6,4 +6,4 @@ description = "OAuth2 token introspection middleware for validating Bearer token
 wasm = "oauth2-auth.wasm"
 
 [capabilities]
-http = true
+host_functions = ["http_call"]

--- a/plugins/observability/Cargo.lock
+++ b/plugins/observability/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/observability/plugin.toml
+++ b/plugins/observability/plugin.toml
@@ -6,8 +6,4 @@ description = "Per-operation observability middleware for SLO monitoring, detail
 wasm = "observability.wasm"
 
 [capabilities]
-log = true
-telemetry = true
-time = true
-context_get = true
-context_set = true
+host_functions = ["log", "context_get", "context_set", "telemetry", "clock_now"]

--- a/plugins/oidc-auth/Cargo.lock
+++ b/plugins/oidc-auth/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/oidc-auth/plugin.toml
+++ b/plugins/oidc-auth/plugin.toml
@@ -6,4 +6,4 @@ description = "OIDC authentication middleware with auto-discovery and JWKS rotat
 wasm = "oidc-auth.wasm"
 
 [capabilities]
-host_functions = ["http_call", "verify_signature"]
+host_functions = ["http_call", "verify_signature", "clock_now"]

--- a/plugins/opa-authz/Cargo.lock
+++ b/plugins/opa-authz/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/opa-authz/plugin.toml
+++ b/plugins/opa-authz/plugin.toml
@@ -6,4 +6,4 @@ description = "OPA authorization middleware — policy-based access control via 
 wasm = "opa-authz.wasm"
 
 [capabilities]
-http = true
+host_functions = ["http_call"]

--- a/plugins/rate-limit/Cargo.lock
+++ b/plugins/rate-limit/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/rate-limit/plugin.toml
+++ b/plugins/rate-limit/plugin.toml
@@ -6,5 +6,4 @@ description = "Rate limiting middleware with IETF draft headers support"
 wasm = "rate-limit.wasm"
 
 [capabilities]
-rate_limit = true
-log = true
+host_functions = ["log", "rate_limit"]

--- a/plugins/redirect/Cargo.lock
+++ b/plugins/redirect/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/redirect/plugin.toml
+++ b/plugins/redirect/plugin.toml
@@ -6,4 +6,4 @@ description = "URL redirections (301/302/307/308) with path matching and query s
 wasm = "redirect.wasm"
 
 [capabilities]
-log = true
+host_functions = []

--- a/plugins/request-size-limit/Cargo.lock
+++ b/plugins/request-size-limit/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/request-size-limit/plugin.toml
+++ b/plugins/request-size-limit/plugin.toml
@@ -6,5 +6,5 @@ description = "Rejects requests that exceed a configurable size limit"
 wasm = "request-size-limit.wasm"
 
 [capabilities]
-log = true
+host_functions = []
 body_access = true

--- a/plugins/request-transformer/Cargo.lock
+++ b/plugins/request-transformer/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/request-transformer/plugin.toml
+++ b/plugins/request-transformer/plugin.toml
@@ -6,6 +6,5 @@ description = "Transform HTTP requests: headers, query parameters, path, and bod
 wasm = "request-transformer.wasm"
 
 [capabilities]
-log = true
-context_get = true
+host_functions = ["log", "context_get"]
 body_access = true

--- a/plugins/response-transformer/Cargo.lock
+++ b/plugins/response-transformer/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/response-transformer/plugin.toml
+++ b/plugins/response-transformer/plugin.toml
@@ -6,5 +6,5 @@ description = "Transform HTTP responses: status code, headers, and body"
 wasm = "response-transformer.wasm"
 
 [capabilities]
-log = true
+host_functions = ["log"]
 body_access = true

--- a/plugins/s3/Cargo.lock
+++ b/plugins/s3/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-sigv4"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "hex",
  "hmac",

--- a/plugins/s3/plugin.toml
+++ b/plugins/s3/plugin.toml
@@ -6,4 +6,4 @@ description = "AWS S3 / S3-compatible object storage dispatcher with SigV4 signi
 wasm = "s3.wasm"
 
 [capabilities]
-host_functions = ["http_call", "log"]
+host_functions = ["http_call", "clock_now"]

--- a/plugins/ws-upstream/Cargo.lock
+++ b/plugins/ws-upstream/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/plugins/ws-upstream/plugin.toml
+++ b/plugins/ws-upstream/plugin.toml
@@ -6,4 +6,4 @@ description = "Transparent WebSocket proxy"
 wasm = "ws-upstream.wasm"
 
 [capabilities]
-host_functions = ["ws_upgrade", "log"]
+host_functions = ["ws_upgrade"]

--- a/tests/fixture-plugins/body-echo/Cargo.lock
+++ b/tests/fixture-plugins/body-echo/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.3.1"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.3.1"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/tests/fixture-plugins/streaming-echo/Cargo.lock
+++ b/tests/fixture-plugins/streaming-echo/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.3.1"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.3.1"
+version = "0.7.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",

--- a/tests/fixtures/security/barbacane.yaml
+++ b/tests/fixtures/security/barbacane.yaml
@@ -1,0 +1,19 @@
+# Manifest for the security fixtures (one directory deeper than tests/fixtures,
+# so plugin paths gain one extra `../`).
+plugins:
+  mock:
+    path: ../../../plugins/mock/mock.wasm
+  opa-authz:
+    path: ../../../plugins/opa-authz/opa-authz.wasm
+  jwt-auth:
+    path: ../../../plugins/jwt-auth/jwt-auth.wasm
+  oidc-auth:
+    path: ../../../plugins/oidc-auth/oidc-auth.wasm
+  ip-restriction:
+    path: ../../../plugins/ip-restriction/ip-restriction.wasm
+  rate-limit:
+    path: ../../../plugins/rate-limit/rate-limit.wasm
+  request-size-limit:
+    path: ../../../plugins/request-size-limit/request-size-limit.wasm
+  http-log:
+    path: ../../../plugins/http-log/http-log.wasm

--- a/tests/fixtures/security/jwt-verify.yaml
+++ b/tests/fixtures/security/jwt-verify.yaml
@@ -1,0 +1,38 @@
+openapi: "3.1.0"
+info:
+  title: JWT Signature Verification Test API
+  version: "1.0.0"
+  description: >
+    Unlike jwt-auth.yaml (which sets skip_signature_validation: true), this
+    fixture ENFORCES signature validation so we can assert that a validly-signed
+    token is accepted while a tampered one is rejected (BARB-SEC-005).
+
+x-barbacane-middlewares:
+  - name: jwt-auth
+    config:
+      issuer: "test-issuer"
+      audience: "test-audience"
+      clock_skew_seconds: 60
+      skip_signature_validation: false
+      # An inline public key the plugin must use to verify RS256 signatures.
+      # (public_key_pem support is part of the BARB-SEC-005 fix.)
+      public_key_pem: |
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtest-placeholder-key
+        -----END PUBLIC KEY-----
+
+paths:
+  /protected:
+    get:
+      operationId: getProtected
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"message":"Access granted"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Success
+        "401":
+          description: Unauthorized

--- a/tests/fixtures/security/metrics.yaml
+++ b/tests/fixtures/security/metrics.yaml
@@ -1,0 +1,16 @@
+openapi: "3.1.0"
+info:
+  title: Metrics Cardinality Test API
+  version: "1.0.0"
+paths:
+  /ok:
+    get:
+      operationId: getOk
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"status":"ok"}'
+      responses:
+        "200":
+          description: OK

--- a/tests/fixtures/security/ssrf.yaml
+++ b/tests/fixtures/security/ssrf.yaml
@@ -1,0 +1,92 @@
+openapi: "3.1.0"
+info:
+  title: SSRF Test API
+  version: "1.0.0"
+  description: >
+    Exercises the WASM host HTTP client against SSRF targets. Each endpoint
+    drives the opa-authz middleware, whose `opa_url` is a plugin-controlled
+    outbound HTTP call. The secure behaviour (BARB-SEC-002) is that the host
+    refuses to connect to loopback / link-local / private / metadata addresses,
+    so the protected upstream response (HTTP 200 "reached") is NEVER returned.
+
+paths:
+  # AWS/GCP/Azure instance metadata service.
+  /ssrf-metadata:
+    get:
+      operationId: ssrfMetadata
+      x-barbacane-middlewares:
+        - name: opa-authz
+          config:
+            opa_url: "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+            timeout: 2
+            deny_message: "blocked"
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"reached":"metadata"}'
+          content_type: application/json
+      responses:
+        "200": { description: reached }
+        "403": { description: denied }
+        "503": { description: blocked or unavailable }
+
+  # Loopback.
+  /ssrf-loopback:
+    get:
+      operationId: ssrfLoopback
+      x-barbacane-middlewares:
+        - name: opa-authz
+          config:
+            opa_url: "http://127.0.0.1:9/v1/data/authz/allow"
+            timeout: 2
+            deny_message: "blocked"
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"reached":"loopback"}'
+          content_type: application/json
+      responses:
+        "200": { description: reached }
+        "503": { description: blocked or unavailable }
+
+  # RFC1918 private address.
+  /ssrf-private:
+    get:
+      operationId: ssrfPrivate
+      x-barbacane-middlewares:
+        - name: opa-authz
+          config:
+            opa_url: "http://10.0.0.1/v1/data/authz/allow"
+            timeout: 2
+            deny_message: "blocked"
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"reached":"private"}'
+          content_type: application/json
+      responses:
+        "200": { description: reached }
+        "503": { description: blocked or unavailable }
+
+  # link-local hostname that resolves to the metadata IP via DNS (DNS-rebind shape).
+  /ssrf-dns-metadata:
+    get:
+      operationId: ssrfDnsMetadata
+      x-barbacane-middlewares:
+        - name: opa-authz
+          config:
+            opa_url: "http://metadata.google.internal/computeMetadata/v1/"
+            timeout: 2
+            deny_message: "blocked"
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"reached":"dns-metadata"}'
+          content_type: application/json
+      responses:
+        "200": { description: reached }
+        "503": { description: blocked or unavailable }

--- a/tests/fixtures/security/xff-rate-limit.yaml
+++ b/tests/fixtures/security/xff-rate-limit.yaml
@@ -1,0 +1,30 @@
+openapi: "3.1.0"
+info:
+  title: XFF Rate Limit Test API
+  version: "1.0.0"
+  description: >
+    Rate limit partitioned by client_ip. Used to prove that rotating a forged
+    X-Forwarded-For must not create fresh buckets (BARB-SEC-005).
+
+paths:
+  /limited:
+    get:
+      operationId: limitedEndpoint
+      summary: Rate limited endpoint (3 req/60s), partitioned by client IP
+      x-barbacane-middlewares:
+        - name: rate-limit
+          config:
+            quota: 3
+            window: 60
+            policy_name: "xff-test-policy"
+            partition_key: "client_ip"
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"message":"ok"}'
+      responses:
+        "200":
+          description: Success
+        "429":
+          description: Rate limit exceeded


### PR DESCRIPTION
Hardening pass from a security review, plus a security testing harness. Everything builds; affected crate test suites and the workspace clippy gate pass locally.

## Hardening
- **Control plane**: admin bearer token required on all routes except `/health` and the data-plane WebSocket; fails closed without `BARBACANE_CONTROL_ADMIN_TOKEN`; CORS restricted to an allowlist (`BARBACANE_CONTROL_ALLOWED_ORIGINS`).
- **Artifact integrity**: Ed25519 signing at compile (`BARBACANE_SIGNING_KEY`) and verify-on-load against a pinned key (`BARBACANE_TRUSTED_PUBKEY`), plus per-plugin/spec/route checksum verification before any plugin is instantiated.
- **MCP**: sessions are enforced for non-`initialize` requests.
- **Plugin egress**: the WASM host HTTP client blocks loopback/link-local/private/metadata targets and no longer follows redirects (`BARBACANE_ALLOW_INTERNAL_EGRESS` to override).
- **jwt-auth**: real signature verification via the host `verify_signature` capability (inline JWK); the test-only skip flag is ignored in production builds.
- **Secrets**: `file://` references confined to `BARBACANE_SECRETS_DIR`.
- **Misc**: fix a fail-open middleware short-circuit; bound Prometheus path-label cardinality on unmatched routes; stop panicking on hostile `x-request-id`/`traceparent`; correct capability map (`cache`/`rate_limit`/`http_stream`); non-root standalone image; correct AGPL image labels; add `deny.toml` license/bans/sources gates.

## Security test framework
- Adversarial integration suite under `crates/barbacane-test/tests/security/`.
- `cargo-fuzz` targets under `fuzz/` (spec parser, artifact loader, JSON-RPC, validator).
- Runbook: `docs/contributing/security-testing.md`; `make security-test` / `make fuzz-build`.

## Config (operators)
| Var | Purpose |
|---|---|
| `BARBACANE_CONTROL_ADMIN_TOKEN` | required to start the control plane |
| `BARBACANE_CONTROL_ALLOWED_ORIGINS` | CORS allowlist (comma-separated) |
| `BARBACANE_SIGNING_KEY` | PKCS#8 Ed25519 key to sign artifacts at compile |
| `BARBACANE_TRUSTED_PUBKEY` | hex Ed25519 pubkey; when set, signature verification is required on load |
| `BARBACANE_SECRETS_DIR` | base dir for `file://` secret references |
| `BARBACANE_ALLOW_INTERNAL_EGRESS` | opt out of the plugin SSRF guard |

## Follow-ups (see ROADMAP "Security hardening")
- Complete the per-plugin default-deny capability linker (needs the official `plugin.toml` capability-dialect migration + the wasm/Docker integration run).
- Ingress timeouts/limits, per-plugin secret scoping, SDK hardening helpers, CI supply-chain gates, control-plane non-root.

Detailed findings are tracked privately.