### PR TITLE
Security: fix plugin auth/access bypasses + fail-open controls

### DIFF
--- a/crates/barbacane-plugin-sdk/src/types.rs
+++ b/crates/barbacane-plugin-sdk/src/types.rs
@@ -143,6 +143,44 @@ pub fn streamed_response() -> Response {
     }
 }
 
+/// Resolve the effective client IP, honoring trusted proxies.
+///
+/// `req.client_ip` is the peer the gateway actually observed. The forwarded
+/// headers (`X-Forwarded-For`, `X-Real-IP`) are attacker-controlled, so they are
+/// consulted **only** when the immediate peer is one of `trusted_proxies`; then
+/// the right-most forwarded address that is not itself a trusted proxy is
+/// returned. With no trusted proxies configured (the default), forwarded headers
+/// are ignored entirely and the observed peer is used.
+///
+/// This is the single source of truth for client-IP resolution so security
+/// middlewares (ip-restriction, rate-limit, ai-token-limit) cannot drift into
+/// independently spoofable implementations.
+pub fn resolve_client_ip(req: &Request, trusted_proxies: &[String]) -> String {
+    let peer = req.client_ip.trim();
+    let is_trusted = |ip: &str| trusted_proxies.iter().any(|p| p.trim() == ip);
+
+    if !is_trusted(peer) {
+        return peer.to_string();
+    }
+
+    if let Some(xff) = req.headers.get("x-forwarded-for") {
+        for hop in xff.split(',').map(str::trim).rev() {
+            if !hop.is_empty() && !is_trusted(hop) {
+                return hop.to_string();
+            }
+        }
+    }
+
+    if let Some(real) = req.headers.get("x-real-ip") {
+        let real = real.trim();
+        if !real.is_empty() {
+            return real.to_string();
+        }
+    }
+
+    peer.to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -470,5 +508,39 @@ mod tests {
             .decode(&encoded)
             .unwrap();
         assert_eq!(bytes, original);
+    }
+
+    fn req_with(peer: &str, xff: Option<&str>) -> Request {
+        let mut headers = BTreeMap::new();
+        if let Some(v) = xff {
+            headers.insert("x-forwarded-for".to_string(), v.to_string());
+        }
+        Request {
+            method: "GET".into(),
+            path: "/".into(),
+            query: None,
+            headers,
+            body: None,
+            client_ip: peer.to_string(),
+            path_params: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn resolve_client_ip_ignores_xff_from_untrusted_peer() {
+        // No trusted proxies: a spoofed XFF must be ignored.
+        let req = req_with("203.0.113.9", Some("10.0.0.5"));
+        assert_eq!(resolve_client_ip(&req, &[]), "203.0.113.9");
+    }
+
+    #[test]
+    fn resolve_client_ip_uses_xff_only_behind_trusted_proxy() {
+        let trusted = vec!["203.0.113.9".to_string()];
+        // Peer is the trusted proxy: take the right-most non-trusted hop.
+        let req = req_with("203.0.113.9", Some("198.51.100.7, 203.0.113.9"));
+        assert_eq!(resolve_client_ip(&req, &trusted), "198.51.100.7");
+        // Peer is NOT trusted: XFF ignored even though one is configured.
+        let req2 = req_with("198.51.100.200", Some("10.0.0.5"));
+        assert_eq!(resolve_client_ip(&req2, &trusted), "198.51.100.200");
     }
 }

--- a/plugins/ai-prompt-guard/config-schema.json
+++ b/plugins/ai-prompt-guard/config-schema.json
@@ -61,6 +61,11 @@
       "description": "Named policy profiles.",
       "additionalProperties": { "$ref": "#/$defs/PromptProfile" },
       "minProperties": 1
+    },
+    "fail_open": {
+      "type": "boolean",
+      "default": false,
+      "description": "When the request body can't be inspected (unparseable JSON or a non-array 'messages'), allow it through instead of rejecting. Defaults to false (fail closed) so the guard can't be bypassed with a malformed body."
     }
   }
 }

--- a/plugins/ai-prompt-guard/src/lib.rs
+++ b/plugins/ai-prompt-guard/src/lib.rs
@@ -91,6 +91,13 @@ pub struct AiPromptGuard {
     /// Named profiles the operator can select between.
     profiles: BTreeMap<String, PromptProfile>,
 
+    /// When the request body can't be inspected (unparseable JSON, or a
+    /// `messages` field that isn't an array), allow it through (fail open)
+    /// instead of rejecting. Defaults to false (fail closed), so a client can't
+    /// bypass the guard by sending a body the parser rejects.
+    #[serde(default)]
+    fail_open: bool,
+
     /// Compiled regex cache, keyed by profile name. Populated lazily.
     #[serde(skip)]
     compiled: BTreeMap<String, Vec<Regex>>,
@@ -129,17 +136,37 @@ impl AiPromptGuard {
             return Action::ShortCircuit(regex_compile_error_response(&profile_name, &err));
         }
 
+        // No body: nothing to inspect (and nothing to inject into).
         let Some(body_bytes) = req.body.as_deref() else {
             return Action::Continue(req);
         };
 
+        // Unparseable body is the classic guard-bypass vector. Fail closed by
+        // default so a client can't skip filtering by sending malformed JSON.
         let mut root: serde_json::Value = match serde_json::from_slice(body_bytes) {
             Ok(v) => v,
-            Err(_) => return Action::Continue(req),
+            Err(_) => {
+                if self.fail_open {
+                    return Action::Continue(req);
+                }
+                return Action::ShortCircuit(reject(&profile, "request body is not valid JSON"));
+            }
         };
 
-        let Some(messages) = root.get("messages").and_then(|v| v.as_array()).cloned() else {
-            return Action::Continue(req);
+        let messages = match root.get("messages") {
+            // No `messages` field at all: a different request shape with no chat
+            // messages to guard — pass through.
+            None => return Action::Continue(req),
+            // Present but not an array: malformed; fail closed unless opted out.
+            Some(v) => match v.as_array() {
+                Some(arr) => arr.clone(),
+                None => {
+                    if self.fail_open {
+                        return Action::Continue(req);
+                    }
+                    return Action::ShortCircuit(reject(&profile, "'messages' is not an array"));
+                }
+            },
         };
 
         // --- Message count limit ---
@@ -493,6 +520,7 @@ mod tests {
                 .into_iter()
                 .map(|(k, v)| (k.to_string(), v))
                 .collect(),
+            fail_open: false,
             compiled: BTreeMap::new(),
             compile_errors: BTreeMap::new(),
         }
@@ -855,11 +883,34 @@ mod tests {
         assert!(matches!(p.on_request(r), Action::Continue(_)));
     }
 
+    // PL-6: an unparseable body must NOT bypass the guard by default.
     #[test]
-    fn non_json_body_continues() {
+    fn non_json_body_fails_closed() {
         mock_host::reset();
         let mut p = single_profile_plugin(profile_with(Some(5), None, vec![]));
+        match p.on_request(req("not json")) {
+            Action::ShortCircuit(resp) => assert_eq!(resp.status, 400),
+            Action::Continue(_) => panic!("unparseable body must fail closed"),
+        }
+    }
+
+    #[test]
+    fn non_json_body_continues_when_fail_open() {
+        mock_host::reset();
+        let mut p = single_profile_plugin(profile_with(Some(5), None, vec![]));
+        p.fail_open = true;
         assert!(matches!(p.on_request(req("not json")), Action::Continue(_)));
+    }
+
+    // PL-6: a `messages` field that isn't an array fails closed by default.
+    #[test]
+    fn non_array_messages_fails_closed() {
+        mock_host::reset();
+        let mut p = single_profile_plugin(profile_with(Some(5), None, vec![]));
+        match p.on_request(req(r#"{"messages":"oops"}"#)) {
+            Action::ShortCircuit(resp) => assert_eq!(resp.status, 400),
+            Action::Continue(_) => panic!("non-array messages must fail closed"),
+        }
     }
 
     #[test]

--- a/plugins/ai-proxy/config-schema.json
+++ b/plugins/ai-proxy/config-schema.json
@@ -23,7 +23,7 @@
         },
         "api_key": {
           "type": "string",
-          "description": "Provider API key. Supports `env://VAR` substitution. Omit for Ollama (unauthenticated local endpoint)."
+          "description": "Provider API key. Use a secret reference (`env://VAR` or `file://...`) rather than a literal value, so the key is resolved at runtime and never baked into the compiled artifact. Omit for Ollama (unauthenticated local endpoint)."
         },
         "base_url": {
           "type": "string",
@@ -58,7 +58,7 @@
         },
         "api_key": {
           "type": "string",
-          "description": "Provider API key. Supports `env://VAR` substitution."
+          "description": "Provider API key. Use a secret reference (`env://VAR` or `file://...`) rather than a literal value, so the key is resolved at runtime and never baked into the compiled artifact."
         },
         "base_url": {
           "type": "string",
@@ -84,7 +84,7 @@
     },
     "api_key": {
       "type": "string",
-      "description": "API key for the flat config. Supports `env://VAR` substitution."
+      "description": "API key for the flat config. Use a secret reference (`env://VAR` or `file://...`) rather than a literal value, so the key is resolved at runtime and never baked into the compiled artifact."
     },
     "base_url": {
       "type": "string",

--- a/plugins/ai-token-limit/config-schema.json
+++ b/plugins/ai-token-limit/config-schema.json
@@ -51,6 +51,17 @@
       "description": "Source of the per-consumer partition key. Accepted forms: `client_ip`, `header:<name>`, `context:<key>`, or a literal string (shared budget across all requests). Matches the `rate-limit` plugin's semantics.",
       "default": "client_ip"
     },
+    "trusted_proxies": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Exact IPs of trusted reverse proxies. With partition_key 'client_ip', X-Forwarded-For / X-Real-IP are honored only behind these; otherwise the observed peer IP is used so clients cannot rotate XFF to evade their budget."
+    },
+    "fail_open": {
+      "type": "boolean",
+      "default": false,
+      "description": "When the host rate limiter is unavailable, allow the request (fail open) instead of rejecting with 503. Defaults to false (fail closed)."
+    },
     "count": {
       "type": "string",
       "description": "Which token counts charge against the budget. `prompt` counts input tokens only, `completion` counts output tokens only, `total` counts both.",

--- a/plugins/ai-token-limit/src/lib.rs
+++ b/plugins/ai-token-limit/src/lib.rs
@@ -88,6 +88,18 @@ pub struct AiTokenLimit {
     #[serde(default = "default_partition_key")]
     partition_key: String,
 
+    /// Exact IPs of trusted reverse proxies, used when `partition_key` is
+    /// "client_ip". Forwarded headers are honored only behind a trusted proxy so
+    /// a client cannot rotate `X-Forwarded-For` to dodge its token budget.
+    #[serde(default)]
+    trusted_proxies: Vec<String>,
+
+    /// When the host rate limiter is unavailable, allow the request (fail open)
+    /// instead of rejecting it. Defaults to false (fail closed), so a limiter
+    /// outage cannot silently disable token budgeting.
+    #[serde(default)]
+    fail_open: bool,
+
     /// Which tokens charge against the budget.
     #[serde(default)]
     count: CountMode,
@@ -115,7 +127,7 @@ impl AiTokenLimit {
             None => return Action::ShortCircuit(misconfig_response(&self.default_profile)),
         };
 
-        let partition = extract_partition(&req, &self.partition_key);
+        let partition = extract_partition(&req, &self.partition_key, &self.trusted_proxies);
 
         // Persist the resolved partition so on_response charges the same
         // bucket — on_response has no Request in scope and header/IP sources
@@ -125,11 +137,20 @@ impl AiTokenLimit {
         let key = self.bucket_key(&profile_name, &partition);
 
         let Some(result) = check_rate_limit(&key, profile.quota, profile.window) else {
+            // Fail closed by default: a limiter outage must not silently disable
+            // token budgeting. Operators may opt into fail-open.
+            if self.fail_open {
+                log_message(
+                    1,
+                    "ai-token-limit: rate limiter unavailable, failing open (allowing request)",
+                );
+                return Action::Continue(req);
+            }
             log_message(
-                1,
-                "ai-token-limit: rate limiter unavailable, allowing request",
+                3,
+                "ai-token-limit: rate limiter unavailable, failing closed (rejecting request)",
             );
-            return Action::Continue(req);
+            return Action::ShortCircuit(unavailable_response());
         };
 
         if result.allowed {
@@ -212,12 +233,8 @@ impl AiTokenLimit {
     }
 
     fn tokens_from_context(&self) -> u32 {
-        let prompt = context_get("ai.prompt_tokens")
-            .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or(0);
-        let completion = context_get("ai.completion_tokens")
-            .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or(0);
+        let prompt = parse_token_count("ai.prompt_tokens");
+        let completion = parse_token_count("ai.completion_tokens");
 
         match self.count {
             CountMode::Prompt => prompt,
@@ -279,6 +296,27 @@ impl AiTokenLimit {
 // Misconfiguration response (fail-closed)
 // ---------------------------------------------------------------------------
 
+/// 503 response returned when the host rate limiter is unavailable and the
+/// plugin is configured to fail closed (the default).
+fn unavailable_response() -> Response {
+    let mut headers = BTreeMap::new();
+    headers.insert(
+        "content-type".to_string(),
+        "application/problem+json".to_string(),
+    );
+    let body = serde_json::json!({
+        "type": "urn:barbacane:error:ai-token-limit-unavailable",
+        "title": "Service Unavailable",
+        "status": 503,
+        "detail": "Token-budget limiter is unavailable; request rejected (fail closed).",
+    });
+    Response {
+        status: 503,
+        headers,
+        body: Some(body.to_string().into_bytes()),
+    }
+}
+
 /// 500 response returned when `default_profile` isn't in the `profiles` map.
 /// Fail-closed: a rate-limit plugin that silently allows traffic on misconfig
 /// is worse than one that errors loudly — operators catch the typo in CI /
@@ -313,25 +351,39 @@ fn misconfig_response(default_profile: &str) -> Response {
 }
 
 // ---------------------------------------------------------------------------
+// Token counting
+// ---------------------------------------------------------------------------
+
+/// Read a token-count context value. A present-but-unparseable value is charged
+/// as 0 (so it can't crash budgeting) but is logged, since silently dropping a
+/// real count would under-charge the budget.
+fn parse_token_count(key: &str) -> u32 {
+    match context_get(key) {
+        Some(raw) => raw.parse::<u32>().unwrap_or_else(|_| {
+            log_message(
+                1,
+                &format!("ai-token-limit: context '{key}' is not a u32; charging 0"),
+            );
+            0
+        }),
+        None => 0,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Partition-key extraction
 // ---------------------------------------------------------------------------
 
-fn extract_partition(req: &Request, source: &str) -> String {
+fn extract_partition(req: &Request, source: &str, trusted_proxies: &[String]) -> String {
     if source == "client_ip" {
-        if let Some(v) = req
-            .headers
-            .get("x-forwarded-for")
-            .and_then(|v| v.split(',').next().map(|s| s.trim().to_string()))
-        {
-            return v;
-        }
-        if let Some(v) = req.headers.get("x-real-ip") {
-            return v.clone();
-        }
-        if !req.client_ip.is_empty() {
-            return req.client_ip.clone();
-        }
-        return "unknown".to_string();
+        // Trusted-proxy-aware: forwarded headers honored only behind a trusted
+        // proxy, otherwise the observed peer is used (no XFF-rotation evasion).
+        let ip = resolve_client_ip(req, trusted_proxies);
+        return if ip.is_empty() {
+            "unknown".to_string()
+        } else {
+            ip
+        };
     }
 
     if let Some(header_name) = source.strip_prefix("header:") {
@@ -570,6 +622,8 @@ mod tests {
                 .collect(),
             policy_name: "ai-tokens".into(),
             partition_key: partition_key.into(),
+            trusted_proxies: vec![],
+            fail_open: false,
             count,
         }
     }
@@ -703,10 +757,23 @@ mod tests {
     }
 
     #[test]
-    fn on_request_fails_open_when_limiter_unavailable() {
+    fn on_request_fails_closed_when_limiter_unavailable() {
         mock_host::reset();
         mock_host::set_rate_limiter_unavailable();
         let mut p = simple(100, 60);
+        // PL-4: default is fail CLOSED — a limiter outage rejects with 503.
+        match p.on_request(make_request()) {
+            Action::ShortCircuit(resp) => assert_eq!(resp.status, 503),
+            _ => panic!("expected 503 fail-closed"),
+        }
+    }
+
+    #[test]
+    fn on_request_fail_open_opt_in_allows_when_limiter_unavailable() {
+        mock_host::reset();
+        mock_host::set_rate_limiter_unavailable();
+        let mut p = simple(100, 60);
+        p.fail_open = true;
         assert!(matches!(p.on_request(make_request()), Action::Continue(_)));
     }
 
@@ -1049,31 +1116,45 @@ mod tests {
     // =======================================================================
 
     #[test]
-    fn partition_from_client_ip_forwarded_for() {
+    fn partition_from_client_ip_ignores_spoofed_forwarded_for() {
+        // PL-4: without a trusted proxy, a spoofed XFF is ignored; the real peer
+        // is used so a client can't rotate XFF to dodge its budget.
         let mut req = make_request();
         req.headers
             .insert("x-forwarded-for".into(), "1.2.3.4, 5.6.7.8".into());
-        assert_eq!(extract_partition(&req, "client_ip"), "1.2.3.4");
+        assert_eq!(extract_partition(&req, "client_ip", &[]), "127.0.0.1");
     }
 
     #[test]
-    fn partition_from_client_ip_real_ip() {
+    fn partition_from_client_ip_honors_xff_behind_trusted_proxy() {
+        let mut req = make_request();
+        req.client_ip = "10.9.9.9".into();
+        req.headers
+            .insert("x-forwarded-for".into(), "1.2.3.4".into());
+        assert_eq!(
+            extract_partition(&req, "client_ip", &["10.9.9.9".to_string()]),
+            "1.2.3.4"
+        );
+    }
+
+    #[test]
+    fn partition_from_client_ip_ignores_spoofed_real_ip() {
         let mut req = make_request();
         req.headers.insert("x-real-ip".into(), "9.9.9.9".into());
-        assert_eq!(extract_partition(&req, "client_ip"), "9.9.9.9");
+        assert_eq!(extract_partition(&req, "client_ip", &[]), "127.0.0.1");
     }
 
     #[test]
     fn partition_from_client_ip_fallback_field() {
         let req = make_request();
-        assert_eq!(extract_partition(&req, "client_ip"), "127.0.0.1");
+        assert_eq!(extract_partition(&req, "client_ip", &[]), "127.0.0.1");
     }
 
     #[test]
     fn partition_from_header() {
         let mut req = make_request();
         req.headers.insert("x-api-key".into(), "abc123".into());
-        assert_eq!(extract_partition(&req, "header:x-api-key"), "abc123");
+        assert_eq!(extract_partition(&req, "header:x-api-key", &[]), "abc123");
     }
 
     #[test]
@@ -1081,20 +1162,20 @@ mod tests {
         mock_host::reset();
         mock_host::set_context("auth.sub", "bob");
         let req = make_request();
-        assert_eq!(extract_partition(&req, "context:auth.sub"), "bob");
+        assert_eq!(extract_partition(&req, "context:auth.sub", &[]), "bob");
     }
 
     #[test]
     fn partition_literal() {
         let req = make_request();
-        assert_eq!(extract_partition(&req, "global"), "global");
+        assert_eq!(extract_partition(&req, "global", &[]), "global");
     }
 
     #[test]
     fn partition_context_missing_defaults_to_unknown() {
         mock_host::reset();
         let req = make_request();
-        assert_eq!(extract_partition(&req, "context:missing"), "unknown");
+        assert_eq!(extract_partition(&req, "context:missing", &[]), "unknown");
     }
 
     #[test]

--- a/plugins/cors/plugin.toml
+++ b/plugins/cors/plugin.toml
@@ -6,4 +6,4 @@ description = "CORS middleware for cross-origin resource sharing"
 wasm = "cors.wasm"
 
 [capabilities]
-host_functions = ["log"]
+host_functions = ["log", "context_get", "context_set"]

--- a/plugins/cors/src/lib.rs
+++ b/plugins/cors/src/lib.rs
@@ -61,6 +61,16 @@ impl Cors {
             }
         };
 
+        // A literal `*` with credentials is invalid per the Fetch spec; warn so
+        // the misconfiguration is visible (behavior already fails closed above).
+        if self.allow_credentials && self.allowed_origins.iter().any(|o| o == "*") {
+            log_message(
+                3,
+                "CORS: allowed_origins contains '*' with allow_credentials=true; \
+                 the wildcard is ignored. List explicit origins instead.",
+            );
+        }
+
         // Validate origin
         if !self.is_origin_allowed(&origin) {
             log_message(2, &format!("CORS: origin not allowed: {}", origin));
@@ -79,24 +89,27 @@ impl Cors {
             }
         }
 
-        // Regular CORS request - add origin to context for response handling
-        let mut modified_req = req;
-        modified_req
-            .headers
-            .insert("x-cors-origin".to_string(), origin);
-        Action::Continue(modified_req)
+        // Regular CORS request: stash the validated origin in request context so
+        // on_response can reflect it (the response itself carries no Origin).
+        context_set("cors.origin", &origin);
+        Action::Continue(req)
     }
 
     /// Add CORS headers to response.
     pub fn on_response(&mut self, mut resp: Response) -> Response {
-        // Check if we stored the origin during request processing
-        // In a real implementation, we'd use context storage
-        // For now, we add headers based on configuration
-
-        // The origin was validated in on_request, add CORS headers
-        if self.allowed_origins.contains(&"*".to_string()) && !self.allow_credentials {
+        if self.wildcard_active() {
+            // Non-credentialed wildcard: a constant `*` works without the origin.
             resp.headers
                 .insert("access-control-allow-origin".to_string(), "*".to_string());
+        } else if let Some(origin) = context_get("cors.origin") {
+            // Reflect the specific origin validated in on_request, and Vary on it
+            // so caches don't serve one origin's response to another.
+            resp.headers.insert(
+                "access-control-allow-origin".to_string(),
+                self.allow_origin_value(&origin),
+            );
+            resp.headers
+                .insert("vary".to_string(), "Origin".to_string());
         }
 
         // Expose headers if configured
@@ -118,21 +131,42 @@ impl Cors {
         resp
     }
 
+    /// Whether a literal `*` wildcard is in effect. Per the Fetch spec, `*` is
+    /// incompatible with credentials, so when `allow_credentials` is set the
+    /// wildcard is ignored entirely and only explicit origins may match.
+    fn wildcard_active(&self) -> bool {
+        !self.allow_credentials && self.allowed_origins.iter().any(|o| o == "*")
+    }
+
     /// Check if the origin is allowed.
     fn is_origin_allowed(&self, origin: &str) -> bool {
         if self.allowed_origins.is_empty() {
             return false;
         }
 
-        // Wildcard allows any origin (but not with credentials)
-        if self.allowed_origins.contains(&"*".to_string()) {
+        // `*` allows any origin, but never together with credentials.
+        if self.wildcard_active() {
             return true;
         }
 
-        // Check exact match
+        // Otherwise require an explicit exact or suffix-wildcard match. Note a
+        // bare "*" entry does NOT match here, so `["*"]` + credentials denies
+        // rather than reflecting an arbitrary origin with credentials.
         self.allowed_origins
             .iter()
+            .filter(|allowed| *allowed != "*")
             .any(|allowed| allowed == origin || self.matches_wildcard_origin(allowed, origin))
+    }
+
+    /// The value to emit in `Access-Control-Allow-Origin` for an already-validated
+    /// origin: `*` only in non-credentialed wildcard mode, otherwise the specific
+    /// origin echoed back (required when credentials are allowed).
+    fn allow_origin_value(&self, origin: &str) -> String {
+        if self.wildcard_active() {
+            "*".to_string()
+        } else {
+            origin.to_string()
+        }
     }
 
     /// Check if origin matches a wildcard pattern like "*.example.com".
@@ -216,15 +250,11 @@ impl Cors {
             return self.forbidden_response(origin);
         }
 
-        // Set origin header
-        if self.allowed_origins.contains(&"*".to_string()) && !self.allow_credentials {
-            headers.insert("access-control-allow-origin".to_string(), "*".to_string());
-        } else {
-            headers.insert(
-                "access-control-allow-origin".to_string(),
-                origin.to_string(),
-            );
-        }
+        // Set origin header (never `*` when credentials are allowed)
+        headers.insert(
+            "access-control-allow-origin".to_string(),
+            self.allow_origin_value(origin),
+        );
 
         // Allow methods
         headers.insert(
@@ -315,6 +345,79 @@ fn log_message(level: i32, msg: &str) {
 #[cfg(not(target_arch = "wasm32"))]
 fn log_message(_level: i32, _msg: &str) {
     // No-op for tests
+}
+
+/// Store a value in the request context (WASM).
+#[cfg(target_arch = "wasm32")]
+fn context_set(key: &str, value: &str) {
+    #[link(wasm_import_module = "barbacane")]
+    extern "C" {
+        fn host_context_set(key_ptr: i32, key_len: i32, val_ptr: i32, val_len: i32);
+    }
+    unsafe {
+        host_context_set(
+            key.as_ptr() as i32,
+            key.len() as i32,
+            value.as_ptr() as i32,
+            value.len() as i32,
+        );
+    }
+}
+
+/// Get a value from the request context (WASM).
+#[cfg(target_arch = "wasm32")]
+fn context_get(key: &str) -> Option<String> {
+    #[link(wasm_import_module = "barbacane")]
+    extern "C" {
+        fn host_context_get(key_ptr: i32, key_len: i32) -> i32;
+        fn host_context_read_result(buf_ptr: i32, buf_len: i32) -> i32;
+    }
+    unsafe {
+        let len = host_context_get(key.as_ptr() as i32, key.len() as i32);
+        if len <= 0 {
+            return None;
+        }
+        let mut buf = vec![0u8; len as usize];
+        let read_len = host_context_read_result(buf.as_mut_ptr() as i32, len);
+        if read_len != len {
+            return None;
+        }
+        String::from_utf8(buf).ok()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn context_set(key: &str, value: &str) {
+    mock_host::context_set(key, value)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn context_get(key: &str) -> Option<String> {
+    mock_host::context_get(key)
+}
+
+/// Native mock context for tests.
+#[cfg(not(target_arch = "wasm32"))]
+mod mock_host {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    thread_local! {
+        static CONTEXT: RefCell<HashMap<String, String>> = RefCell::new(HashMap::new());
+    }
+
+    pub fn context_set(key: &str, value: &str) {
+        CONTEXT.with(|c| c.borrow_mut().insert(key.to_string(), value.to_string()));
+    }
+
+    pub fn context_get(key: &str) -> Option<String> {
+        CONTEXT.with(|c| c.borrow().get(key).cloned())
+    }
+
+    #[cfg(test)]
+    pub fn reset() {
+        CONTEXT.with(|c| c.borrow_mut().clear());
+    }
 }
 
 #[cfg(test)]
@@ -524,19 +627,57 @@ mod tests {
 
     #[test]
     fn test_on_request_allowed_origin() {
+        mock_host::reset();
         let mut cors = create_test_cors(vec!["https://example.com".to_string()]);
         let req = create_request("GET", Some("https://example.com"));
 
         match cors.on_request(req) {
             Action::Continue(returned_req) => {
                 assert_eq!(returned_req.method, "GET");
+                // The validated origin is stashed in context for on_response.
                 assert_eq!(
-                    returned_req.headers.get("x-cors-origin"),
-                    Some(&"https://example.com".to_string())
+                    context_get("cors.origin"),
+                    Some("https://example.com".to_string())
                 );
             }
             Action::ShortCircuit(_) => panic!("Expected Continue, got ShortCircuit"),
         }
+    }
+
+    // PL-3 regression: `*` with credentials must NOT allow an arbitrary origin.
+    #[test]
+    fn wildcard_with_credentials_denies_arbitrary_origin() {
+        let mut cors = create_test_cors(vec!["*".to_string()]);
+        cors.allow_credentials = true;
+        assert!(!cors.is_origin_allowed("https://evil.com"));
+        match cors.on_request(create_request("GET", Some("https://evil.com"))) {
+            Action::ShortCircuit(r) => assert_eq!(r.status, 403),
+            Action::Continue(_) => panic!("wildcard+credentials must not allow arbitrary origins"),
+        }
+    }
+
+    // With credentials, an explicitly-listed origin is allowed and echoed back
+    // specifically (never `*`).
+    #[test]
+    fn credentials_echo_specific_origin_on_response() {
+        mock_host::reset();
+        let mut cors = create_test_cors(vec!["https://app.example.com".to_string()]);
+        cors.allow_credentials = true;
+        let _ = cors.on_request(create_request("GET", Some("https://app.example.com")));
+        let resp = cors.on_response(Response {
+            status: 200,
+            headers: BTreeMap::new(),
+            body: None,
+        });
+        assert_eq!(
+            resp.headers.get("access-control-allow-origin"),
+            Some(&"https://app.example.com".to_string())
+        );
+        assert_eq!(resp.headers.get("vary"), Some(&"Origin".to_string()));
+        assert_eq!(
+            resp.headers.get("access-control-allow-credentials"),
+            Some(&"true".to_string())
+        );
     }
 
     #[test]
@@ -547,7 +688,8 @@ mod tests {
         match cors.on_request(req) {
             Action::ShortCircuit(response) => {
                 assert_eq!(response.status, 403);
-                let body = String::from_utf8(response.body.expect("Response should have a body")).unwrap();
+                let body =
+                    String::from_utf8(response.body.expect("Response should have a body")).unwrap();
                 assert!(body.contains("https://evil.com"));
             }
             Action::Continue(_) => panic!("Expected ShortCircuit, got Continue"),
@@ -623,6 +765,7 @@ mod tests {
 
     #[test]
     fn test_on_response_wildcard_origin() {
+        mock_host::reset();
         let mut cors = create_test_cors(vec!["*".to_string()]);
         let response = Response {
             status: 200,
@@ -673,6 +816,7 @@ mod tests {
 
     #[test]
     fn test_on_response_wildcard_with_credentials_no_wildcard_header() {
+        mock_host::reset();
         let mut cors = create_test_cors(vec!["*".to_string()]);
         cors.allow_credentials = true;
         let response = Response {

--- a/plugins/http-upstream/src/lib.rs
+++ b/plugins/http-upstream/src/lib.rs
@@ -162,18 +162,19 @@ impl HttpUpstreamDispatcher {
             );
         }
 
-        let http_response: HttpResponse =
-            match serde_json::from_slice(&response_buf[..bytes_read as usize]) {
-                Ok(resp) => resp,
-                Err(e) => {
-                    return self.error_response(
-                        502,
-                        "Bad Gateway",
-                        "invalid upstream response",
-                        &e.to_string(),
-                    );
-                }
-            };
+        let http_response: HttpResponse = match serde_json::from_slice(
+            &response_buf[..(bytes_read as usize).min(response_buf.len())],
+        ) {
+            Ok(resp) => resp,
+            Err(e) => {
+                return self.error_response(
+                    502,
+                    "Bad Gateway",
+                    "invalid upstream response",
+                    &e.to_string(),
+                );
+            }
+        };
 
         // Read response body from side-channel.
         let response_body = barbacane_plugin_sdk::body::read_http_response_body();

--- a/plugins/ip-restriction/config-schema.json
+++ b/plugins/ip-restriction/config-schema.json
@@ -14,7 +14,13 @@
       "type": "array",
       "items": { "type": "string" },
       "default": [],
-      "description": "Denylist of IPs or CIDR ranges. These IPs are always blocked (takes precedence over allow)."
+      "description": "Denylist of IPs or CIDR ranges (IPv4 and IPv6). These IPs are always blocked (takes precedence over allow)."
+    },
+    "trusted_proxies": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Exact IPs of trusted reverse proxies. X-Forwarded-For / X-Real-IP are honored only when the immediate peer is one of these; otherwise forwarded headers are ignored so clients cannot spoof their address."
     },
     "message": {
       "type": "string",

--- a/plugins/ip-restriction/src/lib.rs
+++ b/plugins/ip-restriction/src/lib.rs
@@ -6,6 +6,7 @@
 use barbacane_plugin_sdk::prelude::*;
 use serde::Deserialize;
 use std::collections::BTreeMap;
+use std::net::IpAddr;
 
 /// IP restriction middleware configuration.
 #[barbacane_middleware]
@@ -20,6 +21,13 @@ pub struct IpRestriction {
     /// These IPs are blocked (denylist mode).
     #[serde(default)]
     deny: Vec<String>,
+
+    /// Exact IPs of trusted reverse proxies. `X-Forwarded-For` / `X-Real-IP` are
+    /// honored only when the immediate peer is one of these; otherwise the
+    /// observed peer IP is used. Empty (default) means forwarded headers are
+    /// never trusted, so a client cannot spoof its address.
+    #[serde(default)]
+    trusted_proxies: Vec<String>,
 
     /// Custom error message for denied requests.
     #[serde(default = "default_message")]
@@ -42,16 +50,28 @@ fn default_status() -> u16 {
 impl IpRestriction {
     /// Handle incoming request - check IP against allow/deny lists.
     pub fn on_request(&mut self, req: Request) -> Action<Request> {
-        let client_ip = self.extract_client_ip(&req);
+        let client_ip_str = resolve_client_ip(&req, &self.trusted_proxies);
+
+        // Parse the client IP (IPv4 or IPv6). If it can't be parsed we cannot
+        // evaluate the rules, so fail closed whenever any restriction exists.
+        let client_ip = match client_ip_str.parse::<IpAddr>() {
+            Ok(ip) => ip,
+            Err(_) => {
+                if self.allow.is_empty() && self.deny.is_empty() {
+                    return Action::Continue(req);
+                }
+                return Action::ShortCircuit(self.forbidden_response(&client_ip_str));
+            }
+        };
 
         // Check denylist first (takes precedence)
-        if self.is_ip_in_list(&client_ip, &self.deny) {
-            return Action::ShortCircuit(self.forbidden_response(&client_ip));
+        if self.is_ip_in_list(client_ip, &self.deny) {
+            return Action::ShortCircuit(self.forbidden_response(&client_ip_str));
         }
 
         // Check allowlist if configured
-        if !self.allow.is_empty() && !self.is_ip_in_list(&client_ip, &self.allow) {
-            return Action::ShortCircuit(self.forbidden_response(&client_ip));
+        if !self.allow.is_empty() && !self.is_ip_in_list(client_ip, &self.allow) {
+            return Action::ShortCircuit(self.forbidden_response(&client_ip_str));
         }
 
         Action::Continue(req)
@@ -62,50 +82,10 @@ impl IpRestriction {
         resp
     }
 
-    /// Extract client IP from request headers or connection.
-    fn extract_client_ip(&self, req: &Request) -> String {
-        // Check X-Forwarded-For header (first IP in chain)
-        if let Some(xff) = req.headers.get("x-forwarded-for") {
-            if let Some(first_ip) = xff.split(',').next() {
-                return first_ip.trim().to_string();
-            }
-        }
-
-        // Check X-Real-IP header
-        if let Some(real_ip) = req.headers.get("x-real-ip") {
-            return real_ip.clone();
-        }
-
-        // Fall back to direct client IP
-        req.client_ip.clone()
-    }
-
-    /// Check if an IP matches any entry in a list.
-    fn is_ip_in_list(&self, client_ip: &str, list: &[String]) -> bool {
-        let client_addr = match parse_ip(client_ip) {
-            Some(addr) => addr,
-            None => return false,
-        };
-
-        for entry in list {
-            if entry.contains('/') {
-                // CIDR notation
-                if let Some((network, prefix_len)) = parse_cidr(entry) {
-                    if ip_in_cidr(client_addr, network, prefix_len) {
-                        return true;
-                    }
-                }
-            } else {
-                // Single IP
-                if let Some(entry_addr) = parse_ip(entry) {
-                    if client_addr == entry_addr {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        false
+    /// Check if an IP matches any entry in a list (single IPs and CIDR ranges,
+    /// IPv4 and IPv6).
+    fn is_ip_in_list(&self, client_ip: IpAddr, list: &[String]) -> bool {
+        list.iter().any(|entry| ip_matches(client_ip, entry))
     }
 
     /// Generate 403 Forbidden response.
@@ -132,47 +112,58 @@ impl IpRestriction {
     }
 }
 
-/// Parse an IPv4 address into a u32.
-fn parse_ip(ip: &str) -> Option<u32> {
-    let parts: Vec<&str> = ip.trim().split('.').collect();
-    if parts.len() != 4 {
-        return None;
+/// Whether `client` matches a list entry: either a single IP (`10.0.0.5`,
+/// `2001:db8::1`) or a CIDR range (`10.0.0.0/8`, `2001:db8::/32`). IPv4 and IPv6
+/// are both supported; a family mismatch never matches.
+fn ip_matches(client: IpAddr, entry: &str) -> bool {
+    match entry.split_once('/') {
+        Some((network, prefix)) => match (
+            network.trim().parse::<IpAddr>(),
+            prefix.trim().parse::<u8>(),
+        ) {
+            (Ok(network), Ok(prefix)) => ip_in_cidr(client, network, prefix),
+            _ => false,
+        },
+        None => entry
+            .trim()
+            .parse::<IpAddr>()
+            .map(|e| e == client)
+            .unwrap_or(false),
     }
-
-    let mut addr: u32 = 0;
-    for (i, part) in parts.iter().enumerate() {
-        let octet: u8 = part.parse().ok()?;
-        addr |= (octet as u32) << (24 - i * 8);
-    }
-
-    Some(addr)
 }
 
-/// Parse a CIDR notation string into network address and prefix length.
-fn parse_cidr(cidr: &str) -> Option<(u32, u8)> {
-    let parts: Vec<&str> = cidr.split('/').collect();
-    if parts.len() != 2 {
-        return None;
+/// Check if an IP address is within a CIDR range (IPv4 or IPv6).
+fn ip_in_cidr(ip: IpAddr, network: IpAddr, prefix_len: u8) -> bool {
+    match (ip, network) {
+        (IpAddr::V4(ip), IpAddr::V4(net)) => {
+            bits_match(&ip.octets(), &net.octets(), prefix_len, 32)
+        }
+        (IpAddr::V6(ip), IpAddr::V6(net)) => {
+            bits_match(&ip.octets(), &net.octets(), prefix_len, 128)
+        }
+        // Mismatched families (e.g. IPv4 client vs IPv6 range) never match.
+        _ => false,
     }
-
-    let network = parse_ip(parts[0])?;
-    let prefix_len: u8 = parts[1].parse().ok()?;
-
-    if prefix_len > 32 {
-        return None;
-    }
-
-    Some((network, prefix_len))
 }
 
-/// Check if an IP address is within a CIDR range.
-fn ip_in_cidr(ip: u32, network: u32, prefix_len: u8) -> bool {
-    if prefix_len == 0 {
-        return true;
+/// Compare the first `prefix_len` bits of two address byte arrays.
+fn bits_match(a: &[u8], b: &[u8], prefix_len: u8, max_bits: u8) -> bool {
+    if prefix_len > max_bits {
+        return false;
     }
-
-    let mask = !0u32 << (32 - prefix_len);
-    (ip & mask) == (network & mask)
+    let mut remaining = prefix_len as usize;
+    for (x, y) in a.iter().zip(b.iter()) {
+        if remaining == 0 {
+            break;
+        }
+        let take = remaining.min(8);
+        let mask: u8 = if take == 8 { 0xFF } else { !0u8 << (8 - take) };
+        if (x & mask) != (y & mask) {
+            return false;
+        }
+        remaining -= take;
+    }
+    true
 }
 
 #[cfg(test)]
@@ -181,7 +172,7 @@ mod tests {
 
     fn test_plugin() -> IpRestriction {
         serde_json::from_value(serde_json::json!({
-            "allow": ["10.0.0.0/8", "192.168.1.100"],
+            "allow": ["10.0.0.0/8", "192.168.1.100", "2001:db8::/32"],
             "deny": ["10.0.0.5"]
         }))
         .unwrap()
@@ -199,191 +190,144 @@ mod tests {
         }
     }
 
-    fn request_with_forwarded(xff: &str) -> Request {
-        let mut headers = BTreeMap::new();
-        headers.insert("x-forwarded-for".to_string(), xff.to_string());
-        Request {
-            method: "GET".to_string(),
-            path: "/test".to_string(),
-            headers,
-            body: None,
-            query: None,
-            path_params: BTreeMap::new(),
-            client_ip: "0.0.0.0".to_string(),
-        }
-    }
-
-    // --- parse_ip ---
-
-    #[test]
-    fn test_parse_ip_valid() {
-        assert_eq!(parse_ip("192.168.1.1"), Some(0xC0A80101));
-        assert_eq!(parse_ip("10.0.0.1"), Some(0x0A000001));
-        assert_eq!(parse_ip("0.0.0.0"), Some(0));
-        assert_eq!(parse_ip("255.255.255.255"), Some(0xFFFFFFFF));
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
     }
 
     #[test]
-    fn test_parse_ip_invalid() {
-        assert_eq!(parse_ip("not-an-ip"), None);
-        assert_eq!(parse_ip("256.0.0.1"), None);
-        assert_eq!(parse_ip("1.2.3"), None);
-        assert_eq!(parse_ip(""), None);
-    }
-
-    // --- parse_cidr ---
-
-    #[test]
-    fn test_parse_cidr_valid() {
-        let (network, prefix) = parse_cidr("10.0.0.0/8").unwrap();
-        assert_eq!(network, 0x0A000000);
-        assert_eq!(prefix, 8);
+    fn matches_exact_ipv4_and_ipv6() {
+        assert!(ip_matches(ip("192.168.1.100"), "192.168.1.100"));
+        assert!(!ip_matches(ip("192.168.1.101"), "192.168.1.100"));
+        assert!(ip_matches(ip("2001:db8::1"), "2001:db8::1"));
+        assert!(!ip_matches(ip("2001:db8::2"), "2001:db8::1"));
     }
 
     #[test]
-    fn test_parse_cidr_host() {
-        let (_, prefix) = parse_cidr("192.168.1.1/32").unwrap();
-        assert_eq!(prefix, 32);
+    fn matches_cidr_ipv4_and_ipv6() {
+        assert!(ip_matches(ip("10.1.2.3"), "10.0.0.0/8"));
+        assert!(!ip_matches(ip("11.0.0.1"), "10.0.0.0/8"));
+        assert!(ip_matches(ip("192.168.1.50"), "192.168.1.0/24"));
+        assert!(!ip_matches(ip("192.168.2.50"), "192.168.1.0/24"));
+        assert!(ip_matches(ip("2001:db8::abcd"), "2001:db8::/32"));
+        assert!(!ip_matches(ip("2001:db9::1"), "2001:db8::/32"));
     }
 
     #[test]
-    fn test_parse_cidr_invalid_prefix() {
-        assert!(parse_cidr("10.0.0.0/33").is_none());
+    fn cidr_prefix_zero_matches_all() {
+        assert!(ip_matches(ip("1.2.3.4"), "0.0.0.0/0"));
     }
 
     #[test]
-    fn test_parse_cidr_invalid_format() {
-        assert!(parse_cidr("10.0.0.0").is_none());
-    }
-
-    // --- ip_in_cidr ---
-
-    #[test]
-    fn test_ip_in_cidr_matches() {
-        let ip = parse_ip("10.1.2.3").unwrap();
-        let net = parse_ip("10.0.0.0").unwrap();
-        assert!(ip_in_cidr(ip, net, 8));
+    fn family_mismatch_never_matches() {
+        assert!(!ip_matches(ip("10.0.0.1"), "2001:db8::/32"));
+        assert!(!ip_matches(ip("2001:db8::1"), "10.0.0.0/8"));
     }
 
     #[test]
-    fn test_ip_in_cidr_no_match() {
-        let ip = parse_ip("11.0.0.1").unwrap();
-        let net = parse_ip("10.0.0.0").unwrap();
-        assert!(!ip_in_cidr(ip, net, 8));
+    fn invalid_entry_never_matches() {
+        assert!(!ip_matches(ip("10.0.0.1"), "not-an-ip"));
+        assert!(!ip_matches(ip("10.0.0.1"), "10.0.0.0/99"));
     }
 
     #[test]
-    fn test_ip_in_cidr_prefix_zero_matches_all() {
-        let ip = parse_ip("1.2.3.4").unwrap();
-        assert!(ip_in_cidr(ip, 0, 0));
+    fn allowed_ip_continues() {
+        let mut p = test_plugin();
+        assert!(matches!(
+            p.on_request(request_with_ip("10.0.0.1")),
+            Action::Continue(_)
+        ));
     }
 
     #[test]
-    fn test_ip_in_cidr_slash_24() {
-        let ip = parse_ip("192.168.1.50").unwrap();
-        let net = parse_ip("192.168.1.0").unwrap();
-        assert!(ip_in_cidr(ip, net, 24));
-
-        let outside = parse_ip("192.168.2.50").unwrap();
-        assert!(!ip_in_cidr(outside, net, 24));
-    }
-
-    // --- extract_client_ip ---
-
-    #[test]
-    fn test_extract_client_ip_from_xff() {
-        let plugin = test_plugin();
-        let req = request_with_forwarded("10.0.0.1, 172.16.0.1");
-        assert_eq!(plugin.extract_client_ip(&req), "10.0.0.1");
-    }
-
-    #[test]
-    fn test_extract_client_ip_from_real_ip() {
-        let plugin = test_plugin();
-        let mut headers = BTreeMap::new();
-        headers.insert("x-real-ip".to_string(), "10.0.0.2".to_string());
-        let req = Request {
-            method: "GET".to_string(),
-            path: "/test".to_string(),
-            headers,
-            body: None,
-            query: None,
-            path_params: BTreeMap::new(),
-            client_ip: "0.0.0.0".to_string(),
-        };
-        assert_eq!(plugin.extract_client_ip(&req), "10.0.0.2");
-    }
-
-    #[test]
-    fn test_extract_client_ip_direct() {
-        let plugin = test_plugin();
-        let req = request_with_ip("172.16.0.5");
-        assert_eq!(plugin.extract_client_ip(&req), "172.16.0.5");
-    }
-
-    // --- is_ip_in_list ---
-
-    #[test]
-    fn test_is_ip_in_list_cidr_match() {
-        let plugin = test_plugin();
-        assert!(plugin.is_ip_in_list("10.1.2.3", &plugin.allow));
-    }
-
-    #[test]
-    fn test_is_ip_in_list_exact_match() {
-        let plugin = test_plugin();
-        assert!(plugin.is_ip_in_list("192.168.1.100", &plugin.allow));
-    }
-
-    #[test]
-    fn test_is_ip_in_list_no_match() {
-        let plugin = test_plugin();
-        assert!(!plugin.is_ip_in_list("172.16.0.1", &plugin.allow));
-    }
-
-    // --- on_request ---
-
-    #[test]
-    fn test_on_request_allowed_ip() {
-        let mut plugin = test_plugin();
-        let req = request_with_ip("10.0.0.1");
-        assert!(matches!(plugin.on_request(req), Action::Continue(_)));
-    }
-
-    #[test]
-    fn test_on_request_denied_ip_takes_precedence() {
-        let mut plugin = test_plugin();
-        let req = request_with_ip("10.0.0.5");
-        match plugin.on_request(req) {
+    fn denied_ip_takes_precedence() {
+        let mut p = test_plugin();
+        match p.on_request(request_with_ip("10.0.0.5")) {
             Action::ShortCircuit(r) => assert_eq!(r.status, 403),
             _ => panic!("expected ShortCircuit"),
         }
     }
 
     #[test]
-    fn test_on_request_not_in_allowlist() {
-        let mut plugin = test_plugin();
-        let req = request_with_ip("172.16.0.1");
-        match plugin.on_request(req) {
+    fn not_in_allowlist_denied() {
+        let mut p = test_plugin();
+        match p.on_request(request_with_ip("172.16.0.1")) {
             Action::ShortCircuit(r) => assert_eq!(r.status, 403),
             _ => panic!("expected ShortCircuit"),
         }
     }
 
     #[test]
-    fn test_on_request_empty_allow_deny() {
-        let mut plugin: IpRestriction =
-            serde_json::from_value(serde_json::json!({})).unwrap();
-        let req = request_with_ip("1.2.3.4");
-        assert!(matches!(plugin.on_request(req), Action::Continue(_)));
+    fn ipv6_client_in_allowlist_continues() {
+        let mut p = test_plugin();
+        assert!(matches!(
+            p.on_request(request_with_ip("2001:db8::5")),
+            Action::Continue(_)
+        ));
     }
 
-    // --- forbidden_response ---
+    // PL-2 regression: an IPv6 client must be evaluated against a denylist (the
+    // old IPv4-only parser silently let every IPv6 client through).
+    #[test]
+    fn ipv6_client_denylist_does_not_fail_open() {
+        let mut p: IpRestriction =
+            serde_json::from_value(serde_json::json!({ "deny": ["2001:db8::/32"] })).unwrap();
+        match p.on_request(request_with_ip("2001:db8::99")) {
+            Action::ShortCircuit(r) => assert_eq!(r.status, 403),
+            _ => panic!("IPv6 client must be denied, not fail open"),
+        }
+    }
 
     #[test]
-    fn test_forbidden_response_format() {
-        let plugin = test_plugin();
-        let resp = plugin.forbidden_response("10.0.0.5");
+    fn empty_allow_deny_continues() {
+        let mut p: IpRestriction = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(matches!(
+            p.on_request(request_with_ip("1.2.3.4")),
+            Action::Continue(_)
+        ));
+    }
+
+    // PL-2 regression: a spoofed X-Forwarded-For from an untrusted peer must not
+    // bypass the denylist.
+    #[test]
+    fn spoofed_xff_does_not_bypass_denylist() {
+        let mut p: IpRestriction =
+            serde_json::from_value(serde_json::json!({ "deny": ["203.0.113.7"] })).unwrap();
+        let mut req = request_with_ip("203.0.113.7");
+        req.headers
+            .insert("x-forwarded-for".to_string(), "10.0.0.1".to_string());
+        match p.on_request(req) {
+            Action::ShortCircuit(r) => assert_eq!(r.status, 403),
+            _ => panic!("spoofed XFF must not bypass the denylist"),
+        }
+    }
+
+    #[test]
+    fn xff_honored_behind_trusted_proxy() {
+        let mut p: IpRestriction = serde_json::from_value(serde_json::json!({
+            "allow": ["198.51.100.0/24"],
+            "trusted_proxies": ["203.0.113.7"]
+        }))
+        .unwrap();
+        let mut req = request_with_ip("203.0.113.7");
+        req.headers
+            .insert("x-forwarded-for".to_string(), "198.51.100.42".to_string());
+        assert!(matches!(p.on_request(req), Action::Continue(_)));
+    }
+
+    #[test]
+    fn unparseable_client_ip_fails_closed_when_restricted() {
+        let mut p: IpRestriction =
+            serde_json::from_value(serde_json::json!({ "deny": ["10.0.0.5"] })).unwrap();
+        match p.on_request(request_with_ip("garbage")) {
+            Action::ShortCircuit(r) => assert_eq!(r.status, 403),
+            _ => panic!("unparseable IP with restrictions must fail closed"),
+        }
+    }
+
+    #[test]
+    fn forbidden_response_format() {
+        let p = test_plugin();
+        let resp = p.forbidden_response("10.0.0.5");
         assert_eq!(resp.status, 403);
         let body: serde_json::Value = serde_json::from_slice(resp.body.as_ref().unwrap()).unwrap();
         assert_eq!(body["type"], "urn:barbacane:error:ip-restricted");
@@ -391,15 +335,12 @@ mod tests {
     }
 
     #[test]
-    fn test_custom_status_code() {
-        let mut plugin: IpRestriction = serde_json::from_value(serde_json::json!({
-            "deny": ["1.2.3.4"],
-            "status": 451,
-            "message": "Blocked by policy"
+    fn custom_status_code() {
+        let mut p: IpRestriction = serde_json::from_value(serde_json::json!({
+            "deny": ["1.2.3.4"], "status": 451, "message": "Blocked by policy"
         }))
         .unwrap();
-        let req = request_with_ip("1.2.3.4");
-        match plugin.on_request(req) {
+        match p.on_request(request_with_ip("1.2.3.4")) {
             Action::ShortCircuit(r) => {
                 assert_eq!(r.status, 451);
                 let body: serde_json::Value =
@@ -410,28 +351,24 @@ mod tests {
         }
     }
 
-    // --- config deserialization ---
-
     #[test]
-    fn test_config_defaults() {
-        let plugin: IpRestriction = serde_json::from_value(serde_json::json!({})).unwrap();
-        assert!(plugin.allow.is_empty());
-        assert!(plugin.deny.is_empty());
-        assert_eq!(plugin.message, "Access denied");
-        assert_eq!(plugin.status, 403);
+    fn config_defaults() {
+        let p: IpRestriction = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(p.allow.is_empty());
+        assert!(p.deny.is_empty());
+        assert!(p.trusted_proxies.is_empty());
+        assert_eq!(p.message, "Access denied");
+        assert_eq!(p.status, 403);
     }
 
-    // --- on_response passthrough ---
-
     #[test]
-    fn test_on_response_passthrough() {
-        let mut plugin = test_plugin();
+    fn on_response_passthrough() {
+        let mut p = test_plugin();
         let resp = Response {
             status: 200,
             headers: BTreeMap::new(),
             body: None,
         };
-        let result = plugin.on_response(resp);
-        assert_eq!(result.status, 200);
+        assert_eq!(p.on_response(resp).status, 200);
     }
 }

--- a/plugins/kafka/src/lib.rs
+++ b/plugins/kafka/src/lib.rs
@@ -129,13 +129,12 @@ impl KafkaDispatcher {
         }
 
         // Parse the publish result
-        let publish_result: PublishResult =
-            match serde_json::from_slice(&result_buf[..bytes_read as usize]) {
-                Ok(r) => r,
-                Err(e) => {
-                    return self.error_response(502, "invalid publish result", &e.to_string())
-                }
-            };
+        let publish_result: PublishResult = match serde_json::from_slice(
+            &result_buf[..(bytes_read as usize).min(result_buf.len())],
+        ) {
+            Ok(r) => r,
+            Err(e) => return self.error_response(502, "invalid publish result", &e.to_string()),
+        };
 
         if !publish_result.success {
             let detail = publish_result

--- a/plugins/lambda/src/lib.rs
+++ b/plugins/lambda/src/lib.rs
@@ -123,13 +123,14 @@ impl LambdaDispatcher {
         }
 
         // Parse the HTTP response
-        let http_response: HttpResponse =
-            match serde_json::from_slice(&response_buf[..bytes_read as usize]) {
-                Ok(resp) => resp,
-                Err(e) => {
-                    return self.error_response(502, "invalid Lambda response", &e.to_string());
-                }
-            };
+        let http_response: HttpResponse = match serde_json::from_slice(
+            &response_buf[..(bytes_read as usize).min(response_buf.len())],
+        ) {
+            Ok(resp) => resp,
+            Err(e) => {
+                return self.error_response(502, "invalid Lambda response", &e.to_string());
+            }
+        };
 
         // Read response body from side-channel.
         let response_body = read_http_response_body();

--- a/plugins/nats/src/lib.rs
+++ b/plugins/nats/src/lib.rs
@@ -111,13 +111,12 @@ impl NatsDispatcher {
         }
 
         // Parse the publish result
-        let publish_result: PublishResult =
-            match serde_json::from_slice(&result_buf[..bytes_read as usize]) {
-                Ok(r) => r,
-                Err(e) => {
-                    return self.error_response(502, "invalid publish result", &e.to_string())
-                }
-            };
+        let publish_result: PublishResult = match serde_json::from_slice(
+            &result_buf[..(bytes_read as usize).min(result_buf.len())],
+        ) {
+            Ok(r) => r,
+            Err(e) => return self.error_response(502, "invalid publish result", &e.to_string()),
+        };
 
         if !publish_result.success {
             let detail = publish_result

--- a/plugins/oauth2-auth/src/lib.rs
+++ b/plugins/oauth2-auth/src/lib.rs
@@ -303,9 +303,10 @@ impl OAuth2Auth {
 
         // Parse the HTTP response
         let http_response: HttpResponse =
-            serde_json::from_slice(&response_buf[..bytes_read as usize]).map_err(|e| {
-                OAuth2Error::IntrospectionFailed(format!("invalid response format: {}", e))
-            })?;
+            serde_json::from_slice(&response_buf[..(bytes_read as usize).min(response_buf.len())])
+                .map_err(|e| {
+                    OAuth2Error::IntrospectionFailed(format!("invalid response format: {}", e))
+                })?;
 
         // Check HTTP status
         if http_response.status != 200 {
@@ -902,7 +903,10 @@ mod tests {
         };
 
         // Simulate on_request header logic: sub takes precedence over username
-        let consumer = introspection.sub.as_ref().or(introspection.username.as_ref());
+        let consumer = introspection
+            .sub
+            .as_ref()
+            .or(introspection.username.as_ref());
         assert_eq!(consumer.unwrap(), "user-123");
     }
 
@@ -923,7 +927,10 @@ mod tests {
             jti: None,
         };
 
-        let consumer = introspection.sub.as_ref().or(introspection.username.as_ref());
+        let consumer = introspection
+            .sub
+            .as_ref()
+            .or(introspection.username.as_ref());
         assert_eq!(consumer.unwrap(), "alice");
     }
 

--- a/plugins/oidc-auth/src/lib.rs
+++ b/plugins/oidc-auth/src/lib.rs
@@ -764,7 +764,7 @@ impl OidcAuth {
         }
 
         let http_response: HttpResponse =
-            serde_json::from_slice(&response_buf[..bytes_read as usize])
+            serde_json::from_slice(&response_buf[..(bytes_read as usize).min(response_buf.len())])
                 .map_err(|e| format!("invalid response format: {}", e))?;
 
         let body = read_http_response_body();

--- a/plugins/rate-limit/config-schema.json
+++ b/plugins/rate-limit/config-schema.json
@@ -24,6 +24,17 @@
       "type": "string",
       "default": "client_ip",
       "description": "Partition key for rate limiting. Options: 'client_ip', 'header:<name>', 'context:<key>', or a static string"
+    },
+    "trusted_proxies": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Exact IPs of trusted reverse proxies. With partition_key 'client_ip', X-Forwarded-For / X-Real-IP are honored only behind these; otherwise the observed peer IP is used so clients cannot rotate XFF to evade limits."
+    },
+    "fail_open": {
+      "type": "boolean",
+      "default": false,
+      "description": "When the host rate limiter is unavailable, allow the request (fail open) instead of rejecting with 503. Defaults to false (fail closed)."
     }
   },
   "additionalProperties": false

--- a/plugins/rate-limit/src/lib.rs
+++ b/plugins/rate-limit/src/lib.rs
@@ -25,6 +25,18 @@ pub struct RateLimit {
     /// Options: "client_ip", "header:<name>", "context:<key>", or a static string.
     #[serde(default = "default_partition_key")]
     partition_key: String,
+
+    /// Exact IPs of trusted reverse proxies, used when `partition_key` is
+    /// "client_ip". Forwarded headers are honored only behind a trusted proxy;
+    /// otherwise a client cannot rotate `X-Forwarded-For` to dodge the limit.
+    #[serde(default)]
+    trusted_proxies: Vec<String>,
+
+    /// When the host rate limiter is unavailable, allow the request through
+    /// (fail open) instead of rejecting it. Defaults to false (fail closed), so
+    /// a limiter outage cannot silently disable rate limiting.
+    #[serde(default)]
+    fail_open: bool,
 }
 
 fn default_policy_name() -> String {
@@ -55,9 +67,21 @@ impl RateLimit {
         let result = match self.check_rate_limit(&key) {
             Some(r) => r,
             None => {
-                // Rate limiter unavailable - fail open (allow request)
-                log_message(1, "rate limiter unavailable, allowing request");
-                return Action::Continue(req);
+                // Rate limiter unavailable. Fail closed by default so an outage
+                // cannot silently disable rate limiting; operators may opt into
+                // fail-open.
+                if self.fail_open {
+                    log_message(
+                        1,
+                        "rate limiter unavailable, failing open (allowing request)",
+                    );
+                    return Action::Continue(req);
+                }
+                log_message(
+                    3,
+                    "rate limiter unavailable, failing closed (rejecting request)",
+                );
+                return Action::ShortCircuit(self.unavailable_response());
             }
         };
 
@@ -95,12 +119,10 @@ impl RateLimit {
     /// Extract the partition key from the request.
     fn extract_partition_key(&self, req: &Request) -> String {
         if self.partition_key == "client_ip" {
-            // Use client IP from x-forwarded-for or x-real-ip header
-            req.headers
-                .get("x-forwarded-for")
-                .and_then(|v| v.split(',').next().map(|s| s.trim().to_string()))
-                .or_else(|| req.headers.get("x-real-ip").cloned())
-                .unwrap_or_else(|| "unknown".to_string())
+            // Trusted-proxy-aware client IP: forwarded headers are honored only
+            // behind a configured trusted proxy, so the partition can't be
+            // spoofed to get a fresh bucket per request.
+            resolve_client_ip(req, &self.trusted_proxies)
         } else if let Some(header_name) = self.partition_key.strip_prefix("header:") {
             // Use specified header value
             req.headers
@@ -135,6 +157,27 @@ impl RateLimit {
 
         // Parse the JSON result
         serde_json::from_slice(&buf[..read_len as usize]).ok()
+    }
+
+    /// Generate a 503 response used when the limiter is unavailable and the
+    /// plugin is configured to fail closed.
+    fn unavailable_response(&self) -> Response {
+        let mut headers = BTreeMap::new();
+        headers.insert(
+            "content-type".to_string(),
+            "application/problem+json".to_string(),
+        );
+        let body = serde_json::json!({
+            "type": "urn:barbacane:error:rate-limiter-unavailable",
+            "title": "Service Unavailable",
+            "status": 503,
+            "detail": "Rate limiter is unavailable; request rejected (fail closed)."
+        });
+        Response {
+            status: 503,
+            headers,
+            body: Some(body.to_string().into_bytes()),
+        }
     }
 
     /// Generate 429 Too Many Requests response.
@@ -301,8 +344,36 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
+        // PL-4: without a trusted proxy a spoofed XFF is ignored; the real peer
+        // IP is used so a client can't rotate XFF to get fresh buckets.
+        assert_eq!(rate_limit.extract_partition_key(&req), "127.0.0.1");
+    }
+
+    #[test]
+    fn test_partition_key_xff_honored_behind_trusted_proxy() {
+        let mut headers = BTreeMap::new();
+        headers.insert("x-forwarded-for".to_string(), "192.168.1.1".to_string());
+        let req = Request {
+            method: "GET".to_string(),
+            path: "/test".to_string(),
+            headers,
+            body: None,
+            query: None,
+            path_params: BTreeMap::new(),
+            client_ip: "10.9.9.9".to_string(),
+        };
+        let rate_limit = RateLimit {
+            quota: 10,
+            window: 60,
+            policy_name: "default".to_string(),
+            partition_key: "client_ip".to_string(),
+            trusted_proxies: vec!["10.9.9.9".to_string()],
+            fail_open: false,
+        };
         assert_eq!(rate_limit.extract_partition_key(&req), "192.168.1.1");
     }
 
@@ -326,9 +397,12 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
-        assert_eq!(rate_limit.extract_partition_key(&req), "192.168.1.2");
+        // X-Real-IP from an untrusted peer is ignored too.
+        assert_eq!(rate_limit.extract_partition_key(&req), "127.0.0.1");
     }
 
     #[test]
@@ -348,9 +422,12 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
-        assert_eq!(rate_limit.extract_partition_key(&req), "unknown");
+        // No forwarded headers: the real peer IP is used (not "unknown").
+        assert_eq!(rate_limit.extract_partition_key(&req), "127.0.0.1");
     }
 
     #[test]
@@ -373,6 +450,8 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "header:x-custom".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         assert_eq!(rate_limit.extract_partition_key(&req), "custom-value");
@@ -398,6 +477,8 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "header:X-Custom".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         assert_eq!(rate_limit.extract_partition_key(&req), "custom-value");
@@ -420,6 +501,8 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "header:x-custom".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         assert_eq!(rate_limit.extract_partition_key(&req), "unknown");
@@ -442,6 +525,8 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "context:user_id".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         assert_eq!(rate_limit.extract_partition_key(&req), "user_id");
@@ -464,6 +549,8 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "global-limit".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         assert_eq!(rate_limit.extract_partition_key(&req), "global-limit");
@@ -476,6 +563,8 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         let result = RateLimitResult {
@@ -498,6 +587,8 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         let result = RateLimitResult {
@@ -532,6 +623,8 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         let result = RateLimitResult {
@@ -554,6 +647,8 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         let result = RateLimitResult {
@@ -630,6 +725,8 @@ mod tests {
             window: 60,
             policy_name: "test-policy".to_string(),
             partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         let req = Request {
@@ -682,6 +779,8 @@ mod tests {
             window: 60,
             policy_name: "test-policy".to_string(),
             partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         let req = Request {
@@ -719,6 +818,8 @@ mod tests {
             window: 60,
             policy_name: "test-policy".to_string(),
             partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         let req = Request {
@@ -733,13 +834,37 @@ mod tests {
 
         let action = rate_limit.on_request(req);
 
-        // Should fail open (allow request)
+        // PL-4: default is fail CLOSED — a limiter outage rejects with 503
+        // rather than silently disabling the limit.
         match action {
-            Action::Continue(modified_req) => {
-                // Should not have rate limit headers
-                assert!(!modified_req.headers.contains_key("x-ratelimit-policy"));
-            }
-            _ => panic!("Expected Action::Continue (fail open)"),
+            Action::ShortCircuit(resp) => assert_eq!(resp.status, 503),
+            _ => panic!("Expected Action::ShortCircuit (fail closed)"),
+        }
+    }
+
+    #[test]
+    fn test_on_request_rate_limiter_unavailable_fail_open_opt_in() {
+        mock_host::reset();
+        let mut rate_limit = RateLimit {
+            quota: 10,
+            window: 60,
+            policy_name: "test-policy".to_string(),
+            partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: true,
+        };
+        let req = Request {
+            method: "GET".to_string(),
+            path: "/test".to_string(),
+            headers: BTreeMap::new(),
+            body: None,
+            query: None,
+            path_params: BTreeMap::new(),
+            client_ip: "127.0.0.1".to_string(),
+        };
+        match rate_limit.on_request(req) {
+            Action::Continue(r) => assert!(!r.headers.contains_key("x-ratelimit-policy")),
+            _ => panic!("Expected Action::Continue when fail_open is set"),
         }
     }
 
@@ -750,6 +875,8 @@ mod tests {
             window: 60,
             policy_name: "default".to_string(),
             partition_key: "client_ip".to_string(),
+            trusted_proxies: vec![],
+            fail_open: false,
         };
 
         let mut headers = BTreeMap::new();

--- a/plugins/s3/src/lib.rs
+++ b/plugins/s3/src/lib.rs
@@ -278,9 +278,10 @@ impl S3Dispatcher {
         }
 
         let http_response: HttpResponse =
-            serde_json::from_slice(&response_buf[..bytes_read as usize]).map_err(|e| {
-                self.error_response(502, "Bad Gateway", "invalid S3 response", &e.to_string())
-            })?;
+            serde_json::from_slice(&response_buf[..(bytes_read as usize).min(response_buf.len())])
+                .map_err(|e| {
+                    self.error_response(502, "Bad Gateway", "invalid S3 response", &e.to_string())
+                })?;
 
         let response_body = read_http_response_body();
         Ok((http_response, response_body))

--- a/plugins/ws-upstream/src/lib.rs
+++ b/plugins/ws-upstream/src/lib.rs
@@ -147,7 +147,7 @@ impl WsUpstreamDispatcher {
         let bytes_read =
             unsafe { host_http_read_result(buf.as_mut_ptr() as i32, buf.len() as i32) };
         if bytes_read > 0 {
-            String::from_utf8_lossy(&buf[..bytes_read as usize]).to_string()
+            String::from_utf8_lossy(&buf[..(bytes_read as usize).min(buf.len())]).to_string()
         } else {
             "unknown error".to_string()
         }


### PR DESCRIPTION
Hardening of the plugin layer (security review item #7). Secure-by-default: controls that previously failed open now fail closed, with an explicit opt-out. All touched plugins build and pass their tests; the SDK + workspace pass the clippy gate.

## Fixes
- **SDK**: new `resolve_client_ip(req, trusted_proxies)` — one trusted-proxy-aware client-IP resolver shared by the security middlewares (kills the per-plugin spoofable variants).
- **ip-restriction**: IPv4 **and IPv6** (`std::net::IpAddr`) so an IPv6 client is no longer silently let past a denylist; `X-Forwarded-For`/`X-Real-IP` honored only behind configured `trusted_proxies`; fail closed on an unparseable client IP when restrictions exist.
- **cors**: a literal `*` with `allow_credentials` no longer allows an arbitrary origin (Fetch-spec violation); responses now reflect the validated origin with `Vary: Origin` (carried from `on_request` via context).
- **rate-limit / ai-token-limit**: **fail closed (503)** when the host limiter is unavailable by default (`fail_open: true` to opt out); partition by the trusted-proxy-aware client IP so rotating `X-Forwarded-For` can't mint fresh buckets; ai-token-limit logs (instead of silently charging 0) an unparseable token count.
- **ai-prompt-guard**: **fail closed** on an unparseable body or non-array `messages` (`fail_open: true` to opt out) so the guard can't be bypassed with a malformed body.
- **dispatchers** (kafka, nats, lambda, s3, http-upstream, oauth2-auth, oidc-auth, ws-upstream): clamp the host-returned read length to the buffer before slicing — removes a panic vector.
- **ai-proxy**: schema guidance to use secret references (`env://`/`file://`) for `api_key` (keys are not logged anywhere — verified).

## New config (all backward-compatible, secure defaults)
| Key | Plugins | Default |
|---|---|---|
| `trusted_proxies` | ip-restriction, rate-limit, ai-token-limit | `[]` (forwarded headers untrusted) |
| `fail_open` | rate-limit, ai-token-limit, ai-prompt-guard | `false` (fail closed) |

## Behavior changes (secure-by-default)
- Spoofed `X-Forwarded-For` is ignored unless the immediate peer is a configured trusted proxy.
- A rate/token limiter outage now rejects (503) instead of allowing traffic; set `fail_open: true` to keep the old behavior.
- ai-prompt-guard rejects (400) a body it can't inspect instead of passing it through.

Tracked privately as #7. Remaining auth/crypto items (constant-time compare, OIDC alg binding, etc.) are issue #6.