### PR TITLE
Security: auth/crypto hardening (constant-time, JWT/OIDC binding, SigV4, drop hand-rolled crypto)

### DIFF
--- a/crates/barbacane-plugin-sdk/src/types.rs
+++ b/crates/barbacane-plugin-sdk/src/types.rs
@@ -143,6 +143,23 @@ pub fn streamed_response() -> Response {
     }
 }
 
+/// Constant-time byte-slice equality, for comparing secrets (API keys,
+/// passwords) without leaking how many leading bytes matched through timing.
+///
+/// Like `subtle`/`ring::constant_time`, unequal lengths return `false` early
+/// (only the length is revealed, never the content); equal-length inputs are
+/// compared in time independent of where they differ.
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 /// Resolve the effective client IP, honoring trusted proxies.
 ///
 /// `req.client_ip` is the peer the gateway actually observed. The forwarded
@@ -524,6 +541,15 @@ mod tests {
             client_ip: peer.to_string(),
             path_params: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn constant_time_eq_matches_std_equality() {
+        assert!(constant_time_eq(b"secret-key", b"secret-key"));
+        assert!(!constant_time_eq(b"secret-key", b"secret-different"));
+        assert!(!constant_time_eq(b"secret-key", b"secret-keX"));
+        assert!(!constant_time_eq(b"short", b"longer-value"));
+        assert!(constant_time_eq(b"", b""));
     }
 
     #[test]

--- a/crates/barbacane-sigv4/src/lib.rs
+++ b/crates/barbacane-sigv4/src/lib.rs
@@ -142,7 +142,14 @@ pub fn canonical_query(query: Option<&str>) -> String {
                 Some(pos) => (&part[..pos], &part[pos + 1..]),
                 None => (part, ""),
             };
-            Some((percent_encode_query(key), percent_encode_query(value)))
+            // Decode any existing percent-encoding first, then re-encode per the
+            // SigV4 rules. This canonicalizes already-encoded input (e.g.
+            // `logs%2F` stays `logs%2F` instead of double-encoding to `logs%252F`)
+            // so the signed query equals what callers transmit.
+            Some((
+                percent_encode_query(&percent_decode(key)),
+                percent_encode_query(&percent_decode(value)),
+            ))
         })
         .collect();
 
@@ -155,16 +162,25 @@ pub fn canonical_query(query: Option<&str>) -> String {
         .join("&")
 }
 
+/// Canonicalize a header value per SigV4: trim, and collapse sequential
+/// internal whitespace to a single space (for non-quoted values).
+fn canonical_header_value(v: &str) -> String {
+    v.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 /// Compute the SigV4 `Authorization` header and related signed headers.
 ///
 /// # Panics
 /// Never panics — HMAC accepts any key length.
 pub fn sign(input: &SigningInput, creds: &Credentials, config: &SigningConfig) -> SignedHeaders {
     // BTreeMap guarantees keys are already sorted; keys must be lowercase.
+    // SigV4 requires header values to be trimmed AND have sequential internal
+    // whitespace collapsed to a single space; `v.trim()` alone diverges from
+    // AWS's recomputation for multi-space values.
     let canonical_headers_str: String = input
         .headers_to_sign
         .iter()
-        .map(|(k, v)| format!("{}:{}\n", k, v.trim()))
+        .map(|(k, v)| format!("{}:{}\n", k, canonical_header_value(v)))
         .collect();
 
     let signed_headers_str: String = input
@@ -232,6 +248,35 @@ fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
 
 /// Percent-encode a query string key or value (SigV4 rules).
 /// Encodes all bytes except unreserved characters (`A-Z a-z 0-9 - _ . ~`).
+/// Decode percent-escapes (`%XX`) in a query component. Invalid escapes are left
+/// as-is. `+` is treated literally (RFC 3986 query semantics), matching SigV4.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 3 <= bytes.len() {
+            if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                out.push((hi << 4) | lo);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn hex_val(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
 fn percent_encode_query(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     for byte in s.bytes() {
@@ -365,6 +410,26 @@ mod tests {
             canonical_query(Some("key=hello world")),
             "key=hello%20world"
         );
+    }
+
+    // CR-5: already-encoded input is decoded then re-encoded (not double-encoded),
+    // so the signed query matches what is transmitted.
+    #[test]
+    fn test_canonical_query_does_not_double_encode() {
+        assert_eq!(
+            canonical_query(Some("prefix=logs%2Fdir&list-type=2")),
+            "list-type=2&prefix=logs%2Fdir"
+        );
+        // Idempotent: canonicalizing twice yields the same result.
+        let once = canonical_query(Some("k=a%2Bb"));
+        assert_eq!(canonical_query(Some(&once)), once);
+    }
+
+    // CR-5: header values are trimmed AND internal whitespace is collapsed.
+    #[test]
+    fn test_canonical_header_value_collapses_whitespace() {
+        assert_eq!(canonical_header_value("  a   b\tc  "), "a b c");
+        assert_eq!(canonical_header_value("single"), "single");
     }
 
     #[test]

--- a/crates/barbacane-wasm/src/crypto.rs
+++ b/crates/barbacane-wasm/src/crypto.rs
@@ -4,6 +4,7 @@
 //! algorithms. Called by `host_verify_signature` to keep crypto in trusted
 //! host code rather than inside the WASM sandbox.
 
+use base64::Engine;
 use ring::signature;
 use serde::Deserialize;
 
@@ -75,14 +76,17 @@ fn verify_rsa(req: &VerifySignatureRequest, message: &[u8], sig: &[u8]) -> Resul
     let n_b64 = req.jwk.n.as_ref().ok_or("missing RSA modulus (n)")?;
     let e_b64 = req.jwk.e.as_ref().ok_or("missing RSA exponent (e)")?;
 
-    let n_bytes = base64url_decode(n_b64).map_err(|e| format!("invalid base64url in n: {}", e))?;
-    let e_bytes = base64url_decode(e_b64).map_err(|e| format!("invalid base64url in e: {}", e))?;
+    let n_bytes = decode_b64url(n_b64).map_err(|e| format!("invalid base64url in n: {}", e))?;
+    let e_bytes = decode_b64url(e_b64).map_err(|e| format!("invalid base64url in e: {}", e))?;
 
-    let der = build_rsa_der(&n_bytes, &e_bytes);
+    // Verify directly from the modulus/exponent via ring instead of hand-building
+    // a DER SubjectPublicKeyInfo.
+    let public_key = signature::RsaPublicKeyComponents {
+        n: n_bytes,
+        e: e_bytes,
+    };
 
-    let public_key = signature::UnparsedPublicKey::new(params, &der);
-
-    match public_key.verify(message, sig) {
+    match public_key.verify(params, message, sig) {
         Ok(()) => Ok(true),
         Err(_) => Ok(false),
     }
@@ -111,8 +115,8 @@ fn verify_ec(req: &VerifySignatureRequest, message: &[u8], sig: &[u8]) -> Result
     let x_b64 = req.jwk.x.as_ref().ok_or("missing EC x coordinate")?;
     let y_b64 = req.jwk.y.as_ref().ok_or("missing EC y coordinate")?;
 
-    let x_bytes = base64url_decode(x_b64).map_err(|e| format!("invalid base64url in x: {}", e))?;
-    let y_bytes = base64url_decode(y_b64).map_err(|e| format!("invalid base64url in y: {}", e))?;
+    let x_bytes = decode_b64url(x_b64).map_err(|e| format!("invalid base64url in x: {}", e))?;
+    let y_bytes = decode_b64url(y_b64).map_err(|e| format!("invalid base64url in y: {}", e))?;
 
     // Uncompressed EC point: 0x04 || x || y
     let mut point = Vec::with_capacity(1 + x_bytes.len() + y_bytes.len());
@@ -128,148 +132,14 @@ fn verify_ec(req: &VerifySignatureRequest, message: &[u8], sig: &[u8]) -> Result
     }
 }
 
-/// Build a DER-encoded RSAPublicKey from raw n and e bytes.
-///
-/// ASN.1 structure: SEQUENCE { INTEGER n, INTEGER e }
-fn build_rsa_der(n: &[u8], e: &[u8]) -> Vec<u8> {
-    let n_int = der_integer(n);
-    let e_int = der_integer(e);
-
-    let mut seq_content = Vec::with_capacity(n_int.len() + e_int.len());
-    seq_content.extend_from_slice(&n_int);
-    seq_content.extend_from_slice(&e_int);
-
-    let mut result = Vec::with_capacity(2 + seq_content.len());
-    result.push(0x30); // SEQUENCE tag
-    der_write_length(&mut result, seq_content.len());
-    result.extend_from_slice(&seq_content);
-
-    result
-}
-
-/// Encode a byte slice as a DER INTEGER.
-fn der_integer(value: &[u8]) -> Vec<u8> {
-    // Strip leading zeros but keep at least one byte
-    let stripped = match value.iter().position(|&b| b != 0) {
-        Some(pos) => &value[pos..],
-        None => &[0u8],
-    };
-
-    // If the high bit is set, prepend a 0x00 byte (positive integer)
-    let needs_padding = !stripped.is_empty() && (stripped[0] & 0x80) != 0;
-    let content_len = stripped.len() + if needs_padding { 1 } else { 0 };
-
-    let mut result = Vec::with_capacity(2 + content_len);
-    result.push(0x02); // INTEGER tag
-    der_write_length(&mut result, content_len);
-    if needs_padding {
-        result.push(0x00);
-    }
-    result.extend_from_slice(stripped);
-
-    result
-}
-
-/// Write a DER length encoding.
-fn der_write_length(buf: &mut Vec<u8>, len: usize) {
-    if len < 128 {
-        buf.push(len as u8);
-    } else if len < 256 {
-        buf.push(0x81);
-        buf.push(len as u8);
-    } else if len < 65536 {
-        buf.push(0x82);
-        buf.push((len >> 8) as u8);
-        buf.push(len as u8);
-    } else {
-        buf.push(0x83);
-        buf.push((len >> 16) as u8);
-        buf.push((len >> 8) as u8);
-        buf.push(len as u8);
-    }
-}
-
-/// Decode base64url (no padding) to bytes.
-fn base64url_decode(input: &str) -> Result<Vec<u8>, String> {
-    // base64url uses - instead of + and _ instead of /
-    let standard: String = input
-        .chars()
-        .map(|c| match c {
-            '-' => '+',
-            '_' => '/',
-            c => c,
-        })
-        .collect();
-
-    // Add padding if needed
-    let padded = match standard.len() % 4 {
-        2 => format!("{}==", standard),
-        3 => format!("{}=", standard),
-        0 => standard,
-        _ => return Err("invalid base64url length".to_string()),
-    };
-
-    // Use ring's base64 decoding is not available, so we decode manually
-    base64_standard_decode(&padded)
-}
-
-/// Simple standard base64 decoder.
-fn base64_standard_decode(input: &str) -> Result<Vec<u8>, String> {
-    const DECODE_TABLE: [u8; 128] = {
-        let mut table = [255u8; 128];
-        let mut i = 0u8;
-        while i < 26 {
-            table[(b'A' + i) as usize] = i;
-            table[(b'a' + i) as usize] = i + 26;
-            i += 1;
-        }
-        let mut d = 0u8;
-        while d < 10 {
-            table[(b'0' + d) as usize] = d + 52;
-            d += 1;
-        }
-        table[b'+' as usize] = 62;
-        table[b'/' as usize] = 63;
-        table
-    };
-
-    let bytes = input.as_bytes();
-    let mut result = Vec::with_capacity(bytes.len() * 3 / 4);
-
-    for chunk in bytes.chunks(4) {
-        if chunk.len() < 4 {
-            return Err("invalid base64 length".to_string());
-        }
-
-        let mut vals = [0u8; 4];
-        let mut padding = 0;
-
-        for (i, &b) in chunk.iter().enumerate() {
-            if b == b'=' {
-                vals[i] = 0;
-                padding += 1;
-            } else if b < 128 && DECODE_TABLE[b as usize] != 255 {
-                vals[i] = DECODE_TABLE[b as usize];
-            } else {
-                return Err(format!("invalid base64 character: {}", b as char));
-            }
-        }
-
-        let combined = ((vals[0] as u32) << 18)
-            | ((vals[1] as u32) << 12)
-            | ((vals[2] as u32) << 6)
-            | (vals[3] as u32);
-
-        result.push((combined >> 16) as u8);
-        if padding < 2 {
-            result.push((combined >> 8) as u8);
-        }
-        if padding < 1 {
-            result.push(combined as u8);
-        }
-    }
-
-    Ok(result)
+/// Decode a base64url string (padding optional) into bytes, rejecting invalid
+/// or non-canonical input. JWK members (`n`, `e`, `x`, `y`) are base64url per
+/// RFC 7517.
+fn decode_b64url(input: &str) -> Result<Vec<u8>, String> {
+    let trimmed = input.trim_end_matches('=');
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(trimmed)
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]
@@ -285,83 +155,49 @@ mod tests {
     const TEST_RSA_E: &str = "AQAB";
 
     #[test]
-    fn base64url_decode_simple() {
-        let result = base64url_decode("AQAB").unwrap();
-        assert_eq!(result, vec![0x01, 0x00, 0x01]); // RSA exponent 65537
+    fn decode_b64url_simple() {
+        assert_eq!(decode_b64url("AQAB").unwrap(), vec![0x01, 0x00, 0x01]); // 65537
     }
 
     #[test]
-    fn base64url_decode_with_url_chars() {
-        // base64url uses - and _ instead of + and /
-        let result = base64url_decode("a-b_cA").unwrap();
-        let result2 = base64_standard_decode("a+b/cA==").unwrap();
-        assert_eq!(result, result2);
-    }
-
-    #[test]
-    fn base64url_decode_empty() {
-        let result = base64url_decode("").unwrap();
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn base64url_decode_invalid_char() {
-        let result = base64url_decode("abc!");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn der_integer_simple() {
-        let result = der_integer(&[0x01, 0x00, 0x01]);
-        // Tag=0x02, Length=3, Value=010001
-        assert_eq!(result, vec![0x02, 0x03, 0x01, 0x00, 0x01]);
-    }
-
-    #[test]
-    fn der_integer_needs_padding() {
-        // High bit set — needs 0x00 prefix
-        let result = der_integer(&[0x80, 0x01]);
-        assert_eq!(result, vec![0x02, 0x03, 0x00, 0x80, 0x01]);
-    }
-
-    #[test]
-    fn der_integer_strips_leading_zeros() {
-        let result = der_integer(&[0x00, 0x00, 0x42]);
-        assert_eq!(result, vec![0x02, 0x01, 0x42]);
-    }
-
-    #[test]
-    fn der_integer_zero() {
-        let result = der_integer(&[0x00]);
-        assert_eq!(result, vec![0x02, 0x01, 0x00]);
-    }
-
-    #[test]
-    fn build_rsa_der_structure() {
-        let n = vec![0x01, 0x02, 0x03];
-        let e = vec![0x01, 0x00, 0x01];
-        let der = build_rsa_der(&n, &e);
-
-        // SEQUENCE tag
-        assert_eq!(der[0], 0x30);
-        // Should contain two INTEGER values
-        assert!(der.len() > 6);
-    }
-
-    #[test]
-    fn verify_rsa_key_parses() {
-        // Verify that the test RSA key can be used for verification
-        // (UnparsedPublicKey only validates the key when verify() is called)
-        let n_bytes = base64url_decode(TEST_RSA_N).unwrap();
-        let e_bytes = base64url_decode(TEST_RSA_E).unwrap();
-        let der = build_rsa_der(&n_bytes, &e_bytes);
-
-        // Should create a public key without panicking; actual validation
-        // happens at verify() time with ring's UnparsedPublicKey.
-        let _key = ring::signature::UnparsedPublicKey::new(
-            &ring::signature::RSA_PKCS1_2048_8192_SHA256,
-            &der,
+    fn decode_b64url_url_safe_chars() {
+        // base64url uses - and _ in place of + and /
+        assert_eq!(
+            decode_b64url("a-b_cA").unwrap(),
+            base64::engine::general_purpose::STANDARD
+                .decode("a+b/cA==")
+                .unwrap()
         );
+    }
+
+    #[test]
+    fn decode_b64url_empty() {
+        assert!(decode_b64url("").unwrap().is_empty());
+    }
+
+    #[test]
+    fn decode_b64url_invalid_char() {
+        assert!(decode_b64url("abc!").is_err());
+    }
+
+    #[test]
+    fn rsa_components_path_returns_false_on_bad_signature() {
+        // A real modulus/exponent with a bogus signature must verify to
+        // Ok(false), not Err — exercises the RsaPublicKeyComponents path.
+        let req = VerifySignatureRequest {
+            algorithm: "RS256".to_string(),
+            jwk: JwkPublicKey {
+                kty: "RSA".to_string(),
+                n: Some(TEST_RSA_N.to_string()),
+                e: Some(TEST_RSA_E.to_string()),
+                x: None,
+                y: None,
+                crv: None,
+            },
+            message: "header.payload".to_string(),
+            signature: vec![0u8; 256],
+        };
+        assert_eq!(verify_signature(&req), Ok(false));
     }
 
     #[test]

--- a/plugins/apikey-auth/src/lib.rs
+++ b/plugins/apikey-auth/src/lib.rs
@@ -179,11 +179,17 @@ impl ApiKeyAuth {
     }
 
     /// Look up the API key in the configured key store.
+    ///
+    /// Compares every entry in constant time and never early-returns, so request
+    /// timing reveals neither which key matched nor how many entries precede it.
     fn lookup_key(&self, key: &str) -> Result<&ApiKeyEntry, ApiKeyError> {
-        self.keys
-            .iter()
-            .find(|e| e.key == key)
-            .ok_or(ApiKeyError::InvalidKey)
+        let mut found: Option<&ApiKeyEntry> = None;
+        for entry in &self.keys {
+            if constant_time_eq(entry.key.as_bytes(), key.as_bytes()) {
+                found = Some(entry);
+            }
+        }
+        found.ok_or(ApiKeyError::InvalidKey)
     }
 
     /// Generate 401 Unauthorized response.
@@ -437,7 +443,11 @@ mod tests {
         match plugin.on_request(req) {
             Action::ShortCircuit(r) => {
                 assert_eq!(r.status, 401);
-                assert!(r.headers.get("www-authenticate").unwrap().contains("missing_key"));
+                assert!(r
+                    .headers
+                    .get("www-authenticate")
+                    .unwrap()
+                    .contains("missing_key"));
             }
             _ => panic!("expected ShortCircuit"),
         }
@@ -450,7 +460,11 @@ mod tests {
         match plugin.on_request(req) {
             Action::ShortCircuit(r) => {
                 assert_eq!(r.status, 401);
-                assert!(r.headers.get("www-authenticate").unwrap().contains("invalid_key"));
+                assert!(r
+                    .headers
+                    .get("www-authenticate")
+                    .unwrap()
+                    .contains("invalid_key"));
             }
             _ => panic!("expected ShortCircuit"),
         }

--- a/plugins/basic-auth/src/lib.rs
+++ b/plugins/basic-auth/src/lib.rs
@@ -130,14 +130,18 @@ impl BasicAuth {
         req: &Request,
     ) -> Result<(String, &CredentialEntry), BasicAuthError> {
         let (username, password) = self.extract_credentials(req)?;
-        let entry = self
-            .credentials
-            .iter()
-            .find(|e| e.username == username)
-            .ok_or(BasicAuthError::InvalidCredentials)?;
-        if entry.password != password {
-            return Err(BasicAuthError::InvalidCredentials);
+        // Compare username AND password for every entry in constant time without
+        // early-returning, so timing reveals neither valid usernames (no user
+        // enumeration) nor how many password bytes matched.
+        let mut matched: Option<&CredentialEntry> = None;
+        for e in &self.credentials {
+            let user_ok = constant_time_eq(e.username.as_bytes(), username.as_bytes());
+            let pass_ok = constant_time_eq(e.password.as_bytes(), password.as_bytes());
+            if user_ok && pass_ok {
+                matched = Some(e);
+            }
         }
+        let entry = matched.ok_or(BasicAuthError::InvalidCredentials)?;
         Ok((username, entry))
     }
 

--- a/plugins/jwt-auth/config-schema.json
+++ b/plugins/jwt-auth/config-schema.json
@@ -11,7 +11,7 @@
     },
     "audience": {
       "type": "string",
-      "description": "Expected audience (aud claim). If set, tokens must match."
+      "description": "Expected audience (aud claim). Strongly recommended: when unset, a token minted for any relying party at the same issuer is accepted (confused-deputy risk on shared IdPs). When set, tokens must match."
     },
     "clock_skew_seconds": {
       "type": "integer",

--- a/plugins/jwt-auth/src/lib.rs
+++ b/plugins/jwt-auth/src/lib.rs
@@ -397,8 +397,9 @@ impl JwtAuth {
 
         // SAFETY: passing a pointer/length into the host, which copies the bytes
         // out of guest memory before returning.
-        let result =
-            unsafe { host_verify_signature(request_json.as_ptr() as i32, request_json.len() as i32) };
+        let result = unsafe {
+            host_verify_signature(request_json.as_ptr() as i32, request_json.len() as i32)
+        };
         match result {
             1 => Ok(()),
             _ => Err(JwtError::SignatureInvalid),
@@ -431,12 +432,16 @@ impl JwtAuth {
             }
         }
 
-        // Validate audience (aud)
+        // Validate audience (aud). When unset, any token minted for any relying
+        // party at this issuer is accepted (confused-deputy risk on shared
+        // IdPs), so warn once to surface the gap.
         if let Some(expected_aud) = &self.audience {
             match &claims.aud {
                 Some(aud) if aud.contains(expected_aud) => {}
                 _ => return Err(JwtError::InvalidAudience),
             }
+        } else {
+            warn_once_no_audience();
         }
 
         Ok(())
@@ -484,6 +489,28 @@ extern "C" {
 unsafe fn host_verify_signature(_req_ptr: i32, _req_len: i32) -> i32 {
     -1
 }
+
+/// Warn (once) that no `audience` is configured, so tokens for any relying party
+/// at the issuer are accepted. Logged via host_log on the WASM target.
+#[cfg(target_arch = "wasm32")]
+fn warn_once_no_audience() {
+    use core::cell::Cell;
+    thread_local! { static WARNED: Cell<bool> = const { Cell::new(false) }; }
+    WARNED.with(|w| {
+        if !w.get() {
+            w.set(true);
+            #[link(wasm_import_module = "barbacane")]
+            extern "C" {
+                fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
+            }
+            let msg = "jwt-auth: no 'audience' configured; tokens for any audience at this issuer are accepted (confused-deputy risk). Set 'audience' for multi-RP IdPs.";
+            unsafe { host_log(1, msg.as_ptr() as i32, msg.len() as i32) };
+        }
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn warn_once_no_audience() {}
 
 /// Get current Unix timestamp (WASM version using host function).
 #[cfg(target_arch = "wasm32")]

--- a/plugins/oidc-auth/config-schema.json
+++ b/plugins/oidc-auth/config-schema.json
@@ -13,7 +13,7 @@
     },
     "audience": {
       "type": "string",
-      "description": "Expected audience (aud) claim. If set, tokens must match."
+      "description": "Expected audience (aud) claim. Strongly recommended: when unset, a token minted for any relying party at the same issuer is accepted (confused-deputy risk on shared IdPs). When set, tokens must match."
     },
     "required_scopes": {
       "type": "string",

--- a/plugins/oidc-auth/src/lib.rs
+++ b/plugins/oidc-auth/src/lib.rs
@@ -145,6 +145,38 @@ struct JwksDocument {
     keys: Vec<Jwk>,
 }
 
+/// Warn (once) that no `audience` is configured, so tokens for any relying party
+/// at the issuer are accepted (confused-deputy risk on shared IdPs).
+#[cfg(target_arch = "wasm32")]
+fn warn_once_no_audience() {
+    use core::cell::Cell;
+    thread_local! { static WARNED: Cell<bool> = const { Cell::new(false) }; }
+    WARNED.with(|w| {
+        if !w.get() {
+            w.set(true);
+            #[link(wasm_import_module = "barbacane")]
+            extern "C" {
+                fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
+            }
+            let msg = "oidc-auth: no 'audience' configured; tokens for any audience at this issuer are accepted (confused-deputy risk). Set 'audience' for multi-RP IdPs.";
+            unsafe { host_log(1, msg.as_ptr() as i32, msg.len() as i32) };
+        }
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn warn_once_no_audience() {}
+
+/// Whether a JWK may be used to verify a token with the given algorithm:
+/// the key type must match the algorithm family, the key's declared `alg` (if
+/// present) must equal the token's `alg` (RFC 8725), and the key's `use` (if
+/// present) must be `sig` (never an encryption key).
+fn key_is_compatible(key: &Jwk, expected_kty: &str, alg: &str) -> bool {
+    key.kty == expected_kty
+        && key.alg.as_deref().is_none_or(|a| a == alg)
+        && key.use_.as_deref().is_none_or(|u| u == "sig")
+}
+
 /// Partial OIDC discovery response.
 #[derive(Deserialize)]
 struct DiscoveryResponse {
@@ -384,8 +416,17 @@ impl OidcAuth {
         self.ensure_discovery()?;
         self.ensure_jwks()?;
 
-        // Find the matching key
-        let jwk = self.find_key(parsed.header.kid.as_deref(), &parsed.header.alg)?;
+        // Find the matching key. On a kid miss (likely provider key rotation),
+        // force one rate-limited JWKS refresh and retry before giving up.
+        let kid = parsed.header.kid.as_deref();
+        let jwk = match self.find_key(kid, &parsed.header.alg) {
+            Ok(jwk) => jwk,
+            Err(OidcError::KeyNotFound(_)) => {
+                self.refresh_jwks_on_miss()?;
+                self.find_key(kid, &parsed.header.alg)?
+            }
+            Err(e) => return Err(e),
+        };
 
         // Verify signature
         self.verify_token_signature(
@@ -490,9 +531,7 @@ impl OidcAuth {
             self.issuer_url.trim_end_matches('/')
         );
 
-        let (status, body) = self
-            .http_get(&url)
-            .map_err(|e| OidcError::DiscoveryFailed(e))?;
+        let (status, body) = self.http_get(&url).map_err(OidcError::DiscoveryFailed)?;
 
         if status != 200 {
             return Err(OidcError::DiscoveryFailed(format!("status {}", status)));
@@ -534,7 +573,7 @@ impl OidcAuth {
 
         let (status, body) = self
             .http_get(&jwks_uri)
-            .map_err(|e| OidcError::JwksFetchFailed(e))?;
+            .map_err(OidcError::JwksFetchFailed)?;
 
         if status != 200 {
             return Err(OidcError::JwksFetchFailed(format!("status {}", status)));
@@ -553,6 +592,21 @@ impl OidcAuth {
         Ok(())
     }
 
+    /// Refresh the JWKS once on a `kid` miss (provider key rotation), rate-limited
+    /// so a stream of unknown-`kid` tokens can't hammer the provider's JWKS URI.
+    fn refresh_jwks_on_miss(&mut self) -> Result<(), OidcError> {
+        const MIN_REFRESH_ON_MISS_SECS: u64 = 10;
+        let now = current_timestamp();
+        let refreshed_recently = self
+            .jwks_cache
+            .as_ref()
+            .is_some_and(|c| now.saturating_sub(c.fetched_at) < MIN_REFRESH_ON_MISS_SECS);
+        if refreshed_recently {
+            return Ok(());
+        }
+        self.refresh_jwks(now)
+    }
+
     /// Find a key in the JWKS by kid and algorithm compatibility.
     fn find_key(&self, kid: Option<&str>, alg: &str) -> Result<Jwk, OidcError> {
         let cache = self
@@ -566,29 +620,30 @@ impl OidcAuth {
             _ => return Err(OidcError::UnsupportedAlgorithm(alg.to_string())),
         };
 
-        // Try to match by kid first
+        // Try to match by kid first.
         if let Some(kid) = kid {
             for key in &cache.keys {
-                if key.kid.as_deref() == Some(kid) && key.kty == expected_kty {
-                    // Check use field if present (must be "sig")
-                    if key.use_.as_deref().is_none() || key.use_.as_deref() == Some("sig") {
-                        return Ok(key.clone());
-                    }
+                if key.kid.as_deref() == Some(kid) && key_is_compatible(key, expected_kty, alg) {
+                    return Ok(key.clone());
                 }
             }
             return Err(OidcError::KeyNotFound(kid.to_string()));
         }
 
-        // No kid — find first compatible key
-        for key in &cache.keys {
-            if key.kty == expected_kty {
-                if key.use_.as_deref().is_none() || key.use_.as_deref() == Some("sig") {
-                    return Ok(key.clone());
-                }
-            }
+        // No kid: only accept an *unambiguous* match. Picking the first of
+        // several compatible keys lets a token be verified against an unintended
+        // key after rotation (RFC 8725).
+        let mut candidates = cache
+            .keys
+            .iter()
+            .filter(|k| key_is_compatible(k, expected_kty, alg));
+        match (candidates.next(), candidates.next()) {
+            (Some(key), None) => Ok(key.clone()),
+            (Some(_), Some(_)) => Err(OidcError::KeyNotFound(
+                "ambiguous: multiple candidate keys and token has no kid".to_string(),
+            )),
+            _ => Err(OidcError::KeyNotFound("none".to_string())),
         }
-
-        Err(OidcError::KeyNotFound("none".to_string()))
     }
 
     /// Verify the JWT signature via host_verify_signature.
@@ -656,12 +711,16 @@ impl OidcAuth {
             }
         }
 
-        // Validate audience
+        // Validate audience. When unset, a token minted for any relying party at
+        // this issuer is accepted (confused-deputy risk on shared IdPs); warn
+        // once to surface the gap.
         if let Some(expected_aud) = &self.audience {
             match &claims.aud {
                 Some(aud) if aud.contains(expected_aud) => {}
                 _ => return Err(OidcError::InvalidAudience),
             }
+        } else {
+            warn_once_no_audience();
         }
 
         Ok(())
@@ -1514,6 +1573,43 @@ mod tests {
 
         let result = config.find_key(Some("nonexistent-kid"), "RS256");
         assert!(matches!(result, Err(OidcError::KeyNotFound(_))));
+    }
+
+    // CR-3: a key whose declared `alg` differs from the token's `alg` must not
+    // be selected, even when kty + kid would otherwise match.
+    #[test]
+    fn find_key_rejects_declared_alg_mismatch() {
+        let mut config = create_test_config();
+        let mut key = create_test_jwk_rsa(); // kid "test-key-1", alg RS256
+        key.alg = Some("RS512".to_string());
+        config.jwks_cache = Some(JwksCache {
+            keys: vec![key],
+            fetched_at: 1000,
+        });
+        // Token claims RS256 but the only key is declared for RS512 -> no match.
+        assert!(matches!(
+            config.find_key(Some("test-key-1"), "RS256"),
+            Err(OidcError::KeyNotFound(_))
+        ));
+    }
+
+    // CR-3: with no kid and more than one compatible key, selection is ambiguous
+    // and must fail rather than pick the first.
+    #[test]
+    fn find_key_no_kid_ambiguous_is_rejected() {
+        let mut config = create_test_config();
+        let mut k1 = create_test_jwk_rsa();
+        k1.kid = Some("a".to_string());
+        let mut k2 = create_test_jwk_rsa();
+        k2.kid = Some("b".to_string());
+        config.jwks_cache = Some(JwksCache {
+            keys: vec![k1, k2],
+            fetched_at: 1000,
+        });
+        assert!(matches!(
+            config.find_key(None, "RS256"),
+            Err(OidcError::KeyNotFound(_))
+        ));
     }
 
     // --- Discovery URL test ---

--- a/plugins/s3/src/lib.rs
+++ b/plugins/s3/src/lib.rs
@@ -161,10 +161,15 @@ impl S3Dispatcher {
             (host, path.clone(), format!("{}{}", base, path))
         };
 
-        // Append query string to final URL
-        let full_url = match query {
-            Some(qs) if !qs.is_empty() => format!("{}?{}", base_url, qs),
-            _ => base_url,
+        // Canonicalize the query ONCE and use the same form for both signing and
+        // the outbound URL ("sign exactly what you send"). Sending the raw query
+        // while signing the canonical form breaks the signature whenever the
+        // incoming query is already percent-encoded.
+        let canonical_query_str = sigv4::canonical_query(query);
+        let full_url = if canonical_query_str.is_empty() {
+            base_url
+        } else {
+            format!("{}?{}", base_url, canonical_query_str)
         };
 
         // ── Build headers to sign ──────────────────────────────────────────
@@ -188,7 +193,6 @@ impl S3Dispatcher {
             service: "s3",
         };
         let canonical_uri_str = sigv4::canonical_uri(&s3_path);
-        let canonical_query_str = sigv4::canonical_query(query);
         let signing_input = sigv4::SigningInput {
             method,
             canonical_uri: &canonical_uri_str,
@@ -621,7 +625,8 @@ mod tests {
 
     #[test]
     fn test_no_fallback_query_preserved_in_s3_request() {
-        // Without fallback_key, query params must be forwarded to S3.
+        // Without fallback_key, query params must be forwarded to S3 — now in
+        // canonical (sorted, single-encoded) form, matching what is signed.
         let d = make_dispatcher(Some("bucket"), None);
         let req = d.build_s3_request(
             "bucket",
@@ -633,8 +638,8 @@ mod tests {
             TEST_TS,
         );
         assert!(
-            req.url.contains("?list-type=2&delimiter=%2F"),
-            "without fallback_key, query must be forwarded: {}",
+            req.url.contains("?delimiter=%2F&list-type=2"),
+            "query must be forwarded in canonical form: {}",
             req.url
         );
     }


### PR DESCRIPTION
Hardening of the authentication + cryptography paths (security review item #6). All touched crates/plugins build, pass tests, and pass `clippy -D warnings`; the AWS SigV4 test vectors still pass.

## Fixes
- **SDK**: `constant_time_eq` helper for secret comparison.
- **apikey-auth / basic-auth (CR-2)**: compare secrets in constant time and iterate **all** entries without early-return — request timing no longer reveals which key matched, how many precede it, or (basic-auth) which usernames exist.
- **oidc-auth (CR-3)**: bind the selected JWK to the token — the key's declared `alg`/`use` must match (RFC 8725); a no-`kid` token with multiple candidate keys is rejected as ambiguous instead of picking the first; on a `kid` miss the JWKS is refreshed **once, rate-limited** (handles provider key rotation without hammering the JWKS URI).
- **jwt-auth / oidc-auth (CR-4)**: warn once when no `audience` is configured (confused-deputy risk on shared IdPs); schema descriptions now flag it.
- **barbacane-sigv4 (CR-5)**: canonical header values collapse internal whitespace (not just trim); query components are decoded-then-re-encoded so an already-encoded query isn't double-encoded — and s3 now transmits the same canonical query it signs ("sign == send"), fixing 403s on encoded query strings.
- **barbacane-wasm/crypto (CR-6)**: verify RSA via ring's `RsaPublicKeyComponents` (removes the hand-rolled DER builder and its ≥2²⁴ length-truncation bug); decode base64url via the `base64` crate (rejects non-canonical input). All hand-rolled DER/base64 helpers deleted.

## Behavior notes
- No config breakage. New behavior: ambiguous keyless JWKS selection is rejected; encoded query strings to S3 are normalized to canonical form; a missing `audience` logs a one-time warning.

Tracked privately as #6. Remaining areas: WASM sandbox limits (#3/#4), data-plane DoS (#2), control-plane (#8), data-plane misc (#9).