### PR TITLE
security(wasm): bound sandbox resources, remove host panic/DoS vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security**: WASM plugin capability enforcement — plugins may only import host functions covered by the capabilities declared in `plugin.toml`.
 - **security**: `jwt-auth` performs real signature verification via the host `verify_signature` capability (inline JWK).
 - **security**: a security testing framework — adversarial integration suite (`crates/barbacane-test/tests/security/`) and `cargo-fuzz` targets (`fuzz/`).
+- **security**: WASM sandbox resource limits — buffered plugin HTTP responses are capped (`BARBACANE_MAX_UPSTREAM_RESPONSE_BYTES`, default 16 MiB); the host cache and rate limiter bound their entry/partition counts and clamp plugin-supplied TTL/window/quota; a wall-clock epoch deadline backstops fuel-based CPU limiting.
 - **docs**: [Configuration & environment variables](reference/configuration.md) reference.
 
 ### Changed (breaking, secure-by-default)
@@ -22,12 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The control plane refuses to start without `BARBACANE_CONTROL_ADMIN_TOKEN`, and all API routes (except `/health` and the data-plane WebSocket) require the bearer token.
 - `file://` secret references require `BARBACANE_SECRETS_DIR` and are confined to it.
 - MCP requires a valid session for non-`initialize` requests.
-- Plugin HTTP egress to internal/metadata addresses is blocked by default.
+- Plugin egress to internal/metadata addresses is blocked by default — this now covers Kafka/NATS broker connections in addition to plugin HTTP calls.
 
 ### Fixed
 
 - **security**: fail-open middleware short-circuit downgrade in the WASM chain.
 - **security**: panic on hostile `x-request-id` / `traceparent`; unbounded Prometheus path-label cardinality on unmatched routes.
+- **security**: panic vectors in WASM host functions — guest-controlled pointer/length slice reads now use saturating arithmetic, and cache/rate-limiter time arithmetic is overflow/underflow-safe.
 - **deps**: bump `anyhow` to 1.0.103 (RUSTSEC-2026-0190).
 
 ## [0.7.0] - 2026-05-05

--- a/crates/barbacane-wasm/src/broker.rs
+++ b/crates/barbacane-wasm/src/broker.rs
@@ -24,6 +24,48 @@ pub enum BrokerError {
 
     #[error("timeout")]
     Timeout,
+
+    #[error("broker target blocked by SSRF policy: {0}")]
+    Blocked(String),
+}
+
+/// Split a broker address into its host and port, stripping any `scheme://`
+/// prefix and IPv6 brackets. Used to feed the SSRF guard. Falls back to
+/// `default_port` when no port is present.
+pub(crate) fn split_host_port(addr: &str, default_port: u16) -> (String, u16) {
+    // Drop a leading scheme such as `nats://` or `tls://`.
+    let addr = addr
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(addr)
+        .trim();
+    // Drop any path/query that may follow the authority.
+    let authority = addr
+        .split(['/', '?'])
+        .next()
+        .unwrap_or(addr)
+        .trim_end_matches('.');
+
+    // Bracketed IPv6: [::1]:4222 or [::1]
+    if let Some(rest) = authority.strip_prefix('[') {
+        if let Some((host, after)) = rest.split_once(']') {
+            let port = after
+                .strip_prefix(':')
+                .and_then(|p| p.parse::<u16>().ok())
+                .unwrap_or(default_port);
+            return (host.to_string(), port);
+        }
+    }
+
+    // host:port — but only treat the last colon as a port separator when what
+    // follows parses as a port (avoids mangling a bare unbracketed IPv6).
+    if let Some((host, port_str)) = authority.rsplit_once(':') {
+        if let Ok(port) = port_str.parse::<u16>() {
+            return (host.to_string(), port);
+        }
+    }
+
+    (authority.to_string(), default_port)
 }
 
 /// A message to publish to a broker.
@@ -213,6 +255,30 @@ mod tests {
 
         assert_eq!(deserialized.partition, Some(3));
         assert_eq!(deserialized.offset, Some(42));
+    }
+
+    #[test]
+    fn split_host_port_variants() {
+        assert_eq!(split_host_port("kafka:9092", 9092), ("kafka".into(), 9092));
+        assert_eq!(
+            split_host_port("nats://example.com:4222", 4222),
+            ("example.com".into(), 4222)
+        );
+        assert_eq!(
+            split_host_port("broker.internal", 9092),
+            ("broker.internal".into(), 9092)
+        );
+        assert_eq!(split_host_port("[::1]:4222", 4222), ("::1".into(), 4222));
+        assert_eq!(split_host_port("[fe80::1]", 4222), ("fe80::1".into(), 4222));
+        assert_eq!(
+            split_host_port("tls://10.0.0.1:9093/path", 9092),
+            ("10.0.0.1".into(), 9093)
+        );
+        // Bare IPv6 without brackets: no colon is treated as a port.
+        assert_eq!(
+            split_host_port("169.254.169.254:9092", 9092),
+            ("169.254.169.254".into(), 9092)
+        );
     }
 
     #[test]

--- a/crates/barbacane-wasm/src/cache.rs
+++ b/crates/barbacane-wasm/src/cache.rs
@@ -8,6 +8,16 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+/// Upper bound on an entry's TTL. The TTL is plugin-controlled, so it is clamped
+/// before being fed into `Instant + Duration` arithmetic to avoid an
+/// overflow panic on an absurd value (1 year is well beyond any sane cache TTL).
+const MAX_TTL_SECS: u64 = 366 * 24 * 60 * 60;
+
+/// Upper bound on the number of cached entries. A plugin can write arbitrary
+/// keys, so the table is capped to bound host memory; inserts past the cap evict
+/// expired entries first, then the entry closest to expiry.
+const MAX_CACHE_ENTRIES: usize = 10_000;
+
 /// A cached response entry.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CacheEntry {
@@ -97,8 +107,8 @@ impl ResponseCache {
 
                 let mut entry = internal.entry.clone();
                 entry.metadata = Some(CacheMetadata {
-                    created_at: now_unix - internal.created_at.elapsed().as_secs(),
-                    expires_at: now_unix + ttl_remaining,
+                    created_at: now_unix.saturating_sub(internal.created_at.elapsed().as_secs()),
+                    expires_at: now_unix.saturating_add(ttl_remaining),
                     ttl_remaining,
                 });
 
@@ -119,7 +129,12 @@ impl ResponseCache {
     /// Set a cache entry with TTL.
     pub fn set(&self, key: &str, entry: CacheEntry, ttl_secs: u64) {
         let now = Instant::now();
-        let expires_at = now + Duration::from_secs(ttl_secs);
+        // Clamp the plugin-controlled TTL and use checked arithmetic so a huge
+        // value can't overflow-panic `Instant + Duration`.
+        let ttl_secs = ttl_secs.min(MAX_TTL_SECS);
+        let expires_at = now
+            .checked_add(Duration::from_secs(ttl_secs))
+            .unwrap_or(now);
 
         let internal = InternalEntry {
             entry,
@@ -129,6 +144,20 @@ impl ResponseCache {
         };
 
         let mut entries = self.entries.write();
+        if entries.len() >= MAX_CACHE_ENTRIES && !entries.contains_key(key) {
+            // Make room: drop expired entries first.
+            entries.retain(|_, v| v.expires_at > now);
+            // Still full of live entries? Evict the one closest to expiry.
+            if entries.len() >= MAX_CACHE_ENTRIES {
+                if let Some(victim) = entries
+                    .iter()
+                    .min_by_key(|(_, v)| v.expires_at)
+                    .map(|(k, _)| k.clone())
+                {
+                    entries.remove(&victim);
+                }
+            }
+        }
         entries.insert(key.to_string(), internal);
     }
 
@@ -219,6 +248,26 @@ mod tests {
         let cached = result.entry.unwrap();
         assert_eq!(cached.status, 200);
         assert_eq!(cached.body, Some(b"test body".to_vec()));
+    }
+
+    #[test]
+    fn cache_entry_count_is_bounded() {
+        let cache = ResponseCache::new();
+        let entry = CacheEntry {
+            status: 200,
+            headers: HashMap::new(),
+            body: None,
+            metadata: None,
+        };
+        // Write more distinct keys than the cap, all with a live TTL.
+        for i in 0..(MAX_CACHE_ENTRIES + 100) {
+            cache.set(&format!("key-{i}"), entry.clone(), 3600);
+        }
+        assert!(
+            cache.stats().total_entries <= MAX_CACHE_ENTRIES,
+            "cache grew past the cap: {}",
+            cache.stats().total_entries
+        );
     }
 
     #[test]

--- a/crates/barbacane-wasm/src/engine.rs
+++ b/crates/barbacane-wasm/src/engine.rs
@@ -3,10 +3,20 @@
 //! This module provides the core wasmtime engine with settings optimized
 //! for the Barbacane plugin runtime.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
 use wasmtime::{Config, Engine, Module, OptLevel};
 
 use crate::error::WasmError;
 use crate::limits::PluginLimits;
+
+/// Wall-clock granularity of the epoch ticker. The per-call epoch deadline is
+/// expressed as a count of these ticks, so it bounds the slack between a
+/// plugin's configured execution budget and when it is actually interrupted.
+pub(crate) const EPOCH_TICK: Duration = Duration::from_millis(1);
 
 /// A compiled WASM module ready for instantiation.
 #[derive(Clone)]
@@ -31,6 +41,19 @@ impl CompiledModule {
 pub struct WasmEngine {
     engine: Engine,
     limits: PluginLimits,
+    /// Signals the epoch ticker thread to stop on drop.
+    epoch_stop: Arc<AtomicBool>,
+    /// Handle to the background epoch ticker thread.
+    epoch_ticker: Option<JoinHandle<()>>,
+}
+
+impl Drop for WasmEngine {
+    fn drop(&mut self) {
+        self.epoch_stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.epoch_ticker.take() {
+            let _ = handle.join();
+        }
+    }
 }
 
 impl WasmEngine {
@@ -49,6 +72,13 @@ impl WasmEngine {
         // Enable fuel consumption for execution time limiting
         config.consume_fuel(true);
 
+        // Enable epoch interruption as a wall-clock backstop. Fuel bounds the
+        // number of instructions executed, but not wall-clock time (e.g. on a
+        // slow host, or if fuel is miscalibrated). A background thread ticks the
+        // engine epoch and each call sets a deadline, trapping a guest that runs
+        // past its time budget.
+        config.epoch_interruption(true);
+
         // Configure memory settings
         config.max_wasm_stack(limits.max_stack_bytes);
 
@@ -66,7 +96,29 @@ impl WasmEngine {
 
         let engine = Engine::new(&config).map_err(|e| WasmError::EngineCreation(e.to_string()))?;
 
-        Ok(Self { engine, limits })
+        // Spawn the epoch ticker: it increments the engine epoch every
+        // `EPOCH_TICK` so per-call epoch deadlines fire on a wall-clock basis.
+        let epoch_stop = Arc::new(AtomicBool::new(false));
+        let epoch_ticker = {
+            let engine = engine.clone();
+            let stop = Arc::clone(&epoch_stop);
+            std::thread::Builder::new()
+                .name("wasm-epoch-ticker".into())
+                .spawn(move || {
+                    while !stop.load(Ordering::Relaxed) {
+                        std::thread::sleep(EPOCH_TICK);
+                        engine.increment_epoch();
+                    }
+                })
+                .map_err(|e| WasmError::EngineCreation(e.to_string()))?
+        };
+
+        Ok(Self {
+            engine,
+            limits,
+            epoch_stop,
+            epoch_ticker: Some(epoch_ticker),
+        })
     }
 
     /// Get a reference to the underlying wasmtime engine.

--- a/crates/barbacane-wasm/src/http_client.rs
+++ b/crates/barbacane-wasm/src/http_client.rs
@@ -346,15 +346,12 @@ impl HttpClient {
                     })
                     .collect();
 
-                let body = response
-                    .bytes()
-                    .await
-                    .map_err(HttpClientError::ResponseReadError)?;
+                let body = self.read_body_capped(response).await?;
 
                 Ok(HttpResponse {
                     status,
                     headers,
-                    body: Some(body.to_vec()),
+                    body: Some(body),
                 })
             }
             Err(e) => {
@@ -370,6 +367,36 @@ impl HttpClient {
                 }
             }
         }
+    }
+
+    /// Read an upstream response body into memory, refusing to buffer more than
+    /// `max_response_bytes`. The upstream is plugin-chosen and untrusted, so a
+    /// `Content-Length` over the cap is rejected up front and the streamed body
+    /// is bounded chunk-by-chunk (covers chunked encoding with no length).
+    async fn read_body_capped(
+        &self,
+        mut response: reqwest::Response,
+    ) -> Result<Vec<u8>, HttpClientError> {
+        let limit = self.base_config.max_response_bytes;
+
+        if let Some(len) = response.content_length() {
+            if len > limit as u64 {
+                return Err(HttpClientError::ResponseTooLarge { limit });
+            }
+        }
+
+        let mut body = Vec::new();
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(HttpClientError::ResponseReadError)?
+        {
+            if body.len().saturating_add(chunk.len()) > limit {
+                return Err(HttpClientError::ResponseTooLarge { limit });
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok(body)
     }
 
     /// Configure circuit breaker for a host.
@@ -403,7 +430,7 @@ impl HttpClient {
 
 /// Whether an IP address points at an internal / non-routable / metadata range
 /// that an untrusted plugin must not be able to reach.
-fn ip_is_internal(ip: &IpAddr) -> bool {
+pub(crate) fn ip_is_internal(ip: &IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => {
             v4.is_loopback()
@@ -433,21 +460,32 @@ fn ip_is_internal(ip: &IpAddr) -> bool {
     }
 }
 
-/// Reject requests whose target resolves to an internal address. Hostnames are
-/// resolved and rejected if *any* resolved address is internal, defending
-/// against a public name that points at an internal IP.
+/// Outcome of an SSRF host check that distinguishes a policy rejection from a
+/// resolution failure so callers can map each to their own error type.
+pub(crate) enum HostGuardError {
+    /// The host resolves to an internal/non-routable/metadata address.
+    Blocked(String),
+    /// The host could not be resolved.
+    Resolve(String),
+}
+
+/// Reject a target whose host resolves to an internal address. `host` may be an
+/// IP literal (optionally bracketed for IPv6) or a name; `port` is used only for
+/// DNS resolution. A name is rejected if *any* resolved address is internal,
+/// defending against a public name that points at an internal IP.
 ///
-/// Note: a separate connect-time resolution still occurs inside reqwest, so a
+/// Note: a separate connect-time resolution still occurs inside the client, so a
 /// rebinding attacker could in theory return a different address; pinning the
 /// vetted IP via a custom resolver is tracked as follow-up hardening.
-async fn ssrf_guard(url: &reqwest::Url, allow_internal: bool) -> Result<(), HttpClientError> {
+pub(crate) async fn guard_external_host(
+    host: &str,
+    port: u16,
+    allow_internal: bool,
+) -> Result<(), HostGuardError> {
     if allow_internal {
         return Ok(());
     }
 
-    let host = url
-        .host_str()
-        .ok_or_else(|| HttpClientError::InvalidUrl("missing host".into()))?;
     let host_clean = host
         .strip_prefix('[')
         .and_then(|h| h.strip_suffix(']'))
@@ -455,28 +493,42 @@ async fn ssrf_guard(url: &reqwest::Url, allow_internal: bool) -> Result<(), Http
 
     if let Ok(ip) = host_clean.parse::<IpAddr>() {
         if ip_is_internal(&ip) {
-            return Err(HttpClientError::BlockedTarget(host.to_string()));
+            return Err(HostGuardError::Blocked(host.to_string()));
         }
         return Ok(());
     }
 
-    let port = url.port_or_known_default().unwrap_or(0);
     let mut saw_any = false;
     let addrs = tokio::net::lookup_host((host_clean, port))
         .await
-        .map_err(|e| HttpClientError::ConnectionFailed(e.to_string()))?;
+        .map_err(|e| HostGuardError::Resolve(e.to_string()))?;
     for addr in addrs {
         saw_any = true;
         if ip_is_internal(&addr.ip()) {
-            return Err(HttpClientError::BlockedTarget(host.to_string()));
+            return Err(HostGuardError::Blocked(host.to_string()));
         }
     }
     if !saw_any {
-        return Err(HttpClientError::ConnectionFailed(format!(
+        return Err(HostGuardError::Resolve(format!(
             "no DNS records for {host}"
         )));
     }
     Ok(())
+}
+
+/// SSRF guard for the HTTP client: reject requests whose target resolves to an
+/// internal address.
+async fn ssrf_guard(url: &reqwest::Url, allow_internal: bool) -> Result<(), HttpClientError> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| HttpClientError::InvalidUrl("missing host".into()))?;
+    let port = url.port_or_known_default().unwrap_or(0);
+    guard_external_host(host, port, allow_internal)
+        .await
+        .map_err(|e| match e {
+            HostGuardError::Blocked(h) => HttpClientError::BlockedTarget(h),
+            HostGuardError::Resolve(m) => HttpClientError::ConnectionFailed(m),
+        })
 }
 
 /// Configuration for the HTTP client.
@@ -496,6 +548,11 @@ pub struct HttpClientConfig {
     /// disabling the SSRF guard. Off by default; operators opt in for trusted
     /// internal upstreams.
     pub allow_internal_egress: bool,
+    /// Maximum size (bytes) of a buffered upstream response body. A
+    /// plugin-chosen upstream is untrusted, so the buffered `call` path caps the
+    /// body it will read into host memory to avoid an OOM. Streaming dispatchers
+    /// (`stream_raw`) are unaffected.
+    pub max_response_bytes: usize,
 }
 
 impl Default for HttpClientConfig {
@@ -507,6 +564,7 @@ impl Default for HttpClientConfig {
             default_timeout: Duration::from_secs(30),
             allow_plaintext: false,
             allow_internal_egress: false,
+            max_response_bytes: 16 * 1024 * 1024,
         }
     }
 }
@@ -597,6 +655,9 @@ pub enum HttpClientError {
 
     #[error("failed to read response: {0}")]
     ResponseReadError(#[source] reqwest::Error),
+
+    #[error("upstream response exceeds the {limit}-byte buffer limit")]
+    ResponseTooLarge { limit: usize },
 
     #[error("TLS configuration error: {0}")]
     TlsConfig(#[source] TlsConfigError),
@@ -953,6 +1014,81 @@ mod tests {
         assert_eq!(resp.status(), 200);
         let body = resp.text().await.expect("body");
         assert_eq!(body, "ok");
+    }
+
+    #[tokio::test]
+    async fn call_rejects_oversized_response_body() {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+
+        // Server returns a 10-byte body but advertises it; the client cap is 4.
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            let mut buf = [0u8; 1024];
+            let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await;
+            let response = "HTTP/1.1 200 OK\r\ncontent-length: 10\r\n\r\n0123456789";
+            let _ = socket.write_all(response.as_bytes()).await;
+            let _ = socket.shutdown().await;
+        });
+
+        let config = HttpClientConfig {
+            allow_plaintext: true,
+            allow_internal_egress: true,
+            max_response_bytes: 4,
+            ..Default::default()
+        };
+        let client = HttpClient::new(config).expect("client");
+        let req = HttpRequest {
+            method: "GET".into(),
+            url: format!("http://{addr}/"),
+            headers: Default::default(),
+            body: None,
+            timeout: None,
+        };
+        let err = client.call(req).await.unwrap_err();
+        assert!(
+            matches!(err, HttpClientError::ResponseTooLarge { limit: 4 }),
+            "expected ResponseTooLarge, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_allows_response_within_limit() {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            let mut buf = [0u8; 1024];
+            let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await;
+            let response = "HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok";
+            let _ = socket.write_all(response.as_bytes()).await;
+            let _ = socket.shutdown().await;
+        });
+
+        let config = HttpClientConfig {
+            allow_plaintext: true,
+            allow_internal_egress: true,
+            max_response_bytes: 1024,
+            ..Default::default()
+        };
+        let client = HttpClient::new(config).expect("client");
+        let req = HttpRequest {
+            method: "GET".into(),
+            url: format!("http://{addr}/"),
+            headers: Default::default(),
+            body: None,
+            timeout: None,
+        };
+        let resp = client.call(req).await.expect("call should succeed");
+        assert_eq!(resp.status, 200);
+        assert_eq!(resp.body.as_deref(), Some(b"ok".as_slice()));
     }
 
     #[test]

--- a/crates/barbacane-wasm/src/instance.rs
+++ b/crates/barbacane-wasm/src/instance.rs
@@ -492,6 +492,10 @@ impl PluginInstance {
             .set_fuel(limits.max_fuel)
             .map_err(|e| WasmError::Instantiation(format!("failed to set fuel: {}", e)))?;
 
+        // Wall-clock backstop: trap if the guest runs past its time budget. The
+        // deadline is expressed in epoch ticks (see EPOCH_TICK).
+        store.set_epoch_deadline(limits.max_execution_ms.max(1));
+
         // Enable resource limiting
         store.limiter(|state| state);
 
@@ -622,6 +626,9 @@ impl PluginInstance {
         if let Err(e) = self.store.set_fuel(self.limits.max_fuel) {
             tracing::warn!(error = %e, "failed to reset WASM fuel");
         }
+        // Reset the wall-clock deadline for this call.
+        self.store
+            .set_epoch_deadline(self.limits.max_execution_ms.max(1));
 
         // Call init
         let result = init_func
@@ -677,6 +684,15 @@ impl PluginInstance {
         if let Err(e) = self.store.set_fuel(fuel) {
             tracing::warn!(error = %e, "failed to reset WASM fuel");
         }
+        // Reset the wall-clock deadline, scaled by the same factor as fuel so a
+        // large payload's extra serialization work isn't spuriously trapped.
+        let fuel_ratio = (fuel / self.limits.max_fuel.max(1)).max(1);
+        let deadline = self
+            .limits
+            .max_execution_ms
+            .max(1)
+            .saturating_mul(fuel_ratio);
+        self.store.set_epoch_deadline(deadline);
 
         // Write data to memory (may call plugin's `alloc` export)
         let ptr = self.write_to_memory(data)?;
@@ -791,7 +807,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = ptr as usize;
-                let end = start + len as usize;
+                let end = start.saturating_add(len as usize);
                 let data = memory.data(&caller);
 
                 if end <= data.len() {
@@ -835,7 +851,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = ptr as usize;
-                let end = start + len as usize;
+                let end = start.saturating_add(len as usize);
                 let data = memory.data(&caller);
 
                 if end <= data.len() {
@@ -890,7 +906,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = ptr as usize;
-                let end = start + len as usize;
+                let end = start.saturating_add(len as usize);
                 let data = memory.data(&caller);
 
                 if end <= data.len() {
@@ -915,7 +931,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = msg_ptr as usize;
-                let end = start + msg_len as usize;
+                let end = start.saturating_add(msg_len as usize);
                 let data = memory.data(&caller);
 
                 if end <= data.len() {
@@ -945,7 +961,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = key_ptr as usize;
-                let end = start + key_len as usize;
+                let end = start.saturating_add(key_len as usize);
                 let data = memory.data(&caller);
 
                 if end > data.len() {
@@ -990,9 +1006,9 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let key_start = key_ptr as usize;
-                let key_end = key_start + key_len as usize;
+                let key_end = key_start.saturating_add(key_len as usize);
                 let val_start = val_ptr as usize;
-                let val_end = val_start + val_len as usize;
+                let val_end = val_start.saturating_add(val_len as usize);
 
                 // Read data first, then mutate
                 let data = memory.data(&caller);
@@ -1093,7 +1109,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = req_ptr as usize;
-                let end = start + req_len as usize;
+                let end = start.saturating_add(req_len as usize);
                 let data = memory.data(&caller);
 
                 if end > data.len() {
@@ -1250,7 +1266,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = req_ptr as usize;
-                let end = start + req_len as usize;
+                let end = start.saturating_add(req_len as usize);
                 let data = memory.data(&caller);
 
                 if end > data.len() {
@@ -1417,7 +1433,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = req_ptr as usize;
-                let end = start + req_len as usize;
+                let end = start.saturating_add(req_len as usize);
                 let data = memory.data(&caller);
 
                 if end > data.len() {
@@ -1462,7 +1478,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = req_ptr as usize;
-                let end = start + req_len as usize;
+                let end = start.saturating_add(req_len as usize);
                 let data = memory.data(&caller);
 
                 if end > data.len() {
@@ -1512,7 +1528,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = ref_ptr as usize;
-                let end = start + ref_len as usize;
+                let end = start.saturating_add(ref_len as usize);
                 let data = memory.data(&caller);
 
                 if end > data.len() {
@@ -1568,7 +1584,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = key_ptr as usize;
-                let end = start + key_len as usize;
+                let end = start.saturating_add(key_len as usize);
                 let data = memory.data(&caller);
 
                 if end > data.len() {
@@ -1628,7 +1644,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = key_ptr as usize;
-                let end = start + key_len as usize;
+                let end = start.saturating_add(key_len as usize);
                 let data = memory.data(&caller);
 
                 if end > data.len() {
@@ -1687,9 +1703,9 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let key_start = key_ptr as usize;
-                let key_end = key_start + key_len as usize;
+                let key_end = key_start.saturating_add(key_len as usize);
                 let entry_start = entry_ptr as usize;
-                let entry_end = entry_start + entry_len as usize;
+                let entry_end = entry_start.saturating_add(entry_len as usize);
                 let data = memory.data(&caller);
 
                 if key_end > data.len() || entry_end > data.len() {
@@ -1753,9 +1769,9 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
 
                 let data = memory.data(&caller);
                 let name_start = name_ptr as usize;
-                let name_end = name_start + name_len as usize;
+                let name_end = name_start.saturating_add(name_len as usize);
                 let labels_start = labels_ptr as usize;
-                let labels_end = labels_start + labels_len as usize;
+                let labels_end = labels_start.saturating_add(labels_len as usize);
 
                 if name_end > data.len() || labels_end > data.len() {
                     return;
@@ -1799,9 +1815,9 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
 
                 let data = memory.data(&caller);
                 let name_start = name_ptr as usize;
-                let name_end = name_start + name_len as usize;
+                let name_end = name_start.saturating_add(name_len as usize);
                 let labels_start = labels_ptr as usize;
-                let labels_end = labels_start + labels_len as usize;
+                let labels_end = labels_start.saturating_add(labels_len as usize);
 
                 if name_end > data.len() || labels_end > data.len() {
                     return;
@@ -1844,7 +1860,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
 
                 let data = memory.data(&caller);
                 let start = name_ptr as usize;
-                let end = start + name_len as usize;
+                let end = start.saturating_add(name_len as usize);
 
                 if end > data.len() {
                     return -1;
@@ -1894,9 +1910,9 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
 
                 let data = memory.data(&caller);
                 let key_start = key_ptr as usize;
-                let key_end = key_start + key_len as usize;
+                let key_end = key_start.saturating_add(key_len as usize);
                 let val_start = val_ptr as usize;
-                let val_end = val_start + val_len as usize;
+                let val_end = val_start.saturating_add(val_len as usize);
 
                 if key_end > data.len() || val_end > data.len() {
                     return;
@@ -1934,7 +1950,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = msg_ptr as usize;
-                let end = start + msg_len as usize;
+                let end = start.saturating_add(msg_len as usize);
                 let data = memory.data(&caller);
 
                 if end > data.len() {
@@ -2035,7 +2051,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                 };
 
                 let start = msg_ptr as usize;
-                let end = start + msg_len as usize;
+                let end = start.saturating_add(msg_len as usize);
                 let data = memory.data(&caller);
 
                 if end > data.len() {
@@ -2143,7 +2159,7 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                     None => return 1,
                 };
                 let start = buf_ptr as usize;
-                let end = start + buf_len as usize;
+                let end = start.saturating_add(buf_len as usize);
                 let data = memory.data_mut(&mut caller);
                 if end > data.len() {
                     return 1;
@@ -2401,8 +2417,9 @@ mod tests {
     #[test]
     fn plugin_state_with_all_options_sets_publishers() {
         let limits = PluginLimits::default();
-        let nats = Arc::new(crate::nats_client::NatsPublisher::new());
-        let kafka = Arc::new(crate::kafka_client::KafkaPublisher::new());
+        let nats = Arc::new(crate::nats_client::NatsPublisher::new(true).expect("nats publisher"));
+        let kafka =
+            Arc::new(crate::kafka_client::KafkaPublisher::new(true).expect("kafka publisher"));
         let state = PluginState::with_all_options(
             "test".into(),
             &limits,

--- a/crates/barbacane-wasm/src/kafka_client.rs
+++ b/crates/barbacane-wasm/src/kafka_client.rs
@@ -15,6 +15,16 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
+/// Default Kafka broker port, used when an address omits one.
+const DEFAULT_KAFKA_PORT: u16 = 9092;
+
+/// Upper bound on cached broker connections, so a plugin can't force unbounded
+/// connection growth by publishing to many distinct broker strings.
+const MAX_KAFKA_CONNECTIONS: usize = 256;
+
+/// Timeout for an individual produce operation.
+const PRODUCE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Kafka publisher with connection caching.
 ///
 /// Owns a dedicated tokio runtime so that `rskafka::Client` background tasks
@@ -23,27 +33,25 @@ use std::time::Duration;
 pub struct KafkaPublisher {
     runtime: tokio::runtime::Runtime,
     clients: Mutex<HashMap<String, Arc<Client>>>,
-}
-
-impl Default for KafkaPublisher {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// When false, broker addresses resolving to internal/metadata ranges are
+    /// rejected (SSRF guard). Operators opt in for trusted internal brokers.
+    allow_internal_egress: bool,
 }
 
 impl KafkaPublisher {
     /// Create a new Kafka publisher with its own background runtime.
-    pub fn new() -> Self {
+    pub fn new(allow_internal_egress: bool) -> Result<Self, BrokerError> {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
             .thread_name("kafka-runtime")
             .enable_all()
             .build()
-            .expect("failed to create Kafka runtime");
-        Self {
+            .map_err(|e| BrokerError::ConnectionFailed(format!("failed to create runtime: {e}")))?;
+        Ok(Self {
             runtime,
             clients: Mutex::new(HashMap::new()),
-        }
+            allow_internal_egress,
+        })
     }
 
     /// Blocking publish for use from sync WASM host functions.
@@ -88,10 +96,13 @@ impl KafkaPublisher {
             timestamp: Utc::now(),
         };
 
-        let offsets = partition_client
-            .produce(vec![record], Compression::NoCompression)
-            .await
-            .map_err(|e| BrokerError::PublishFailed(e.to_string()))?;
+        let offsets = tokio::time::timeout(
+            PRODUCE_TIMEOUT,
+            partition_client.produce(vec![record], Compression::NoCompression),
+        )
+        .await
+        .map_err(|_| BrokerError::Timeout)?
+        .map_err(|e| BrokerError::PublishFailed(e.to_string()))?;
 
         let offset = offsets.first().copied();
 
@@ -117,6 +128,23 @@ impl KafkaPublisher {
         // Parse broker addresses (comma-separated)
         let broker_list: Vec<String> = brokers.split(',').map(|s| s.trim().to_string()).collect();
 
+        // SSRF guard: refuse to connect to internal/metadata targets unless the
+        // operator has opted into internal egress.
+        for broker in &broker_list {
+            let (host, port) = crate::broker::split_host_port(broker, DEFAULT_KAFKA_PORT);
+            match crate::http_client::guard_external_host(&host, port, self.allow_internal_egress)
+                .await
+            {
+                Ok(()) => {}
+                Err(crate::http_client::HostGuardError::Blocked(h)) => {
+                    return Err(BrokerError::Blocked(h));
+                }
+                Err(crate::http_client::HostGuardError::Resolve(m)) => {
+                    return Err(BrokerError::ConnectionFailed(m));
+                }
+            }
+        }
+
         // Connect (outside the lock) with a 5s deadline to avoid blocking the host function
         let backoff = BackoffConfig {
             deadline: Some(Duration::from_secs(5)),
@@ -131,9 +159,14 @@ impl KafkaPublisher {
         let client = Arc::new(client);
         tracing::info!(brokers = %brokers, "established Kafka connection");
 
-        // Cache the new connection
+        // Cache the new connection, bounding the cache size.
         {
             let mut clients = self.clients.lock();
+            if clients.len() >= MAX_KAFKA_CONNECTIONS && !clients.contains_key(brokers) {
+                return Err(BrokerError::ConnectionFailed(
+                    "Kafka connection cache is full".to_string(),
+                ));
+            }
             clients.insert(brokers.to_string(), client.clone());
         }
 
@@ -147,21 +180,27 @@ mod tests {
 
     #[test]
     fn publisher_starts_empty() {
-        let publisher = KafkaPublisher::new();
+        let publisher = KafkaPublisher::new(true).expect("kafka publisher");
         let clients = publisher.clients.lock();
         assert!(clients.is_empty());
     }
 
     #[test]
-    fn default_impl() {
-        let publisher = KafkaPublisher::default();
-        let clients = publisher.clients.lock();
-        assert!(clients.is_empty());
+    fn blocks_internal_broker_when_egress_disallowed() {
+        let publisher = KafkaPublisher::new(false).expect("kafka publisher");
+        let result = publisher.publish_blocking(
+            "169.254.169.254:9092",
+            "test-topic",
+            None,
+            "hello",
+            BTreeMap::new(),
+        );
+        assert!(matches!(result, Err(BrokerError::Blocked(_))));
     }
 
     #[test]
     fn publish_blocking_connection_refused() {
-        let publisher = KafkaPublisher::new();
+        let publisher = KafkaPublisher::new(true).expect("kafka publisher");
         let result = publisher.publish_blocking(
             "127.0.0.1:19092",
             "test-topic",
@@ -176,7 +215,7 @@ mod tests {
 
     #[test]
     fn publish_blocking_from_thread_scope() {
-        let publisher = KafkaPublisher::new();
+        let publisher = KafkaPublisher::new(true).expect("kafka publisher");
         let result = std::thread::scope(|s| {
             s.spawn(|| {
                 publisher.publish_blocking(
@@ -195,7 +234,7 @@ mod tests {
 
     #[test]
     fn publish_blocking_with_key_and_headers() {
-        let publisher = KafkaPublisher::new();
+        let publisher = KafkaPublisher::new(true).expect("kafka publisher");
         let mut headers = BTreeMap::new();
         headers.insert("x-request-id".to_string(), "req-123".to_string());
 
@@ -212,7 +251,7 @@ mod tests {
 
     #[test]
     fn publish_blocking_comma_separated_brokers() {
-        let publisher = KafkaPublisher::new();
+        let publisher = KafkaPublisher::new(true).expect("kafka publisher");
         let result = publisher.publish_blocking(
             "127.0.0.1:19092, 127.0.0.1:19093",
             "test-topic",

--- a/crates/barbacane-wasm/src/nats_client.rs
+++ b/crates/barbacane-wasm/src/nats_client.rs
@@ -8,6 +8,20 @@ use crate::broker::{BrokerError, PublishResult};
 use bytes::Bytes;
 use parking_lot::Mutex;
 use std::collections::{BTreeMap, HashMap};
+use std::time::Duration;
+
+/// Default NATS server port, used when an address omits one.
+const DEFAULT_NATS_PORT: u16 = 4222;
+
+/// Upper bound on cached NATS connections, so a plugin can't force unbounded
+/// connection growth by publishing to many distinct server strings.
+const MAX_NATS_CONNECTIONS: usize = 256;
+
+/// Timeout for establishing a NATS connection.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Timeout for an individual publish operation.
+const PUBLISH_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// NATS publisher with connection caching.
 ///
@@ -17,27 +31,25 @@ use std::collections::{BTreeMap, HashMap};
 pub struct NatsPublisher {
     runtime: tokio::runtime::Runtime,
     connections: Mutex<HashMap<String, async_nats::Client>>,
-}
-
-impl Default for NatsPublisher {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// When false, server addresses resolving to internal/metadata ranges are
+    /// rejected (SSRF guard). Operators opt in for trusted internal servers.
+    allow_internal_egress: bool,
 }
 
 impl NatsPublisher {
     /// Create a new NATS publisher with its own background runtime.
-    pub fn new() -> Self {
+    pub fn new(allow_internal_egress: bool) -> Result<Self, BrokerError> {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
             .thread_name("nats-runtime")
             .enable_all()
             .build()
-            .expect("failed to create NATS runtime");
-        Self {
+            .map_err(|e| BrokerError::ConnectionFailed(format!("failed to create runtime: {e}")))?;
+        Ok(Self {
             runtime,
             connections: Mutex::new(HashMap::new()),
-        }
+            allow_internal_egress,
+        })
     }
 
     /// Blocking publish for use from sync WASM host functions.
@@ -66,19 +78,25 @@ impl NatsPublisher {
         let client = self.get_or_connect(url).await?;
 
         if headers.is_empty() {
-            client
-                .publish(subject.to_string(), payload)
-                .await
-                .map_err(|e| BrokerError::PublishFailed(e.to_string()))?;
+            tokio::time::timeout(
+                PUBLISH_TIMEOUT,
+                client.publish(subject.to_string(), payload),
+            )
+            .await
+            .map_err(|_| BrokerError::Timeout)?
+            .map_err(|e| BrokerError::PublishFailed(e.to_string()))?;
         } else {
             let mut header_map = async_nats::HeaderMap::new();
             for (k, v) in &headers {
                 header_map.insert(k.as_str(), v.as_str());
             }
-            client
-                .publish_with_headers(subject.to_string(), header_map, payload)
-                .await
-                .map_err(|e| BrokerError::PublishFailed(e.to_string()))?;
+            tokio::time::timeout(
+                PUBLISH_TIMEOUT,
+                client.publish_with_headers(subject.to_string(), header_map, payload),
+            )
+            .await
+            .map_err(|_| BrokerError::Timeout)?
+            .map_err(|e| BrokerError::PublishFailed(e.to_string()))?;
         }
 
         Ok(PublishResult::success(subject.to_string()))
@@ -94,16 +112,36 @@ impl NatsPublisher {
             }
         }
 
-        // Connect (outside the lock)
-        let client = async_nats::connect(url)
+        // SSRF guard: refuse to connect to internal/metadata targets unless the
+        // operator has opted into internal egress.
+        let (host, port) = crate::broker::split_host_port(url, DEFAULT_NATS_PORT);
+        match crate::http_client::guard_external_host(&host, port, self.allow_internal_egress).await
+        {
+            Ok(()) => {}
+            Err(crate::http_client::HostGuardError::Blocked(h)) => {
+                return Err(BrokerError::Blocked(h));
+            }
+            Err(crate::http_client::HostGuardError::Resolve(m)) => {
+                return Err(BrokerError::ConnectionFailed(m));
+            }
+        }
+
+        // Connect (outside the lock) with a bounded timeout.
+        let client = tokio::time::timeout(CONNECT_TIMEOUT, async_nats::connect(url))
             .await
+            .map_err(|_| BrokerError::Timeout)?
             .map_err(|e| BrokerError::ConnectionFailed(e.to_string()))?;
 
         tracing::info!(url = %url, "established NATS connection");
 
-        // Cache the new connection
+        // Cache the new connection, bounding the cache size.
         {
             let mut conns = self.connections.lock();
+            if conns.len() >= MAX_NATS_CONNECTIONS && !conns.contains_key(url) {
+                return Err(BrokerError::ConnectionFailed(
+                    "NATS connection cache is full".to_string(),
+                ));
+            }
             conns.insert(url.to_string(), client.clone());
         }
 
@@ -117,21 +155,26 @@ mod tests {
 
     #[test]
     fn publisher_starts_empty() {
-        let publisher = NatsPublisher::new();
+        let publisher = NatsPublisher::new(true).expect("nats publisher");
         let conns = publisher.connections.lock();
         assert!(conns.is_empty());
     }
 
     #[test]
-    fn default_impl() {
-        let publisher = NatsPublisher::default();
-        let conns = publisher.connections.lock();
-        assert!(conns.is_empty());
+    fn blocks_internal_server_when_egress_disallowed() {
+        let publisher = NatsPublisher::new(false).expect("nats publisher");
+        let result = publisher.publish_blocking(
+            "nats://169.254.169.254:4222",
+            "test.subject",
+            Bytes::from_static(b"hello"),
+            BTreeMap::new(),
+        );
+        assert!(matches!(result, Err(BrokerError::Blocked(_))));
     }
 
     #[test]
     fn publish_blocking_connection_refused() {
-        let publisher = NatsPublisher::new();
+        let publisher = NatsPublisher::new(true).expect("nats publisher");
         let result = publisher.publish_blocking(
             "nats://127.0.0.1:19999",
             "test.subject",
@@ -145,7 +188,7 @@ mod tests {
 
     #[test]
     fn publish_blocking_from_thread_scope() {
-        let publisher = NatsPublisher::new();
+        let publisher = NatsPublisher::new(true).expect("nats publisher");
         let result = std::thread::scope(|s| {
             s.spawn(|| {
                 publisher.publish_blocking(
@@ -163,7 +206,7 @@ mod tests {
 
     #[test]
     fn publish_blocking_with_headers() {
-        let publisher = NatsPublisher::new();
+        let publisher = NatsPublisher::new(true).expect("nats publisher");
         let mut headers = BTreeMap::new();
         headers.insert("x-request-id".to_string(), "req-123".to_string());
         headers.insert("x-trace-id".to_string(), "trace-456".to_string());

--- a/crates/barbacane-wasm/src/rate_limiter.rs
+++ b/crates/barbacane-wasm/src/rate_limiter.rs
@@ -8,6 +8,19 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+/// Upper bound on a rate-limit window. The window is plugin-controlled, so it is
+/// clamped before being turned into a Duration to keep `Instant` arithmetic out
+/// of overflow territory (1 year is far beyond any sane window).
+const MAX_WINDOW_SECS: u64 = 366 * 24 * 60 * 60;
+
+/// Upper bound on the plugin-controlled quota. Caps how many timestamps a single
+/// window can retain, bounding per-window memory.
+const MAX_QUOTA: u32 = 1_000_000;
+
+/// Upper bound on the number of distinct partition keys tracked at once. Bounds
+/// the total memory an attacker can force by varying the partition key.
+const MAX_PARTITIONS: usize = 100_000;
+
 /// Result of a rate limit check.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct RateLimitResult {
@@ -43,24 +56,30 @@ impl SlidingWindow {
     /// Check if a request is allowed and record it if so.
     fn check_and_record(&mut self, quota: u32) -> RateLimitResult {
         let now = Instant::now();
-        let window_start = now - self.window;
 
-        // Remove expired timestamps
-        self.timestamps.retain(|&t| t > window_start);
+        // Remove expired timestamps. Compare via `duration_since` (recorded
+        // timestamps are always <= now on the monotonic clock) instead of
+        // `now - window`, which underflow-panics when the window exceeds the
+        // process's monotonic-clock uptime.
+        self.timestamps
+            .retain(|&t| now.duration_since(t) < self.window);
 
-        // Calculate reset time (end of current window from first request)
-        let reset_instant = if let Some(&first) = self.timestamps.first() {
-            first + self.window
-        } else {
-            now + self.window
-        };
+        // Calculate reset time (end of current window from first request).
+        // checked_add guards against `Instant + Duration` overflow.
+        let reset_instant = self
+            .timestamps
+            .first()
+            .copied()
+            .unwrap_or(now)
+            .checked_add(self.window)
+            .unwrap_or(now);
 
         // Convert to Unix timestamp
         let reset = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0)
-            + reset_instant.saturating_duration_since(now).as_secs();
+            .saturating_add(reset_instant.saturating_duration_since(now).as_secs());
 
         let count = self.timestamps.len() as u32;
 
@@ -122,13 +141,47 @@ impl RateLimiter {
     /// * `quota` - Maximum requests allowed in the window
     /// * `window_secs` - Window duration in seconds
     pub fn check(&self, key: &str, quota: u32, window_secs: u64) -> RateLimitResult {
+        // Clamp the plugin-controlled window so the Duration can't drive
+        // `Instant` arithmetic into overflow territory (1 year is far beyond
+        // any sane rate-limit window).
+        let window_secs = window_secs.min(MAX_WINDOW_SECS);
         let window_duration = Duration::from_secs(window_secs);
+        // Clamp the plugin-controlled quota so a huge value can't grow the
+        // per-window timestamp log without bound.
+        let quota = quota.min(MAX_QUOTA);
 
         // Periodic cleanup
         self.maybe_cleanup();
 
         // Check and update window
         let mut windows = self.windows.write();
+
+        // Bound the partition table: an attacker-controlled partition key (e.g.
+        // a spoofable header) could otherwise create unbounded windows. When the
+        // table is full of a fresh key, evict stale partitions first; if it is
+        // still saturated with active keys, fail closed for the new key.
+        if windows.len() >= MAX_PARTITIONS && !windows.contains_key(key) {
+            let now = Instant::now();
+            windows.retain(|_, w| {
+                w.timestamps
+                    .iter()
+                    .any(|&t| now.duration_since(t) < self.cleanup_threshold)
+            });
+            if windows.len() >= MAX_PARTITIONS {
+                let reset = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0)
+                    .saturating_add(window_secs);
+                return RateLimitResult {
+                    allowed: false,
+                    remaining: 0,
+                    reset,
+                    limit: quota,
+                    retry_after: Some(window_secs.max(1)),
+                };
+            }
+        }
 
         let window = windows
             .entry(key.to_string())
@@ -158,12 +211,16 @@ impl RateLimiter {
             if now.duration_since(*last) >= self.cleanup_threshold {
                 *last = now;
 
-                // Cleanup old windows
+                // Cleanup old windows. Compare via `duration_since` (recorded
+                // timestamps are <= now) rather than `now - threshold`, which
+                // underflow-panics early in the process's uptime.
                 if let Some(mut windows) = self.windows.try_write() {
-                    let threshold = now - self.cleanup_threshold;
                     windows.retain(|_, window| {
                         // Keep if any timestamp is recent
-                        window.timestamps.iter().any(|&t| t > threshold)
+                        window
+                            .timestamps
+                            .iter()
+                            .any(|&t| now.duration_since(t) < self.cleanup_threshold)
                     });
                 }
             }
@@ -189,6 +246,23 @@ pub struct RateLimiterStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn quota_is_clamped() {
+        let limiter = RateLimiter::new();
+        // A huge plugin-supplied quota is clamped to MAX_QUOTA.
+        let result = limiter.check("clamp-key", u32::MAX, 60);
+        assert!(result.allowed);
+        assert_eq!(result.limit, MAX_QUOTA);
+    }
+
+    #[test]
+    fn huge_window_does_not_panic() {
+        let limiter = RateLimiter::new();
+        // u64::MAX seconds would overflow Instant arithmetic if not clamped.
+        let result = limiter.check("big-window", 5, u64::MAX);
+        assert!(result.allowed);
+    }
 
     #[test]
     fn test_basic_rate_limiting() {

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -703,9 +703,16 @@ impl Gateway {
                 .as_deref(),
             Some("1" | "true" | "TRUE" | "yes")
         );
+        // Cap the body the buffered plugin-egress path will read into host
+        // memory. Operators can raise/lower it; default is 16 MiB.
+        let max_response_bytes = std::env::var("BARBACANE_MAX_UPSTREAM_RESPONSE_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or_else(|| HttpClientConfig::default().max_response_bytes);
         let http_client_config = HttpClientConfig {
             allow_plaintext: allow_plaintext_upstream,
             allow_internal_egress,
+            max_response_bytes,
             ..Default::default()
         };
         let http_client = HttpClient::new(http_client_config)
@@ -848,11 +855,14 @@ impl Gateway {
         // Create response cache for host_cache_get/set calls
         let response_cache = ResponseCache::new();
 
-        // Create NATS publisher for host_nats_publish calls
-        let nats_publisher = barbacane_wasm::NatsPublisher::new();
+        // Create NATS publisher for host_nats_publish calls. Broker egress
+        // honors the same internal-egress policy as plugin HTTP calls.
+        let nats_publisher = barbacane_wasm::NatsPublisher::new(allow_internal_egress)
+            .map_err(|e| format!("failed to create NATS publisher: {}", e))?;
 
         // Create Kafka publisher for host_kafka_publish calls
-        let kafka_publisher = barbacane_wasm::KafkaPublisher::new();
+        let kafka_publisher = barbacane_wasm::KafkaPublisher::new(allow_internal_egress)
+            .map_err(|e| format!("failed to create Kafka publisher: {}", e))?;
 
         // Create pool with all options: HTTP client, secrets, rate limiter, cache, NATS, and Kafka
         let plugin_pool = InstancePool::with_all_options(

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -15,7 +15,8 @@ insecurely.
 | `BARBACANE_TRUSTED_PUBKEY` | Data plane | _unset_ | Hex-encoded Ed25519 public key. When set, the data plane requires every loaded `.bca` artifact to carry a valid signature produced by the matching private key; load fails otherwise. When unset, the artifact's content hashes are still verified, but signature checking is skipped (a startup warning is logged). |
 | `BARBACANE_SIGNING_KEY` | Compiler | _unset_ | Path to a PKCS#8 Ed25519 private key. When set, `barbacane compile` signs the artifact's content hash. When unset, the artifact is built unsigned. |
 | `BARBACANE_SECRETS_DIR` | Data plane | _unset_ | Base directory that `file://` secret references are confined to. **Required to use `file://` secrets** — references are rejected when it is unset, and any path resolving outside this directory (after symlink/`..` resolution) is rejected. |
-| `BARBACANE_ALLOW_INTERNAL_EGRESS` | Data plane | `false` | Set to `1`/`true` to disable the plugin SSRF guard and allow plugin HTTP calls to internal/loopback/link-local/cloud-metadata addresses. Leave off unless you have legitimate internal upstreams. |
+| `BARBACANE_ALLOW_INTERNAL_EGRESS` | Data plane | `false` | Set to `1`/`true` to disable the plugin SSRF guard and allow plugin egress (HTTP calls **and** Kafka/NATS broker connections) to internal/loopback/link-local/cloud-metadata addresses. Leave off unless you have legitimate internal upstreams or brokers. |
+| `BARBACANE_MAX_UPSTREAM_RESPONSE_BYTES` | Data plane | `16777216` (16 MiB) | Maximum size of an upstream response body that the buffered plugin HTTP-call path will read into host memory. Bodies larger than this are rejected, bounding host memory against a hostile or compromised upstream. Streaming dispatchers are unaffected. |
 
 ## Breaking-by-design defaults
 
@@ -33,8 +34,9 @@ These changes are intentional secure defaults. Adopt them as follows:
    (`tools/list`, `tools/call`, …) without a valid `Mcp-Session-Id` are now
    rejected; call `initialize` first and reuse the returned session id.
 
-4. **Plugin HTTP calls to internal addresses are blocked by default.** If a
-   plugin legitimately calls an internal upstream, set
+4. **Plugin egress to internal addresses is blocked by default.** This now
+   covers both plugin HTTP calls and Kafka/NATS broker connections. If a plugin
+   legitimately reaches an internal upstream or broker, set
    `BARBACANE_ALLOW_INTERNAL_EGRESS=1` (or prefer an explicit allowlist when one
    is available).
 


### PR DESCRIPTION
## Area: WASM sandbox limits

Hardens the WASM host runtime against a hostile or compromised plugin. Fail-closed by default, with operator opt-outs where appropriate. Continues the sequential, one-PR-per-area security work.

### Panic vectors removed
- Guest-controlled pointer/length slice reads in `instance.rs` use `saturating_add`, so a negative/oversized `len` fails the existing bounds check instead of panicking on an inverted range.
- `cache.rs` / `rate_limiter.rs` `Instant`/`Duration` arithmetic is overflow/underflow-safe (`checked_*` / `saturating_*` / `duration_since`), including cleanup paths that underflow in the first minutes of process uptime.

### Memory bounds (DoS)
- Response cache caps its entry count (evicts expired, then soonest-to-expire).
- Rate limiter clamps plugin-supplied **quota** and **window**, and caps the partition table — failing closed when saturated with active keys.

### Upstream body cap
- The buffered plugin HTTP-call path reads at most `BARBACANE_MAX_UPSTREAM_RESPONSE_BYTES` (default 16 MiB) via a chunked, `Content-Length`-aware read. Streaming dispatchers are unaffected.

### Wall-clock backstop
- Epoch interruption + a background ticker trap a guest that runs past its time budget, complementing fuel-based CPU limiting.

### Broker hardening (Kafka/NATS)
- SSRF guard on broker addresses (honors `BARBACANE_ALLOW_INTERNAL_EGRESS`), connect/publish timeouts, bounded connection caches.
- Runtime build errors now propagate instead of `expect`-panicking.

### Docs
- `BARBACANE_MAX_UPSTREAM_RESPONSE_BYTES` documented; internal-egress default note extended to brokers; CHANGELOG updated.

### Verification
- `cargo fmt --all --check`, `cargo clippy --workspace --lib --bins --exclude barbacane-test -D warnings`, and `cargo test --workspace --lib --bins --exclude barbacane-test` all green. New unit tests cover the body cap, cache/quota/window clamps, broker SSRF rejection, and `split_host_port`.

Resolves the WASM sandbox-limits items tracked privately (#3/#4).