### PR TITLE
security(data-plane): ingress DoS hardening + chunked body-size cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security**: `jwt-auth` performs real signature verification via the host `verify_signature` capability (inline JWK).
 - **security**: a security testing framework — adversarial integration suite (`crates/barbacane-test/tests/security/`) and `cargo-fuzz` targets (`fuzz/`).
 - **security**: WASM sandbox resource limits — buffered plugin HTTP responses are capped (`BARBACANE_MAX_UPSTREAM_RESPONSE_BYTES`, default 16 MiB); the host cache and rate limiter bound their entry/partition counts and clamp plugin-supplied TTL/window/quota; a wall-clock epoch deadline backstops fuel-based CPU limiting.
+- **security**: ingress DoS hardening — a per-request header-read deadline (slowloris defense, doubling as the HTTP keep-alive idle timeout, wiring the previously-ignored `--keepalive-timeout`), a TLS handshake timeout, an HTTP/2 concurrent-stream cap, and a concurrent-connection ceiling (`BARBACANE_MAX_CONNECTIONS`, default 10000).
 - **docs**: [Configuration & environment variables](reference/configuration.md) reference.
 
 ### Changed (breaking, secure-by-default)
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security**: fail-open middleware short-circuit downgrade in the WASM chain.
 - **security**: panic on hostile `x-request-id` / `traceparent`; unbounded Prometheus path-label cardinality on unmatched routes.
 - **security**: panic vectors in WASM host functions — guest-controlled pointer/length slice reads now use saturating arithmetic, and cache/rate-limiter time arithmetic is overflow/underflow-safe.
+- **security**: chunked request bodies with no `Content-Length` are now size-capped while streaming (`http_body_util::Limited`) instead of being fully buffered before the limit check.
 - **deps**: bump `anyhow` to 1.0.103 (RUSTSEC-2026-0190).
 
 ## [0.7.0] - 2026-05-05

--- a/crates/barbacane-test/tests/security/dos.rs
+++ b/crates/barbacane-test/tests/security/dos.rs
@@ -17,7 +17,7 @@
 //!      request path on the `RouteMatch::NotFound` arm
 //!      (`crates/barbacane/src/main.rs`), so an attacker can blow up metric
 //!      cardinality (memory DoS) and exfiltrate scanned paths. The fix replaces
-//!      the label with a sentinel such as `<not_found>`.
+//!      the label with an `<unmatched>` sentinel.
 
 use barbacane_test::TestGateway;
 
@@ -27,21 +27,24 @@ use crate::{fixture, security_fixture};
 // 1. Oversized chunked body -> 413
 // ---------------------------------------------------------------------------
 
-/// A chunked request whose body exceeds the configured limit must get 413.
+/// A chunked request whose body exceeds the gateway's body-size limit must be
+/// rejected with 413 while streaming — not buffered in full and then checked.
 ///
-/// `request-size-limit.yaml` caps `/limited` at 100 bytes. We send ~64 KiB with
+/// We boot the gateway with `--max-body-size 100` and POST ~64 KiB with
 /// `Transfer-Encoding: chunked` (reqwest streams a body of unknown length as
-/// chunked). The hardened gateway rejects it with 413.
+/// chunked, so there is no Content-Length). The hardened gateway caps the read
+/// (`http_body_util::Limited`) and returns 413 before the body is fully
+/// buffered or schema validation runs.
 #[tokio::test]
 async fn oversized_chunked_body_rejected_with_413() {
-    // EXPECTED TO FAIL until BARB-SEC-003 is fixed (chunked bodies without a
-    // Content-Length must be size-capped while streaming, not buffered then
-    // checked / accepted).
-    let gw = TestGateway::from_spec(&fixture("request-size-limit.yaml"))
-        .await
-        .expect("failed to start gateway");
+    let gw = TestGateway::from_spec_with_args(
+        &fixture("request-size-limit.yaml"),
+        &["--max-body-size", "100"],
+    )
+    .await
+    .expect("failed to start gateway");
 
-    // A 64 KiB payload (limit is 100 bytes). Using a streaming body forces
+    // A 64 KiB payload (gateway limit is 100 bytes). A streaming body forces
     // chunked transfer-encoding (no Content-Length).
     let big = vec![b'a'; 64 * 1024];
     let body = reqwest::Body::wrap_stream(futures_util::stream::once(async move {
@@ -68,23 +71,54 @@ async fn oversized_chunked_body_rejected_with_413() {
 // ---------------------------------------------------------------------------
 
 /// Slowloris: a client that opens a connection and dribbles bytes (or never
-/// finishes the body) must be timed out so it cannot pin a worker indefinitely.
+/// finishes the request headers) must be timed out so it cannot pin a worker
+/// indefinitely.
 ///
-/// This is inherently timing-dependent and would require holding a socket open
-/// and measuring that the server closes it within a header/body read deadline.
-/// Asserting that deterministically (without sleeps that make CI flaky) needs a
-/// configurable, observable read timeout we can drive from the test. Parked
-/// until the gateway exposes a read/header timeout knob we can set low and a
-/// signal we can assert on.
+/// We boot the gateway with `--keepalive-timeout 2`, which drives the
+/// per-request header-read deadline. Then we open a raw TCP socket, send a
+/// partial request (request line + one header, but never the terminating blank
+/// line) and assert the server closes the connection well within a generous
+/// window rather than waiting forever.
 #[tokio::test]
-#[ignore = "BLOCKED: needs a configurable+observable read/header timeout to assert slowloris defence without flaky wall-clock sleeps (BARB-SEC-003)"]
 async fn slowloris_connection_is_timed_out() {
-    // EXPECTED TO FAIL until BARB-SEC-003 (slowloris) is addressed.
-    //
-    // Intended shape: open a raw TCP socket to the gateway, send a partial
-    // request ("GET /health HTTP/1.1\r\nHost: x\r\n") and then stop, and assert
-    // the server closes the connection within N seconds rather than waiting
-    // forever. Requires a deterministic timeout to assert against.
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    let gw = TestGateway::from_spec_with_args(
+        &fixture("request-size-limit.yaml"),
+        &["--keepalive-timeout", "2"],
+    )
+    .await
+    .expect("failed to start gateway");
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{}", gw.port()))
+        .await
+        .expect("connect");
+
+    // Partial request: never send the blank line that ends the header block.
+    // A vulnerable server would wait on this read forever.
+    stream
+        .write_all(b"GET /limited HTTP/1.1\r\nHost: x\r\n")
+        .await
+        .expect("write");
+    stream.flush().await.expect("flush");
+
+    // A hardened server hits the header-read deadline and closes the connection
+    // (EOF / reset), optionally after a 408/400. The 15s window is far larger
+    // than the 2s deadline, so this is not timing-sensitive.
+    let mut buf = [0u8; 1024];
+    match tokio::time::timeout(std::time::Duration::from_secs(15), stream.read(&mut buf)).await {
+        Ok(Ok(0)) => { /* EOF: server closed the slow connection — good */ }
+        Ok(Ok(n)) => {
+            let resp = String::from_utf8_lossy(&buf[..n]);
+            assert!(
+                resp.contains("408") || resp.contains("400"),
+                "expected the server to time out the slow connection, got: {resp}"
+            );
+        }
+        Ok(Err(_)) => { /* connection reset by peer — server closed it, good */ }
+        Err(_) => panic!("server did not time out the slowloris connection within 15s"),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -93,13 +127,10 @@ async fn slowloris_connection_is_timed_out() {
 
 /// Flooding unique unmatched paths must not create a distinct Prometheus series
 /// per raw path. We hit many random 404 paths, then scrape `/metrics` and
-/// assert (a) none of the raw flood paths appear as label values, and (b) a
-/// `<not_found>` sentinel label is present instead.
+/// assert (a) none of the raw flood paths appear as label values, and (b) an
+/// `<unmatched>` sentinel label is present instead.
 #[tokio::test]
 async fn not_found_flood_does_not_explode_metric_cardinality() {
-    // EXPECTED TO FAIL until BARB-SEC-003 is fixed (RouteMatch::NotFound records
-    // the raw request path as a metric label; should use a `<not_found>`
-    // sentinel).
     let gw = TestGateway::from_spec(&security_fixture("metrics.yaml"))
         .await
         .expect("failed to start gateway");
@@ -133,7 +164,7 @@ async fn not_found_flood_does_not_explode_metric_cardinality() {
 
     // (b) Unmatched requests should collapse to a sentinel label.
     assert!(
-        metrics.contains("<not_found>"),
-        "expected a `<not_found>` sentinel label for unmatched requests"
+        metrics.contains("<unmatched>"),
+        "expected an `<unmatched>` sentinel label for unmatched requests"
     );
 }

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -1127,8 +1127,8 @@ impl Gateway {
         // Check content-length before reading body (if present)
         if let Some(content_length) = headers.get("content-length") {
             if let Ok(len) = content_length.parse::<usize>() {
-                if let Err(e) = self.limits.validate_body_size(len) {
-                    let response = self.validation_error_response(&[e]);
+                if self.limits.validate_body_size(len).is_err() {
+                    let response = self.payload_too_large_response(self.limits.max_body_size);
                     self.record_request_metrics(
                         &method_str,
                         UNMATCHED_ROUTE_LABEL,
@@ -1165,10 +1165,27 @@ impl Gateway {
                 let (body_bytes, upgrade_handle) = if is_ws_upgrade {
                     (Bytes::new(), Some(hyper::upgrade::on(req)))
                 } else {
-                    match req.collect().await {
+                    // Cap the bytes read while collecting so a chunked body with
+                    // no content-length can't be buffered past the limit (DoS).
+                    // `Limited` errors as soon as the cap is exceeded.
+                    let limited =
+                        http_body_util::Limited::new(req.into_body(), self.limits.max_body_size);
+                    match limited.collect().await {
                         Ok(collected) => (collected.to_bytes(), None),
-                        Err(_) => {
-                            let response = self.bad_request_response("failed to read request body");
+                        Err(e) => {
+                            let response = if e
+                                .downcast_ref::<http_body_util::LengthLimitError>()
+                                .is_some()
+                            {
+                                self.metrics.record_validation_failure(
+                                    &method_str,
+                                    &route_path,
+                                    "body_too_large",
+                                );
+                                self.payload_too_large_response(self.limits.max_body_size)
+                            } else {
+                                self.bad_request_response("failed to read request body")
+                            };
                             self.record_request_metrics(
                                 &method_str,
                                 &route_path,
@@ -1189,13 +1206,13 @@ impl Gateway {
                 let request_size = body_bytes.len() as u64;
 
                 // Validate actual body size (in case content-length was missing or wrong)
-                if let Err(e) = self.limits.validate_body_size(body_bytes.len()) {
+                if self.limits.validate_body_size(body_bytes.len()).is_err() {
                     self.metrics.record_validation_failure(
                         &method_str,
                         &route_path,
                         "body_too_large",
                     );
-                    let response = self.validation_error_response(&[e]);
+                    let response = self.payload_too_large_response(self.limits.max_body_size);
                     self.record_request_metrics(
                         &method_str,
                         &route_path,
@@ -2232,31 +2249,35 @@ impl Gateway {
             .and_then(|v| v.to_str().ok())
             .and_then(|s| s.parse::<usize>().ok())
         {
-            if let Err(e) = self.limits.validate_body_size(content_length) {
-                let response = self.validation_error_response(&[e]);
+            if self.limits.validate_body_size(content_length).is_err() {
+                let response = self.payload_too_large_response(self.limits.max_body_size);
                 return box_full(Self::add_standard_headers(response, request_id, trace_id));
             }
         }
 
-        let body = match http_body_util::BodyExt::collect(req.into_body()).await {
+        // Cap the bytes read while collecting so a chunked body with no
+        // content-length can't be buffered past the limit (DoS).
+        let limited = http_body_util::Limited::new(req.into_body(), self.limits.max_body_size);
+        let body = match limited.collect().await {
             Ok(collected) => collected.to_bytes(),
-            Err(_) => {
-                let response = Response::builder()
-                    .status(StatusCode::BAD_REQUEST)
-                    .header("content-type", "application/problem+json")
-                    .body(Full::new(Bytes::from(
-                        r#"{"type":"urn:barbacane:error:bad-request","title":"Bad Request","status":400,"detail":"failed to read request body"}"#,
-                    )))
-                    .expect("valid response");
+            Err(e) => {
+                let response = if e
+                    .downcast_ref::<http_body_util::LengthLimitError>()
+                    .is_some()
+                {
+                    self.payload_too_large_response(self.limits.max_body_size)
+                } else {
+                    Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .header("content-type", "application/problem+json")
+                        .body(Full::new(Bytes::from(
+                            r#"{"type":"urn:barbacane:error:bad-request","title":"Bad Request","status":400,"detail":"failed to read request body"}"#,
+                        )))
+                        .expect("valid response")
+                };
                 return box_full(Self::add_standard_headers(response, request_id, trace_id));
             }
         };
-
-        // Validate collected body size
-        if let Err(e) = self.limits.validate_body_size(body.len()) {
-            let response = self.validation_error_response(&[e]);
-            return box_full(Self::add_standard_headers(response, request_id, trace_id));
-        }
 
         // Single parse: handle_request returns the appropriate result type
         let result = mcp_server.handle_request(&body, session_id.as_deref());
@@ -2653,6 +2674,24 @@ impl Gateway {
             .status(StatusCode::BAD_REQUEST)
             .header("content-type", "application/problem+json")
             .body(Full::new(Bytes::from(problem.to_json())))
+            .expect("valid response")
+    }
+
+    /// Build a 413 Payload Too Large response (RFC 9457). Used when the request
+    /// body exceeds the configured size limit, whether detected via
+    /// `Content-Length` or while streaming a chunked body.
+    fn payload_too_large_response(&self, limit: usize) -> Response<Full<Bytes>> {
+        let body = serde_json::json!({
+            "type": "urn:barbacane:error:payload-too-large",
+            "title": "Payload Too Large",
+            "status": 413,
+            "detail": format!("Request body exceeds the maximum allowed size of {limit} bytes."),
+        });
+
+        Response::builder()
+            .status(StatusCode::PAYLOAD_TOO_LARGE)
+            .header("content-type", "application/problem+json")
+            .body(Full::new(Bytes::from(body.to_string())))
             .expect("valid response")
     }
 
@@ -3987,11 +4026,7 @@ async fn run_dev(
 
                     let io = TokioIo::new(stream);
                     let mut builder = auto::Builder::new(TokioExecutor::new());
-                    builder.http1().keep_alive(true);
-                    builder
-                        .http2()
-                        .timer(TokioTimer::new())
-                        .keep_alive_interval(Some(Duration::from_secs(20)));
+                    configure_conn_builder(&mut builder, DEFAULT_KEEPALIVE);
                     let conn = builder.serve_connection_with_upgrades(io, service);
 
                     tokio::pin!(conn);
@@ -4024,6 +4059,41 @@ async fn run_dev(
     drop(temp_artifact);
 
     ExitCode::SUCCESS
+}
+
+/// Default ceiling on concurrently served connections, bounding file-descriptor
+/// and task growth under a connection flood. Override with
+/// `BARBACANE_MAX_CONNECTIONS`.
+const DEFAULT_MAX_CONNECTIONS: usize = 10_000;
+
+/// Maximum time allowed to complete a TLS handshake before the connection is
+/// dropped. Bounds slowloris-style handshake stalls.
+const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Default idle keep-alive timeout used where no operator value is supplied
+/// (e.g. the dev server). Also the per-request header-read deadline.
+const DEFAULT_KEEPALIVE: Duration = Duration::from_secs(60);
+
+/// Maximum number of concurrent HTTP/2 streams per connection, bounding a
+/// single client's ability to multiplex a flood of streams.
+const HTTP2_MAX_CONCURRENT_STREAMS: u32 = 256;
+
+/// Apply ingress DoS hardening to a connection builder: a header-read deadline
+/// (slowloris defense, doubling as the HTTP/1 idle keep-alive timeout), an
+/// HTTP/2 keep-alive probe + timeout, and a per-connection stream cap.
+fn configure_conn_builder(builder: &mut auto::Builder<TokioExecutor>, keepalive: Duration) {
+    builder
+        .http1()
+        // A timer is required for `header_read_timeout` to function.
+        .timer(TokioTimer::new())
+        .keep_alive(true)
+        .header_read_timeout(keepalive);
+    builder
+        .http2()
+        .timer(TokioTimer::new())
+        .keep_alive_interval(Some(Duration::from_secs(20)))
+        .keep_alive_timeout(keepalive)
+        .max_concurrent_streams(HTTP2_MAX_CONCURRENT_STREAMS);
 }
 
 /// TLS configuration for the server.
@@ -4314,9 +4384,18 @@ async fn run_serve(
         });
     }
 
-    // Keep-alive timeout (currently used for documentation; HTTP/1.1 uses internal defaults)
-    let _keepalive_duration = Duration::from_secs(keepalive_timeout);
+    // Keep-alive / idle timeout: bounds how long an idle connection may wait for
+    // the next request's headers (slowloris defense + HTTP keep-alive idle).
+    let keepalive_duration = Duration::from_secs(keepalive_timeout.max(1));
     let shutdown_duration = Duration::from_secs(shutdown_timeout);
+
+    // Cap concurrently served connections to bound FD/task growth under a flood.
+    let max_connections = std::env::var("BARBACANE_MAX_CONNECTIONS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_MAX_CONNECTIONS);
+    let conn_semaphore = Arc::new(tokio::sync::Semaphore::new(max_connections));
 
     // Track active connections for graceful shutdown
     let active_connections = Arc::new(AtomicU64::new(0));
@@ -4421,6 +4500,17 @@ async fn run_serve(
                     }
                 };
 
+                // Connection cap: shed load when at capacity rather than letting
+                // FDs/tasks grow without bound.
+                let permit = match conn_semaphore.clone().try_acquire_owned() {
+                    Ok(p) => p,
+                    Err(_) => {
+                        tracing::warn!(%peer_addr, "connection limit reached; dropping connection");
+                        drop(stream);
+                        continue;
+                    }
+                };
+
                 // Track connection
                 metrics.connection_opened();
                 active_connections.fetch_add(1, Ordering::SeqCst);
@@ -4434,8 +4524,11 @@ async fn run_serve(
                 let conn_counter = active_connections.clone();
                 let mut conn_shutdown_rx = shutdown_rx.clone();
                 let client_addr = Some(peer_addr);
+                let conn_keepalive = keepalive_duration;
 
                 tokio::spawn(async move {
+                    // Held for the connection's lifetime; released on drop.
+                    let _permit = permit;
                     let service = service_fn(move |req| {
                         let gateway = Arc::clone(&gateway_snapshot);
                         let client_addr = client_addr;
@@ -4443,16 +4536,26 @@ async fn run_serve(
                     });
 
                     if let Some(acceptor) = tls_acceptor {
-                        // TLS connection - uses auto protocol detection (HTTP/1.1 or HTTP/2 via ALPN)
-                        match acceptor.accept(stream).await {
-                            Ok(tls_stream) => {
+                        // TLS connection - uses auto protocol detection (HTTP/1.1 or HTTP/2 via ALPN).
+                        // Bound the handshake so a stalled client can't pin the task.
+                        let accepted =
+                            match tokio::time::timeout(TLS_HANDSHAKE_TIMEOUT, acceptor.accept(stream))
+                                .await
+                            {
+                                Ok(Ok(tls_stream)) => Some(tls_stream),
+                                Ok(Err(e)) => {
+                                    tracing::debug!(error = %e, "TLS handshake failed");
+                                    None
+                                }
+                                Err(_) => {
+                                    tracing::debug!("TLS handshake timed out");
+                                    None
+                                }
+                            };
+                        if let Some(tls_stream) = accepted {
                                 let io = TokioIo::new(tls_stream);
                                 let mut builder = auto::Builder::new(TokioExecutor::new());
-                                builder.http1().keep_alive(true);
-                                builder
-                                    .http2()
-                                    .timer(TokioTimer::new())
-                                    .keep_alive_interval(Some(std::time::Duration::from_secs(20)));
+                                configure_conn_builder(&mut builder, conn_keepalive);
                                 let conn = builder.serve_connection_with_upgrades(io, service);
 
                                 // Pin the connection for graceful shutdown
@@ -4476,21 +4579,13 @@ async fn run_serve(
                                         }
                                     }
                                 }
-                            }
-                            Err(e) => {
-                                tracing::debug!(error = %e, "TLS handshake failed");
-                            }
                         }
                     } else {
                         // Plain TCP connection - uses auto protocol detection
                         // Supports both HTTP/1.1 and HTTP/2 prior knowledge (h2c)
                         let io = TokioIo::new(stream);
                         let mut builder = auto::Builder::new(TokioExecutor::new());
-                        builder.http1().keep_alive(true);
-                        builder
-                            .http2()
-                            .timer(TokioTimer::new())
-                            .keep_alive_interval(Some(std::time::Duration::from_secs(20)));
+                        configure_conn_builder(&mut builder, conn_keepalive);
                         let conn = builder.serve_connection_with_upgrades(io, service);
 
                         // Pin the connection for graceful shutdown

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -17,6 +17,7 @@ insecurely.
 | `BARBACANE_SECRETS_DIR` | Data plane | _unset_ | Base directory that `file://` secret references are confined to. **Required to use `file://` secrets** — references are rejected when it is unset, and any path resolving outside this directory (after symlink/`..` resolution) is rejected. |
 | `BARBACANE_ALLOW_INTERNAL_EGRESS` | Data plane | `false` | Set to `1`/`true` to disable the plugin SSRF guard and allow plugin egress (HTTP calls **and** Kafka/NATS broker connections) to internal/loopback/link-local/cloud-metadata addresses. Leave off unless you have legitimate internal upstreams or brokers. |
 | `BARBACANE_MAX_UPSTREAM_RESPONSE_BYTES` | Data plane | `16777216` (16 MiB) | Maximum size of an upstream response body that the buffered plugin HTTP-call path will read into host memory. Bodies larger than this are rejected, bounding host memory against a hostile or compromised upstream. Streaming dispatchers are unaffected. |
+| `BARBACANE_MAX_CONNECTIONS` | Data plane | `10000` | Maximum number of concurrently served ingress connections. Beyond this, new connections are dropped (load shed) rather than letting file descriptors and tasks grow without bound under a connection flood. |
 
 ## Breaking-by-design defaults
 


### PR DESCRIPTION
## Area: data-plane ingress DoS (#2)

Closes the ingress DoS gaps. Continues the sequential, one-PR-per-area security work, fail-closed by default with operator opt-outs.

### DP-2 — ingress timeouts / connection cap
- **Header-read deadline** (slowloris defense) per request, doubling as the HTTP keep-alive idle timeout — this finally wires the previously-discarded `--keepalive-timeout` flag (`_keepalive_duration` → used).
- **TLS handshake timeout** (10s) wrapping `acceptor.accept`, so a stalled handshake can't pin a task/FD.
- **HTTP/2 `max_concurrent_streams`** cap (256) against per-connection stream floods.
- **Concurrent-connection ceiling** with load shedding (`BARBACANE_MAX_CONNECTIONS`, default 10000).
- Applied via a shared `configure_conn_builder` across the dev + production accept loops. The HTTP/1 builder now also gets a timer (required for `header_read_timeout` to function — without it the connection task panics, which is why a missing timer would hang every request).

### DP-3 — chunked body-size bypass
- Both request-body collection sites wrap the body in `http_body_util::Limited`, so a `Transfer-Encoding: chunked` body with no `Content-Length` is capped **while streaming** instead of being fully buffered before the size check.
- Body-too-large now returns **413** (RFC 9457 `payload-too-large`) consistently via a dedicated helper, instead of a generic 400.

### Tests
The DoS security suite (`crates/barbacane-test/tests/security/dos.rs`) is now green:
- `oversized_chunked_body_rejected_with_413` — rewritten to boot with `--max-body-size 100` so it exercises the gateway's streaming cap (its stated intent) rather than being confounded by schema validation running before the size-limit middleware.
- `slowloris_connection_is_timed_out` — **un-`#[ignore]`d**: now implementable because the header-read timeout is configurable (`--keepalive-timeout`) and observable.
- `not_found_flood_does_not_explode_metric_cardinality` — assertion aligned to the already-shipped `<unmatched>` sentinel (the cardinality fix landed in PR #85; only the sentinel string differed).

CI gates verified locally green: `cargo fmt --all --check`, `cargo clippy --workspace --lib --bins --exclude barbacane-test -D warnings`, `cargo test --workspace --lib --bins --exclude barbacane-test`.

### Note (separate finding)
While verifying, I found the **integration test binaries under `crates/barbacane-test/tests/` (including the entire adversarial security suite) are not run by CI** — the "Integration Tests" job runs only `cargo test -p barbacane-test --lib`. I verified this PR's DoS tests + the 2MB-body proxy test locally instead. Wiring the suite into CI is worth a follow-up (filing separately).

Resolves the data-plane ingress DoS items tracked privately (#2).