### PR TITLE
feat(compiler): warn (E1070) on plaintext secrets in plugin config (schema-driven)

### DIFF
--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -307,6 +307,7 @@ pub fn compile_with_manifest(
             wasm_bytes: p.wasm_bytes,
             body_access: p.body_access,
             host_functions: p.host_functions,
+            secret_fields: p.secret_fields,
         })
         .collect();
 
@@ -442,6 +443,8 @@ pub struct PluginBundle {
     pub body_access: bool,
     /// Declared capability host-function names from plugin.toml.
     pub host_functions: Vec<String>,
+    /// Config fields marked `writeOnly` (secret) in the plugin's config-schema.json.
+    pub secret_fields: Vec<String>,
 }
 
 /// Parse spec files into (ApiSpec, content, sha256) tuples.
@@ -490,6 +493,15 @@ fn compile_inner(
 ) -> Result<CompileResult, CompileError> {
     let mut warnings: Vec<CompileWarning> = Vec::new();
     let mut operations: Vec<CompiledOperation> = Vec::new();
+
+    // Per-plugin set of secret (writeOnly) config fields, from each plugin's
+    // config-schema.json, used to warn on plaintext secrets baked into configs.
+    let plugin_secret_fields: HashMap<&str, std::collections::BTreeSet<String>> = plugins
+        .iter()
+        .filter(|p| !p.secret_fields.is_empty())
+        .map(|p| (p.name.as_str(), p.secret_fields.iter().cloned().collect()))
+        .collect();
+
     let mut seen_routes: HashMap<(String, String), String> = HashMap::new();
     let mut seen_structural: HashMap<(String, String), (String, String)> = HashMap::new();
     let mut seen_operation_ids: HashMap<String, String> = HashMap::new();
@@ -603,6 +615,24 @@ fn compile_inner(
                         idx + 1,
                         location
                     )));
+                }
+            }
+
+            // Warn on plaintext secrets in config (E1070): a field the plugin's
+            // schema marks `writeOnly` but that holds a literal gets baked into
+            // the artifact. Recommend env:// / file:// references.
+            if let Some(fields) = plugin_secret_fields.get(dispatch.name.as_str()) {
+                scan_plaintext_secrets(
+                    &dispatch.config,
+                    &dispatch.name,
+                    fields,
+                    &location,
+                    &mut warnings,
+                );
+            }
+            for mw in &middlewares {
+                if let Some(fields) = plugin_secret_fields.get(mw.name.as_str()) {
+                    scan_plaintext_secrets(&mw.config, &mw.name, fields, &location, &mut warnings);
                 }
             }
 
@@ -991,6 +1021,103 @@ fn now_utc_iso8601() -> String {
     chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
 
+/// Collect the names of config fields a plugin's `config-schema.json` marks as
+/// secret via the standard JSON Schema `writeOnly: true` keyword. Walks the
+/// whole schema (properties, array `items`, `additionalProperties`, and the
+/// `$defs`/`allOf`/`anyOf`/`oneOf` combinators) so nested shapes such as
+/// ai-proxy's `routes[].api_key` and `targets{}.api_key` are covered.
+pub fn collect_writeonly_fields(schema: &serde_json::Value) -> std::collections::BTreeSet<String> {
+    fn walk(node: &serde_json::Value, out: &mut std::collections::BTreeSet<String>) {
+        match node {
+            serde_json::Value::Object(map) => {
+                // A `properties` map names fields; a child marked writeOnly is a secret.
+                if let Some(serde_json::Value::Object(props)) = map.get("properties") {
+                    for (field, subschema) in props {
+                        if subschema.get("writeOnly").and_then(|v| v.as_bool()) == Some(true) {
+                            out.insert(field.clone());
+                        }
+                        walk(subschema, out);
+                    }
+                }
+                // Recurse into the remaining schema structure.
+                for key in [
+                    "items",
+                    "additionalProperties",
+                    "$defs",
+                    "definitions",
+                    "allOf",
+                    "anyOf",
+                    "oneOf",
+                    "then",
+                    "else",
+                ] {
+                    if let Some(child) = map.get(key) {
+                        walk(child, out);
+                    }
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    walk(item, out);
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut out = std::collections::BTreeSet::new();
+    walk(schema, &mut out);
+    out
+}
+
+/// Recursively scan a plugin config for `secret_fields` (declared `writeOnly` in
+/// the plugin's schema) whose value is a plaintext literal rather than an
+/// `env://` / `file://` reference. Such values are baked into the compiled
+/// artifact at rest; warn (E1070) so operators move them to a secret reference
+/// that is resolved at runtime. With no schema-declared secrets, this is a no-op.
+fn scan_plaintext_secrets(
+    config: &serde_json::Value,
+    plugin: &str,
+    secret_fields: &std::collections::BTreeSet<String>,
+    location: &str,
+    warnings: &mut Vec<CompileWarning>,
+) {
+    if secret_fields.is_empty() {
+        return;
+    }
+
+    /// A value that is resolved at runtime rather than stored in the artifact.
+    fn is_secret_ref(value: &str) -> bool {
+        value.starts_with("env://") || value.starts_with("file://")
+    }
+
+    match config {
+        serde_json::Value::Object(map) => {
+            for (key, value) in map {
+                if let serde_json::Value::String(s) = value {
+                    if secret_fields.contains(key) && !s.is_empty() && !is_secret_ref(s) {
+                        warnings.push(CompileWarning {
+                            code: "E1070".to_string(),
+                            message: format!(
+                                "plugin '{plugin}' config field '{key}' is a secret but is set to \
+                                 a plaintext literal; use an env:// or file:// reference so it is \
+                                 resolved at runtime instead of baked into the artifact"
+                            ),
+                            location: Some(location.to_string()),
+                        });
+                    }
+                }
+                scan_plaintext_secrets(value, plugin, secret_fields, location, warnings);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                scan_plaintext_secrets(item, plugin, secret_fields, location, warnings);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Extract upstream URL from dispatch config, if present.
 ///
 /// Looks for common URL fields in the dispatch config:
@@ -1325,6 +1452,88 @@ mod tests {
     use std::io::Write;
     use tempfile::TempDir;
 
+    #[test]
+    fn collect_writeonly_fields_finds_nested_secrets() {
+        // Mirrors ai-proxy: writeOnly api_key at top level, in routes[].items,
+        // and in targets{}.additionalProperties. `base_url` is not writeOnly.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "api_key": { "type": "string", "writeOnly": true },
+                "base_url": { "type": "string" },
+                "routes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "api_key": { "type": "string", "writeOnly": true }
+                        }
+                    }
+                },
+                "targets": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "client_secret": { "type": "string", "writeOnly": true }
+                        }
+                    }
+                }
+            }
+        });
+        let fields = collect_writeonly_fields(&schema);
+        assert!(fields.contains("api_key"));
+        assert!(fields.contains("client_secret"));
+        assert!(!fields.contains("base_url"));
+    }
+
+    #[test]
+    fn scan_plaintext_secrets_flags_literals_and_ignores_refs() {
+        let secret_fields: std::collections::BTreeSet<String> = ["api_key", "client_secret"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        // Nested shape like ai-proxy: routes[] and targets{}.
+        let config = serde_json::json!({
+            "routes": [
+                { "provider": "openai", "api_key": "sk-live-plaintext" },
+                { "provider": "ollama", "base_url": "env://OLLAMA_BASE_URL" },
+            ],
+            "targets": {
+                "claude": { "api_key": "env://ANTHROPIC_API_KEY" },
+                "azure": { "client_secret": "hunter2" },
+            },
+            "timeout": 30,
+        });
+        let mut warnings = Vec::new();
+        scan_plaintext_secrets(
+            &config,
+            "ai-proxy",
+            &secret_fields,
+            "GET /v1 in 'api.yaml'",
+            &mut warnings,
+        );
+
+        // Two plaintext secrets: routes[0].api_key and targets.azure.client_secret.
+        // routes[1].base_url is not a secret field; the env:// api_key is ignored.
+        assert_eq!(warnings.len(), 2, "got: {warnings:?}");
+        assert!(warnings.iter().all(|w| w.code == "E1070"));
+    }
+
+    #[test]
+    fn scan_plaintext_secrets_ignores_nonsecret_and_empty_fields() {
+        let secret_fields: std::collections::BTreeSet<String> =
+            ["api_key"].iter().map(|s| s.to_string()).collect();
+        let config = serde_json::json!({
+            "url": "https://api.example.com",
+            "model": "gpt-4o",
+            "api_key": "",
+        });
+        let mut warnings = Vec::new();
+        scan_plaintext_secrets(&config, "ai-proxy", &secret_fields, "loc", &mut warnings);
+        assert!(warnings.is_empty(), "got: {warnings:?}");
+    }
+
     fn create_test_spec(dir: &Path, name: &str, content: &str) -> std::path::PathBuf {
         let path = dir.join(name);
         let mut file = File::create(&path).unwrap();
@@ -1606,6 +1815,7 @@ paths:
             wasm_bytes: fake_wasm.clone(),
             body_access: false,
             host_functions: vec![],
+            secret_fields: vec![],
         }];
 
         let result = compile(

--- a/crates/barbacane-compiler/src/manifest.rs
+++ b/crates/barbacane-compiler/src/manifest.rs
@@ -63,6 +63,25 @@ fn read_plugin_metadata(wasm_path: &Path) -> Option<PluginMetadata> {
     parse_plugin_metadata(&content)
 }
 
+/// Read config-schema.json next to the WASM and return the names of fields
+/// marked `writeOnly` (secret). Best-effort: an absent or invalid schema yields
+/// an empty list (no secret-field warnings for that plugin).
+fn read_secret_fields(wasm_path: &Path) -> Vec<String> {
+    let Some(dir) = wasm_path.parent() else {
+        return Vec::new();
+    };
+    let content = match std::fs::read_to_string(dir.join("config-schema.json")) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    match serde_json::from_str::<serde_json::Value>(&content) {
+        Ok(schema) => crate::artifact::collect_writeonly_fields(&schema)
+            .into_iter()
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
 /// Resolve a WASM path from a plugin source, relative to a base path.
 fn resolve_wasm_path(path_source: &PathSource, base_path: &Path) -> std::path::PathBuf {
     if Path::new(&path_source.path).is_absolute() {
@@ -117,6 +136,15 @@ fn resolve_plugin(
             .and_then(parse_plugin_metadata),
     };
 
+    // Secret (writeOnly) config fields from config-schema.json (path plugins
+    // only; URL plugins do not fetch the schema).
+    let secret_fields = match source {
+        PluginSource::Path(path_source) => {
+            read_secret_fields(&resolve_wasm_path(path_source, base_path))
+        }
+        PluginSource::Url(_) => Vec::new(),
+    };
+
     Ok(ResolvedPlugin {
         name: name.to_string(),
         source: source.description(),
@@ -128,6 +156,7 @@ fn resolve_plugin(
             .as_ref()
             .map(|m| m.host_functions.clone())
             .unwrap_or_default(),
+        secret_fields,
     })
 }
 
@@ -251,6 +280,8 @@ pub struct ResolvedPlugin {
     pub body_access: bool,
     /// Declared capability host-function names from plugin.toml.
     pub host_functions: Vec<String>,
+    /// Config fields marked `writeOnly` (secret) in config-schema.json, if present.
+    pub secret_fields: Vec<String>,
 }
 
 impl ProjectManifest {

--- a/crates/barbacane-control/src/compiler/worker.rs
+++ b/crates/barbacane-control/src/compiler/worker.rs
@@ -274,6 +274,11 @@ async fn resolve_project_plugins(
             // plane loads them without capability enforcement (WA-1).
             body_access: false,
             host_functions: vec![],
+            // The registry doesn't persist config-schema.json, so no secret
+            // (writeOnly) fields are known here; the plaintext-secret warning
+            // (E1070) is a no-op for control-plane compiles. Same limitation as
+            // host_functions above (WA-1).
+            secret_fields: vec![],
         });
     }
 

--- a/docs/rulesets/functions/barbacane-validate-dispatch-config.js
+++ b/docs/rulesets/functions/barbacane-validate-dispatch-config.js
@@ -6,9 +6,10 @@ const schemas = {
     required: [],
     properties: {
       provider: { type: "string" },
-      api_key: { type: "string" },
+      api_key: { type: "string", writeOnly: true },
       base_url: { type: "string" },
       timeout: { type: "integer", minimum: 1 },
+      models_timeout_ms: { type: "integer", minimum: 1 },
       max_tokens: { type: "integer", minimum: 1 },
       fallback: { type: "array" },
       routes: { type: "array" },
@@ -87,8 +88,8 @@ const schemas = {
     required: ["access_key_id","secret_access_key","region"],
     properties: {
       access_key_id: { type: "string" },
-      secret_access_key: { type: "string" },
-      session_token: { type: "string" },
+      secret_access_key: { type: "string", writeOnly: true },
+      session_token: { type: "string", writeOnly: true },
       region: { type: "string" },
       endpoint: { type: "string" },
       force_path_style: { type: "boolean" },
@@ -164,6 +165,20 @@ function runRule(input) {
     for (const [key, prop] of Object.entries(schema.properties)) {
       const value = config[key];
       if (value === undefined || value === null) continue;
+
+      // Secret fields (writeOnly in config-schema.json) must not be plaintext
+      // literals — they would be baked into the artifact. Mirrors compiler E1070.
+      if (
+        prop.writeOnly &&
+        typeof value === "string" &&
+        value.length > 0 &&
+        !value.startsWith("env://") &&
+        !value.startsWith("file://")
+      ) {
+        results.push({
+          message: `Config field "${key}" for dispatcher "${pluginName}" is a secret; use an env:// or file:// reference instead of a plaintext literal so it is not baked into the artifact.`,
+        });
+      }
 
       if (typeof value === "string" && (value.startsWith("env://") || value.startsWith("file://"))) {
         continue;

--- a/docs/rulesets/functions/barbacane-validate-middleware-config.js
+++ b/docs/rulesets/functions/barbacane-validate-middleware-config.js
@@ -31,6 +31,7 @@ const schemas = {
       context_key: { type: "string" },
       default_profile: { type: "string" },
       profiles: { type: "object" },
+      fail_open: { type: "boolean" },
     },
     additionalProperties: false,
   },
@@ -53,6 +54,8 @@ const schemas = {
       profiles: { type: "object" },
       policy_name: { type: "string" },
       partition_key: { type: "string" },
+      trusted_proxies: { type: "array" },
+      fail_open: { type: "boolean" },
       count: { type: "string" },
     },
     additionalProperties: false,
@@ -155,6 +158,7 @@ const schemas = {
     properties: {
       allow: { type: "array" },
       deny: { type: "array" },
+      trusted_proxies: { type: "array" },
       message: { type: "string" },
       status: { type: "integer", minimum: 100, maximum: 599 },
     },
@@ -171,6 +175,7 @@ const schemas = {
       jwks_url: { type: "string" },
       groups_claim: { type: "string" },
       public_key_pem: { type: "string" },
+      public_key_jwk: { type: "object" },
     },
     additionalProperties: false,
   },
@@ -180,7 +185,7 @@ const schemas = {
     properties: {
       introspection_endpoint: { type: "string" },
       client_id: { type: "string" },
-      client_secret: { type: "string" },
+      client_secret: { type: "string", writeOnly: true },
       required_scopes: { type: "string" },
       timeout: { type: "number", minimum: 0 },
     },
@@ -234,6 +239,8 @@ const schemas = {
       window: { type: "integer", minimum: 1 },
       policy_name: { type: "string" },
       partition_key: { type: "string" },
+      trusted_proxies: { type: "array" },
+      fail_open: { type: "boolean" },
     },
     additionalProperties: false,
   },
@@ -331,6 +338,20 @@ function runRule(input) {
     for (const [key, prop] of Object.entries(schema.properties)) {
       const value = config[key];
       if (value === undefined || value === null) continue;
+
+      // Secret fields (writeOnly in config-schema.json) must not be plaintext
+      // literals — they would be baked into the artifact. Mirrors compiler E1070.
+      if (
+        prop.writeOnly &&
+        typeof value === "string" &&
+        value.length > 0 &&
+        !value.startsWith("env://") &&
+        !value.startsWith("file://")
+      ) {
+        results.push({
+          message: `Config field "${key}" for middleware "${pluginName}" is a secret; use an env:// or file:// reference instead of a plaintext literal so it is not baked into the artifact.`,
+        });
+      }
 
       if (typeof value === "string" && (value.startsWith("env://") || value.startsWith("file://"))) {
         continue;

--- a/docs/rulesets/generate.mjs
+++ b/docs/rulesets/generate.mjs
@@ -17,6 +17,7 @@ function formatSchemas(schemas) {
         const parts = [`type: "${v.type}"`];
         if (v.minimum !== undefined) parts.push(`minimum: ${v.minimum}`);
         if (v.maximum !== undefined) parts.push(`maximum: ${v.maximum}`);
+        if (v.writeOnly) parts.push(`writeOnly: true`);
         return `      ${k}: { ${parts.join(", ")} },`;
       })
       .join("\n");
@@ -93,6 +94,20 @@ function runRule(input) {
     for (const [key, prop] of Object.entries(schema.properties)) {
       const value = config[key];
       if (value === undefined || value === null) continue;
+
+      // Secret fields (writeOnly in config-schema.json) must not be plaintext
+      // literals — they would be baked into the artifact. Mirrors compiler E1070.
+      if (
+        prop.writeOnly &&
+        typeof value === "string" &&
+        value.length > 0 &&
+        !value.startsWith("env://") &&
+        !value.startsWith("file://")
+      ) {
+        results.push({
+          message: \`Config field "\${key}" for ${kind.toLowerCase()} "\${pluginName}" is a secret; use an env:// or file:// reference instead of a plaintext literal so it is not baked into the artifact.\`,
+        });
+      }
 
       if (typeof value === "string" && (value.startsWith("env://") || value.startsWith("file://"))) {
         continue;
@@ -183,6 +198,7 @@ for (const name of readdirSync(PLUGINS).sort()) {
     const prop = { type: v.type };
     if (v.minimum !== undefined) prop.minimum = v.minimum;
     if (v.maximum !== undefined) prop.maximum = v.maximum;
+    if (v.writeOnly === true) prop.writeOnly = true;
     simplified.properties[k] = prop;
   }
 

--- a/docs/rulesets/tests/invalid-plaintext-secret.yaml
+++ b/docs/rulesets/tests/invalid-plaintext-secret.yaml
@@ -1,0 +1,21 @@
+openapi: "3.1.0"
+info:
+  title: Plaintext secret test
+  version: "1.0.0"
+# A config field marked `writeOnly` in the plugin's config-schema.json (here
+# ai-proxy's `api_key`) must not be a plaintext literal — it would be baked into
+# the compiled artifact. The generated dispatch validator must surface this
+# (mirrors compiler warning E1070). Using an env:// / file:// reference is clean.
+paths:
+  /v1/chat/completions:
+    post:
+      operationId: chat
+      summary: Flat ai-proxy config with a plaintext api_key
+      x-barbacane-dispatch:
+        name: ai-proxy
+        config:
+          provider: openai
+          api_key: "sk-plaintext-should-warn"
+      responses:
+        "200":
+          description: OK

--- a/docs/rulesets/tests/run-tests.sh
+++ b/docs/rulesets/tests/run-tests.sh
@@ -82,6 +82,9 @@ assert_has_violations "$SCRIPT_DIR/invalid-ai-regex.yaml" "invalid-ai-regex" 4
 # ADR-0030 §0 migration UX: leftover `model:` on ai-proxy must surface at lint
 # time via the auto-generated dispatch validator (additionalProperties: false).
 assert_has_violations "$SCRIPT_DIR/invalid-ai-proxy-leftover-model.yaml" "invalid-ai-proxy-leftover-model" 1
+# A `writeOnly` (secret) config field set to a plaintext literal must be flagged
+# by the generated dispatch validator (mirrors compiler warning E1070).
+assert_has_violations "$SCRIPT_DIR/invalid-plaintext-secret.yaml" "invalid-plaintext-secret" 1
 echo ""
 
 echo "Results: $PASS passed, $FAIL failed"

--- a/plugins/ai-proxy/config-schema.json
+++ b/plugins/ai-proxy/config-schema.json
@@ -23,6 +23,7 @@
         },
         "api_key": {
           "type": "string",
+          "writeOnly": true,
           "description": "Provider API key. Use a secret reference (`env://VAR` or `file://...`) rather than a literal value, so the key is resolved at runtime and never baked into the compiled artifact. Omit for Ollama (unauthenticated local endpoint)."
         },
         "base_url": {
@@ -58,6 +59,7 @@
         },
         "api_key": {
           "type": "string",
+          "writeOnly": true,
           "description": "Provider API key. Use a secret reference (`env://VAR` or `file://...`) rather than a literal value, so the key is resolved at runtime and never baked into the compiled artifact."
         },
         "base_url": {
@@ -84,6 +86,7 @@
     },
     "api_key": {
       "type": "string",
+      "writeOnly": true,
       "description": "API key for the flat config. Use a secret reference (`env://VAR` or `file://...`) rather than a literal value, so the key is resolved at runtime and never baked into the compiled artifact."
     },
     "base_url": {

--- a/plugins/apikey-auth/config-schema.json
+++ b/plugins/apikey-auth/config-schema.json
@@ -30,6 +30,7 @@
         "properties": {
           "key": {
             "type": "string",
+            "writeOnly": true,
             "description": "The API key value. Supports secret references (e.g. env://MY_API_KEY)."
           },
           "id": {

--- a/plugins/basic-auth/config-schema.json
+++ b/plugins/basic-auth/config-schema.json
@@ -28,6 +28,7 @@
           },
           "password": {
             "type": "string",
+            "writeOnly": true,
             "description": "Password for this user. Supports secret references (e.g. env://MY_PASSWORD)."
           },
           "roles": {

--- a/plugins/oauth2-auth/config-schema.json
+++ b/plugins/oauth2-auth/config-schema.json
@@ -17,6 +17,7 @@
     },
     "client_secret": {
       "type": "string",
+      "writeOnly": true,
       "description": "Client secret for introspection request"
     },
     "required_scopes": {

--- a/plugins/s3/config-schema.json
+++ b/plugins/s3/config-schema.json
@@ -12,10 +12,12 @@
     },
     "secret_access_key": {
       "type": "string",
+      "writeOnly": true,
       "description": "AWS secret access key. Supports env:// references (e.g. env://AWS_SECRET_ACCESS_KEY)."
     },
     "session_token": {
       "type": "string",
+      "writeOnly": true,
       "description": "Session token for temporary credentials (STS / AssumeRole / IRSA). Supports env:// references."
     },
     "region": {


### PR DESCRIPTION
## What

Secret plugin-config fields set to a **plaintext literal** get baked into the compiled `.bca` at rest. This warns (non-fatal **E1070**) and recommends `env://` / `file://` references, which are resolved at runtime.

## Authoritative, not heuristic

Secret fields are declared in each plugin's `config-schema.json` with the standard JSON Schema **`writeOnly: true`** keyword (the canonical marker for sensitive/write-only values, e.g. passwords). The compiler reads `config-schema.json` next to the wasm (exactly as it already reads `plugin.toml`), collects the `writeOnly` field names, and warns when the config holds a plaintext value there. It walks nested shapes — ai-proxy `routes[]`/`targets{}`, apikey-auth `keys[]`, basic-auth `users[]`.

This replaces the earlier name-substring heuristic, which both false-positived (e.g. a `token_url`) and false-negatived (any secret not on the list). `writeOnly` is per-field human judgment in the schema — e.g. `kafka.key` is a *message* key and is deliberately **not** marked.

**Marked:** ai-proxy `api_key`, oauth2-auth `client_secret`, apikey-auth `keys[].key`, basic-auth `users[].password`, s3 `secret_access_key` + `session_token`.

## Linter alignment (per review)

- The vacuum ruleset generator now emits `writeOnly`, and the generated dispatch/middleware validators flag plaintext secrets too — so `vacuum lint` mirrors `barbacane compile`'s E1070 from the **same `writeOnly` source of truth**. (Linter covers top-level fields; the compiler additionally covers nested.)
- Regenerated the validators, which had **drifted** from the schemas (`fail_open`, `trusted_proxies`, `public_key_jwk`, `models_timeout_ms` were missing from the checked-in rulesets). Added a dedicated ruleset test.

## Scope

Closes **PL-7** — the last open item in private #7 (PL-2..PL-6 already resolved), so **#7 can close** on merge.

## Tests / verification

- Compiler unit tests: `collect_writeonly_fields` (nested), `scan_plaintext_secrets` (flags literals, ignores `env://`/empty/non-secret). Full compiler suite green (116).
- End-to-end (real CLI): plaintext ai-proxy `api_key` → E1070; `env://` → clean; apikey-auth **nested** `keys[].key` plaintext → E1070.
- Vacuum ruleset tests: 16/16 pass (added `invalid-plaintext-secret`).
