### PR TITLE
fix(wasm): WebSocket SSRF guard (completes WA-9) + security-hardening docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security**: a security testing framework — adversarial integration suite (`crates/barbacane-test/tests/security/`) and `cargo-fuzz` targets (`fuzz/`).
 - **security**: WASM sandbox resource limits — buffered plugin HTTP responses are capped (`BARBACANE_MAX_UPSTREAM_RESPONSE_BYTES`, default 16 MiB); the host cache and rate limiter bound their entry/partition counts and clamp plugin-supplied TTL/window/quota; a wall-clock epoch deadline backstops fuel-based CPU limiting.
 - **security**: ingress DoS hardening — a per-request header-read deadline (slowloris defense, doubling as the HTTP keep-alive idle timeout, wiring the previously-ignored `--keepalive-timeout`), a TLS handshake timeout, an HTTP/2 concurrent-stream cap, and a concurrent-connection ceiling (`BARBACANE_MAX_CONNECTIONS`, default 10000).
+- **security**: plugin outbound HTTP drops attacker-controllable `Host` and hop-by-hop / message-framing headers (`Content-Length`, `Transfer-Encoding`, `Connection`, …), preventing routing confusion and request smuggling. `Authorization` is still allowed so dispatchers can authenticate to their upstream.
+- **security**: the plugin HTTP SSRF guard is now DNS-rebinding safe — a custom resolver filters internal addresses at connection time, so the vetted IP is the one actually connected to.
+- **security**: WebSocket upstreams (`host_ws_upgrade`) are covered by the SSRF guard (internal/metadata targets blocked unless `BARBACANE_ALLOW_INTERNAL_EGRESS`).
+- **security**: `barbacane compile` warns (E1070) when a plugin config field marked `writeOnly` in its `config-schema.json` (a secret) is set to a plaintext literal instead of an `env://` / `file://` reference; the vacuum ruleset flags the same at lint time.
 - **docs**: [Configuration & environment variables](reference/configuration.md) reference.
 
 ### Changed (breaking, secure-by-default)
@@ -24,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The control plane refuses to start without `BARBACANE_CONTROL_ADMIN_TOKEN`, and all API routes (except `/health` and the data-plane WebSocket) require the bearer token.
 - `file://` secret references require `BARBACANE_SECRETS_DIR` and are confined to it.
 - MCP requires a valid session for non-`initialize` requests.
-- Plugin egress to internal/metadata addresses is blocked by default — this now covers Kafka/NATS broker connections in addition to plugin HTTP calls.
+- Plugin egress to internal/metadata addresses is blocked by default — this now covers Kafka/NATS broker connections and WebSocket upstreams in addition to plugin HTTP calls.
 
 ### Fixed
 
@@ -34,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security**: chunked request bodies with no `Content-Length` are now size-capped while streaming (`http_body_util::Limited`) instead of being fully buffered before the limit check.
 - **plugin**: `jwt-auth` and `oidc-auth` now declare the `log` capability they use, so they load under WASM capability enforcement (they emit a one-time warning when no `audience` is configured).
 - **ci**: the adversarial security suite (`crates/barbacane-test/tests/security/`) now runs in CI.
+- **ci**: the full `barbacane-test` integration suite (every `tests/*.rs` binary) now runs in CI instead of only the crate's lib tests, repairing ~21 integration tests that had rotted while excluded.
+- **wasm**: blocking host calls (broker publish, HTTP call/stream) no longer count their network wait against the plugin's wall-clock execution deadline — a slow/unavailable upstream now returns a clean error (e.g. broker-unavailable → 502) instead of trapping the dispatch (500). The CPU guard on actual WASM execution is unchanged.
 - **security (control plane)**: request-body size limits — 1 MiB default for JSON endpoints, 32 MiB for spec/plugin uploads — bound in-memory buffering; database errors are routed through the generic error mapper (no schema disclosure); upload filenames are sanitized to a safe basename (defeating path traversal into the compile temp dir and CRLF/quote injection in `Content-Disposition`); and concurrent WebSocket sessions are capped so unauthenticated sockets can't pile up during the registration window.
 - **security (data plane)**: a single canonical, UTF-8-correct percent-decoder is applied to query and path parameters before validation and dispatch (the previous per-byte decode corrupted multi-byte sequences); request header limits are enforced on the raw header map so duplicate header names can't undercount the header limit or skip per-value size checks; and the unauthenticated admin port (`/health`, `/metrics`, `/provenance`) logs a startup warning when bound to a non-loopback address.
 - **deps**: bump `anyhow` to 1.0.103 (RUSTSEC-2026-0190).

--- a/crates/barbacane-wasm/src/ws_client.rs
+++ b/crates/barbacane-wasm/src/ws_client.rs
@@ -31,7 +31,33 @@ fn default_connect_timeout_ms() -> u64 {
 ///
 /// Returns the established WebSocket stream on success, or an error string
 /// on failure (to be stored in `last_http_result` for the plugin to read).
-pub async fn connect_upstream(req: WsUpgradeRequest) -> Result<UpstreamWsStream, String> {
+pub async fn connect_upstream(
+    req: WsUpgradeRequest,
+    allow_internal_egress: bool,
+) -> Result<UpstreamWsStream, String> {
+    // SSRF guard: resolve the upstream host and refuse internal / loopback /
+    // link-local / cloud-metadata targets unless egress is explicitly allowed.
+    // Mirrors the HTTP and broker guards so a plugin can't reach internal
+    // services over ws:// / wss://.
+    let parsed = reqwest::Url::parse(&req.url)
+        .map_err(|e| format!("invalid WebSocket URL '{}': {}", req.url, e))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| format!("WebSocket URL '{}' has no host", req.url))?;
+    let port = parsed.port_or_known_default().unwrap_or(0);
+    if let Err(e) = crate::http_client::guard_external_host(host, port, allow_internal_egress).await
+    {
+        return Err(match e {
+            crate::http_client::HostGuardError::Blocked(h) => format!(
+                "WebSocket target '{h}' is an internal address; set \
+                 BARBACANE_ALLOW_INTERNAL_EGRESS to allow"
+            ),
+            crate::http_client::HostGuardError::Resolve(m) => {
+                format!("WebSocket target resolution failed: {m}")
+            }
+        });
+    }
+
     // Build the request with custom headers
     let mut ws_request = req
         .url
@@ -60,5 +86,28 @@ pub async fn connect_upstream(req: WsUpgradeRequest) -> Result<UpstreamWsStream,
             "WebSocket connection timed out after {}ms",
             req.connect_timeout_ms
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn connect_upstream_blocks_internal_target_when_egress_disallowed() {
+        let req = WsUpgradeRequest {
+            url: "ws://127.0.0.1:9/".to_string(),
+            connect_timeout_ms: 1000,
+            headers: BTreeMap::new(),
+        };
+        // Egress disallowed: the SSRF guard must reject the loopback target
+        // before any connection attempt.
+        let err = connect_upstream(req, false)
+            .await
+            .expect_err("loopback must be blocked when egress is disallowed");
+        assert!(
+            err.contains("internal address"),
+            "expected SSRF block, got: {err}"
+        );
     }
 }

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -658,6 +658,10 @@ struct Gateway {
     /// Request limits (body size, headers, URI length).
     limits: RequestLimits,
     dev_mode: bool,
+    /// Whether plugin egress to internal/loopback/metadata targets is allowed
+    /// (BARBACANE_ALLOW_INTERNAL_EGRESS). The HTTP/broker clients carry their own
+    /// copy; this one guards WebSocket upstream connections.
+    allow_internal_egress: bool,
     /// WASM engine for plugin execution (kept alive for engine lifetime).
     _wasm_engine: Arc<WasmEngine>,
     /// Plugin instance pool.
@@ -952,6 +956,7 @@ impl Gateway {
             specs,
             limits,
             dev_mode,
+            allow_internal_egress,
             _wasm_engine: wasm_engine,
             plugin_pool: Arc::new(plugin_pool),
             _plugin_limits: plugin_limits,
@@ -2038,20 +2043,24 @@ impl Gateway {
                     // This MUST happen here (not in a temporary runtime) so the
                     // TcpStream is registered with the I/O driver that will drive
                     // the relay task.
-                    let ws_upstream =
-                        match barbacane_wasm::ws_client::connect_upstream(ws_request).await {
-                            Ok(stream) => stream,
-                            Err(err) => {
-                                tracing::warn!(
-                                    error = %err,
-                                    "WebSocket upstream connection failed"
-                                );
-                                return Err(self.dev_error_response(format_args!(
-                                    "WebSocket upstream connection failed: {}",
-                                    err
-                                )));
-                            }
-                        };
+                    let ws_upstream = match barbacane_wasm::ws_client::connect_upstream(
+                        ws_request,
+                        self.allow_internal_egress,
+                    )
+                    .await
+                    {
+                        Ok(stream) => stream,
+                        Err(err) => {
+                            tracing::warn!(
+                                error = %err,
+                                "WebSocket upstream connection failed"
+                            );
+                            return Err(self.dev_error_response(format_args!(
+                                "WebSocket upstream connection failed: {}",
+                                err
+                            )));
+                        }
+                    };
 
                     // Run on_response for observability (modifications discarded).
                     if !middleware_instances.is_empty() {

--- a/docs/contributing/plugins.md
+++ b/docs/contributing/plugins.md
@@ -135,6 +135,27 @@ host_functions = ["log"]
 }
 ```
 
+Mark any field that carries a secret (API key, password, token, client secret)
+with `"writeOnly": true` — the standard JSON Schema keyword for sensitive
+values:
+
+```json
+"api_key": {
+  "type": "string",
+  "writeOnly": true,
+  "description": "Provider API key. Use a secret reference (env://VAR or file://...)."
+}
+```
+
+`barbacane compile` then warns (**E1070**) — and the vacuum linter flags — when
+such a field is set to a plaintext literal instead of an `env://` / `file://`
+reference, so credentials are never baked into the compiled artifact. The
+detection is nested-aware (arrays and maps of objects). Do **not** mark
+non-secret fields (e.g. a message-key expression) `writeOnly`.
+
+After changing `config-schema.json`, regenerate the vacuum ruleset validators
+(`node docs/rulesets/generate.mjs`) and run `docs/rulesets/tests/run-tests.sh`.
+
 ### 6. Build
 
 ```bash

--- a/docs/guide/secrets.md
+++ b/docs/guide/secrets.md
@@ -260,6 +260,22 @@ error: failed to resolve secrets: unsupported secret scheme: vault
 
 This means you're using a scheme that isn't implemented yet. Currently only `env://` and `file://` are supported.
 
+## Compile-time detection
+
+Plugin config fields that hold secrets are marked `writeOnly` in the plugin's
+schema (`api_key`, `client_secret`, passwords, provider keys, etc.). If you set
+one to a **plaintext literal** instead of an `env://` / `file://` reference,
+`barbacane compile` warns:
+
+```
+warning[E1070]: plugin 'ai-proxy' config field 'api_key' is a secret but is set
+to a plaintext literal; use an env:// or file:// reference so it is resolved at
+runtime instead of baked into the artifact
+```
+
+The [vacuum linter](vacuum.md) flags the same thing at lint time. This keeps
+plaintext credentials out of the compiled `.bca`.
+
 ## Security Considerations
 
 1. **Never commit secrets to Git** - Use `.gitignore` for `.env` files

--- a/docs/guide/vacuum.md
+++ b/docs/guide/vacuum.md
@@ -22,9 +22,10 @@ Several rules use custom JavaScript functions (config schema validation, duplica
 ```bash
 mkdir -p .barbacane/rulesets/functions .barbacane/rulesets/schemas
 curl -fsSL https://docs.barbacane.dev/rulesets/barbacane.yaml -o .barbacane/rulesets/barbacane.yaml
-for f in barbacane-auth-opt-out barbacane-no-duplicate-middlewares barbacane-no-plaintext-upstream \
+for f in barbacane-auth-opt-out barbacane-mcp-requires-fields barbacane-no-plaintext-upstream \
          barbacane-no-unknown-extensions barbacane-valid-path-params barbacane-valid-secret-refs \
-         barbacane-validate-dispatch-config barbacane-validate-middleware-config; do
+         barbacane-validate-ai-regex barbacane-validate-dispatch-config \
+         barbacane-validate-middleware-config; do
   curl -fsSL "https://docs.barbacane.dev/rulesets/functions/${f}.js" -o ".barbacane/rulesets/functions/${f}.js"
 done
 ```
@@ -92,6 +93,7 @@ The same rules apply to operation-level middlewares (`barbacane-op-middleware-*`
 |------|----------|-------------|
 | `barbacane-no-plaintext-upstream` | warn | `http-upstream` URLs should use HTTPS |
 | `barbacane-secret-ref-format` | error | Secret references must match `env://VAR_NAME` or `file:///path` |
+| `barbacane-dispatch-config-valid` / `barbacane-middleware-config-valid` | warn | A secret field (marked `writeOnly` in the plugin schema) set to a plaintext literal should use an `env://` / `file://` reference instead (mirrors compiler warning E1070) |
 
 ### Auth Safety
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -15,7 +15,7 @@ insecurely.
 | `BARBACANE_TRUSTED_PUBKEY` | Data plane | _unset_ | Hex-encoded Ed25519 public key. When set, the data plane requires every loaded `.bca` artifact to carry a valid signature produced by the matching private key; load fails otherwise. When unset, the artifact's content hashes are still verified, but signature checking is skipped (a startup warning is logged). |
 | `BARBACANE_SIGNING_KEY` | Compiler | _unset_ | Path to a PKCS#8 Ed25519 private key. When set, `barbacane compile` signs the artifact's content hash. When unset, the artifact is built unsigned. |
 | `BARBACANE_SECRETS_DIR` | Data plane | _unset_ | Base directory that `file://` secret references are confined to. **Required to use `file://` secrets** — references are rejected when it is unset, and any path resolving outside this directory (after symlink/`..` resolution) is rejected. |
-| `BARBACANE_ALLOW_INTERNAL_EGRESS` | Data plane | `false` | Set to `1`/`true` to disable the plugin SSRF guard and allow plugin egress (HTTP calls **and** Kafka/NATS broker connections) to internal/loopback/link-local/cloud-metadata addresses. Leave off unless you have legitimate internal upstreams or brokers. |
+| `BARBACANE_ALLOW_INTERNAL_EGRESS` | Data plane | `false` | Set to `1`/`true` to disable the plugin SSRF guard and allow plugin egress (HTTP calls, Kafka/NATS broker connections, **and** WebSocket upstreams) to internal/loopback/link-local/cloud-metadata addresses. The HTTP guard also pins the vetted IP at connect time (DNS-rebinding safe). Leave off unless you have legitimate internal upstreams or brokers. |
 | `BARBACANE_MAX_UPSTREAM_RESPONSE_BYTES` | Data plane | `16777216` (16 MiB) | Maximum size of an upstream response body that the buffered plugin HTTP-call path will read into host memory. Bodies larger than this are rejected, bounding host memory against a hostile or compromised upstream. Streaming dispatchers are unaffected. |
 | `BARBACANE_MAX_CONNECTIONS` | Data plane | `10000` | Maximum number of concurrently served ingress connections. Beyond this, new connections are dropped (load shed) rather than letting file descriptors and tasks grow without bound under a connection flood. |
 
@@ -35,9 +35,9 @@ These changes are intentional secure defaults. Adopt them as follows:
    (`tools/list`, `tools/call`, …) without a valid `Mcp-Session-Id` are now
    rejected; call `initialize` first and reuse the returned session id.
 
-4. **Plugin egress to internal addresses is blocked by default.** This now
-   covers both plugin HTTP calls and Kafka/NATS broker connections. If a plugin
-   legitimately reaches an internal upstream or broker, set
+4. **Plugin egress to internal addresses is blocked by default.** This covers
+   plugin HTTP calls, Kafka/NATS broker connections, and WebSocket upstreams. If
+   a plugin legitimately reaches an internal upstream or broker, set
    `BARBACANE_ALLOW_INTERNAL_EGRESS=1` (or prefer an explicit allowlist when one
    is available).
 


### PR DESCRIPTION
## What

`host_ws_upgrade` connected to any `ws://`/`wss://` URL a plugin supplied **with no egress check**, so a plugin could reach internal / loopback / cloud-metadata services over WebSocket — bypassing the SSRF guard that already covers HTTP and Kafka/NATS.

## Fix

`ws_client::connect_upstream` now resolves the upstream host and refuses internal targets via the shared `guard_external_host`, unless `BARBACANE_ALLOW_INTERNAL_EGRESS` is set. The egress policy is threaded from the `Gateway`.

## Scope

Completes the broker/WS egress-guard portion of **WA-9** (private #3). Kafka and NATS already guard + time out + bound their connection caches; the HTTP outbound-header denylist landed in #99. After this, #3's only remaining item is the optional WA-5 bounded worker pool (per-call timeouts + the epoch-deadline refresh already mitigate the "pin a worker" concern).

## Tests

- Unit: `connect_upstream` blocks a loopback target when egress is disallowed.
- Existing ws-upstream integration tests (egress allowed) still reach loopback mocks — all 6 green locally.
- Workspace clippy + `cargo check --workspace --lib --bins` clean.