### PR TITLE
fix(wasm): scope host_get_secret to each plugin's own secrets (WA-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/barbacane-wasm/src/pool.rs
+++ b/crates/barbacane-wasm/src/pool.rs
@@ -4,6 +4,7 @@
 //! separate WASM instance. Under load, instances are cloned from the
 //! AOT-compiled module.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -101,6 +102,11 @@ pub struct InstancePool {
 
     /// Plugin configs by key.
     configs: DashMap<InstanceKey, Vec<u8>>,
+
+    /// Secret references (env://… / file://…) each plugin declares in its config,
+    /// keyed by plugin name. Used to scope `host_get_secret` to a plugin's own
+    /// secrets (WA-3). A plugin absent from this map gets an empty secrets store.
+    secret_refs_by_plugin: HashMap<String, HashSet<String>>,
 }
 
 impl InstancePool {
@@ -118,6 +124,7 @@ impl InstancePool {
             modules: DashMap::new(),
             instances: DashMap::new(),
             configs: DashMap::new(),
+            secret_refs_by_plugin: HashMap::new(),
         }
     }
 
@@ -139,6 +146,7 @@ impl InstancePool {
             modules: DashMap::new(),
             instances: DashMap::new(),
             configs: DashMap::new(),
+            secret_refs_by_plugin: HashMap::new(),
         }
     }
 
@@ -161,6 +169,7 @@ impl InstancePool {
             modules: DashMap::new(),
             instances: DashMap::new(),
             configs: DashMap::new(),
+            secret_refs_by_plugin: HashMap::new(),
         }
     }
 
@@ -188,7 +197,15 @@ impl InstancePool {
             modules: DashMap::new(),
             instances: DashMap::new(),
             configs: DashMap::new(),
+            secret_refs_by_plugin: HashMap::new(),
         }
+    }
+
+    /// Set the per-plugin secret reference scopes (WA-3). Chain after a
+    /// constructor: `InstancePool::with_all_options(..).with_secret_scopes(map)`.
+    pub fn with_secret_scopes(mut self, scopes: HashMap<String, HashSet<String>>) -> Self {
+        self.secret_refs_by_plugin = scopes;
+        self
     }
 
     /// Register a compiled module in the pool.
@@ -216,13 +233,23 @@ impl InstancePool {
             .get(key)
             .ok_or_else(|| WasmError::InitFailed(format!("config not found for: {}", key.name)))?;
 
+        // Scope host_get_secret to this plugin's own config references (WA-3):
+        // a plugin can resolve the secrets it declares, not another plugin's.
+        let scoped_secrets = self.secrets.as_ref().map(|store| {
+            match self.secret_refs_by_plugin.get(&key.name) {
+                Some(refs) => store.scoped(refs),
+                // Plugin declared no secret references -> empty store (default-deny).
+                None => store.scoped(&HashSet::new()),
+            }
+        });
+
         // Create a new instance with all options
         let mut instance = PluginInstance::new_with_all_options(
             self.engine.engine(),
             &module,
             self.limits.clone(),
             self.http_client.clone(),
-            self.secrets.clone(),
+            scoped_secrets,
             self.rate_limiter.clone(),
             self.response_cache.clone(),
             self.nats_publisher.clone(),

--- a/crates/barbacane-wasm/src/secrets.rs
+++ b/crates/barbacane-wasm/src/secrets.rs
@@ -6,7 +6,7 @@
 //!
 //! Future: `vault://`, `aws-sm://`, `k8s://` references.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use thiserror::Error;
@@ -56,6 +56,21 @@ impl SecretsStore {
     /// Get a secret by its reference.
     pub fn get(&self, reference: &str) -> Option<&String> {
         self.secrets.get(reference)
+    }
+
+    /// Return a new store containing only the references in `allowed`.
+    ///
+    /// Used to scope `host_get_secret` to a single plugin's own config
+    /// references (WA-3): a plugin can resolve the secrets it declares in its
+    /// config, but not another plugin's secrets held in the shared store.
+    pub fn scoped(&self, allowed: &HashSet<String>) -> Self {
+        let scoped: HashMap<String, String> = self
+            .secrets
+            .iter()
+            .filter(|(k, _)| allowed.contains(*k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        Self::from_map(scoped)
     }
 
     /// Check if a reference exists in the store.
@@ -249,6 +264,31 @@ pub fn resolve_all_secrets(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn scoped_store_only_exposes_allowed_references() {
+        let mut all = HashMap::new();
+        all.insert("env://PLUGIN_A_KEY".to_string(), "a-secret".to_string());
+        all.insert("env://PLUGIN_B_KEY".to_string(), "b-secret".to_string());
+        let store = SecretsStore::from_map(all);
+
+        // Plugin A is scoped to only its own reference.
+        let allowed: HashSet<String> = ["env://PLUGIN_A_KEY".to_string()].into_iter().collect();
+        let scoped = store.scoped(&allowed);
+
+        assert_eq!(
+            scoped.get("env://PLUGIN_A_KEY").map(String::as_str),
+            Some("a-secret")
+        );
+        // ...and cannot read plugin B's secret from the shared store.
+        assert!(scoped.get("env://PLUGIN_B_KEY").is_none());
+
+        // An empty scope (plugin declared no secrets) exposes nothing.
+        assert!(store
+            .scoped(&HashSet::new())
+            .get("env://PLUGIN_A_KEY")
+            .is_none());
+    }
 
     #[test]
     fn test_is_secret_reference() {

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -51,7 +51,7 @@ const SERVER_VERSION: &str = concat!("barbacane/", env!("CARGO_PKG_VERSION"));
 const UNMATCHED_ROUTE_LABEL: &str = "<unmatched>";
 
 use barbacane_telemetry::MetricsRegistry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use barbacane_compiler::{
     compile_with_manifest, load_manifest, load_plugins, load_routes, load_specs, CompileOptions,
@@ -843,6 +843,26 @@ impl Gateway {
                 format!("failed to resolve secrets: {}", messages.join(", "))
             })?;
 
+        // WA-3: map each plugin name to the secret references in its own config
+        // (collected from the raw, pre-substitution configs), so the pool can
+        // scope host_get_secret per plugin — a plugin can resolve the secrets it
+        // declares, not another plugin's secrets held in the shared store.
+        let mut secret_refs_by_plugin: HashMap<String, HashSet<String>> = HashMap::new();
+        for op in &routes.operations {
+            for mw in &op.middlewares {
+                secret_refs_by_plugin
+                    .entry(mw.name.clone())
+                    .or_default()
+                    .extend(barbacane_wasm::collect_secret_references(&mw.config));
+            }
+            secret_refs_by_plugin
+                .entry(op.dispatch.name.clone())
+                .or_default()
+                .extend(barbacane_wasm::collect_secret_references(
+                    &op.dispatch.config,
+                ));
+        }
+
         // Replace secret references in route configs with resolved values
         let mut resolved_operations = routes.operations;
         for op in &mut resolved_operations {
@@ -878,7 +898,8 @@ impl Gateway {
             Some(response_cache),
             Some(Arc::new(nats_publisher)),
             Some(Arc::new(kafka_publisher)),
-        );
+        )
+        .with_secret_scopes(secret_refs_by_plugin);
 
         // Register all compiled modules in the pool
         for (name, version, module) in compiled_modules {


### PR DESCRIPTION
## What

All plugin instances shared one `SecretsStore`, so any plugin with the `get_secret` capability could read **another plugin's** resolved secret by reference name.

Config-substituted secrets are already per-plugin scoped (each config only gets its own refs resolved); this closes the **`host_get_secret`** path. Defense-in-depth: no official plugin currently declares `get_secret`, but a custom/third-party one could.

## How

- In `main.rs`, collect each plugin's secret references from its **own config** (before substitution) into a `plugin name -> {refs}` map, and pass it to the instance pool (`.with_secret_scopes(..)`).
- `InstancePool::get_instance` hands each instance a `SecretsStore` **scoped** to that plugin's references (new `SecretsStore::scoped`). A plugin with no declared references gets an **empty** store (default-deny).

Scope granularity: **per plugin name** (union across its config instances) — a plugin can't read a *different* plugin's secrets.

## Scope

Addresses **WA-3** (private #5). WA-1 capability enforcement (`validate_imports` at load, default-deny on undeclared imports) is already wired; the per-plugin default-deny *linker* remains as optional defense-in-depth.

## Tests

- Unit: `scoped()` exposes only allowed refs; empty scope exposes nothing.
- Config-substitution path unchanged — auth secrets integration tests green; workspace clippy + check clean.