### PR TITLE
fix(control-plane): enforce data-plane:connect scope on WS connect (CP-2)

### DIFF
--- a/crates/barbacane-control/src/api/auth.rs
+++ b/crates/barbacane-control/src/api/auth.rs
@@ -24,6 +24,18 @@ use sha2::{Digest, Sha256};
 
 use crate::error::ProblemDetails;
 
+/// API-key scopes (`api_keys.scopes`). A key being valid for a project is not
+/// sufficient — it must also carry the scope required by the action it performs.
+pub mod scopes {
+    /// Permits a data plane to register and connect over `/ws/data-plane`.
+    pub const DATA_PLANE_CONNECT: &str = "data-plane:connect";
+}
+
+/// Whether an API key's granted `scopes` include `required`.
+pub fn key_has_scope(scopes: &[String], required: &str) -> bool {
+    scopes.iter().any(|s| s == required)
+}
+
 /// Authentication policy applied to protected control-plane routes.
 #[derive(Clone)]
 pub enum AdminAuth {
@@ -102,5 +114,26 @@ pub async fn require_admin(
             axum::http::HeaderValue::from_static("Bearer"),
         );
         response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_has_scope_matches_exactly() {
+        let scopes = vec!["data-plane:connect".to_string(), "project:read".to_string()];
+        assert!(key_has_scope(&scopes, scopes::DATA_PLANE_CONNECT));
+        assert!(key_has_scope(&scopes, "project:read"));
+        // No partial / prefix matching.
+        assert!(!key_has_scope(&scopes, "data-plane"));
+        assert!(!key_has_scope(&scopes, "project:write"));
+        // A key without the scope is rejected.
+        assert!(!key_has_scope(
+            &["project:read".to_string()],
+            scopes::DATA_PLANE_CONNECT
+        ));
+        assert!(!key_has_scope(&[], scopes::DATA_PLANE_CONNECT));
     }
 }

--- a/crates/barbacane-control/src/api/ws/handler.rs
+++ b/crates/barbacane-control/src/api/ws/handler.rs
@@ -86,6 +86,19 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
         return;
     }
 
+    // Enforce the data-plane:connect scope: a key valid for the project must
+    // also be authorized for this action (api_keys.scopes), not merely exist.
+    if !crate::api::auth::key_has_scope(
+        &api_key.scopes,
+        crate::api::auth::scopes::DATA_PLANE_CONNECT,
+    ) {
+        let msg = ControlPlaneMessage::RegistrationFailed {
+            reason: "API key lacks the data-plane:connect scope".to_string(),
+        };
+        let _ = sender.send(to_ws_message(&msg)).await;
+        return;
+    }
+
     // Create data plane record
     let data_planes_repo = DataPlanesRepository::new(state.pool.clone());
     let data_plane = match data_planes_repo


### PR DESCRIPTION
## What

`api_keys` carry a `scopes` array, but `/ws/data-plane` accepted **any** valid, project-matching key regardless of its scopes. Now the key must carry the **`data-plane:connect`** scope before a data plane registers — being valid for the project is not enough; the key must be *authorized* for the action.

## Change

- New `api::auth::scopes` module (scope constants) + a testable `key_has_scope()` helper (exact match, no prefix).
- WS handler checks the scope after the existing project-ownership check.

## Scope

Addresses the **actionable** part of **CP-2** (private #8). The other #8 items — CP-3 (DB error leakage), CP-4 (upload body limits), CP-6 (WS pre-auth cap + filename sanitize) — already landed in #96.

The REST-side project-ownership guard from CP-2 is **not reachable today**: the control plane is single-tenant in practice (one admin token; all resources use the default project, e.g. `store_spec(.., DEFAULT_PROJECT_ID)`). That guard is future-proofing for multi-tenant REST auth and is best built alongside the API-key REST-auth branch (its non-admin caller is what makes the guard non-trivial). Noted on the issue.

## Tests

Unit test for `key_has_scope` (exact match, absent scope, empty). Workspace clippy + check clean.