### PR TITLE
fix(mcp): validate path-param substitution and cap unauthenticated sessions

### DIFF
--- a/crates/barbacane/src/mcp/jsonrpc.rs
+++ b/crates/barbacane/src/mcp/jsonrpc.rs
@@ -36,6 +36,7 @@ pub const PARSE_ERROR: i32 = -32700;
 pub const INVALID_REQUEST: i32 = -32600;
 pub const METHOD_NOT_FOUND: i32 = -32601;
 pub const INVALID_PARAMS: i32 = -32602;
+pub const INTERNAL_ERROR: i32 = -32603;
 
 impl JsonRpcResponse {
     pub fn success(id: Option<serde_json::Value>, result: serde_json::Value) -> Self {

--- a/crates/barbacane/src/mcp/mod.rs
+++ b/crates/barbacane/src/mcp/mod.rs
@@ -13,7 +13,8 @@ use std::time::Duration;
 use barbacane_compiler::{CompiledOperation, McpConfig};
 
 use self::jsonrpc::{
-    JsonRpcRequest, JsonRpcResponse, INVALID_PARAMS, INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR,
+    JsonRpcRequest, JsonRpcResponse, INTERNAL_ERROR, INVALID_PARAMS, INVALID_REQUEST,
+    METHOD_NOT_FOUND, PARSE_ERROR,
 };
 use self::session::SessionStore;
 use self::tools::{McpTool, ToolEntry};
@@ -129,11 +130,22 @@ impl McpServer {
 
         match req.method.as_str() {
             "initialize" => {
-                let client_info = req
-                    .params
-                    .as_ref()
-                    .and_then(|p| p.get("clientInfo").cloned());
-                let new_session_id = self.session_store.create(client_info);
+                // Do not retain the attacker-controlled `clientInfo` blob; it was
+                // unused and only amplified the session-exhaustion vector (MCP-2).
+                let new_session_id = match self.session_store.create() {
+                    Some(id) => id,
+                    None => {
+                        let resp = JsonRpcResponse::error(
+                            req.id,
+                            INTERNAL_ERROR,
+                            "session capacity reached; retry later",
+                        );
+                        return McpResult::Response {
+                            body: serde_json::to_vec(&resp).unwrap_or_default(),
+                            session_id: None,
+                        };
+                    }
+                };
                 let resp = JsonRpcResponse::success(
                     req.id,
                     serde_json::json!({
@@ -230,7 +242,16 @@ impl McpServer {
             .cloned()
             .unwrap_or(serde_json::json!({}));
 
-        let (path, query, body) = tools::decompose_arguments(entry, &arguments);
+        let (path, query, body) = match tools::decompose_arguments(entry, &arguments) {
+            Ok(parts) => parts,
+            Err(msg) => {
+                let resp = JsonRpcResponse::error(req.id, INVALID_PARAMS, msg);
+                return McpResult::Response {
+                    body: serde_json::to_vec(&resp).unwrap_or_default(),
+                    session_id: None,
+                };
+            }
+        };
 
         McpResult::NeedsDispatch {
             operation_index: entry.operation_index,
@@ -363,7 +384,7 @@ mod tests {
     #[test]
     fn tools_list_returns_mcp_enabled_tools() {
         let server = make_server();
-        let sid = server.session_store.create(None);
+        let sid = server.session_store.create().expect("under cap");
         let body = br#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#;
         match server.handle_request(body, Some(&sid)) {
             McpResult::Response {
@@ -382,7 +403,7 @@ mod tests {
     #[test]
     fn tools_call_returns_needs_dispatch() {
         let server = make_server();
-        let sid = server.session_store.create(None);
+        let sid = server.session_store.create().expect("under cap");
         let body =
             br#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"getHealth"}}"#;
         match server.handle_request(body, Some(&sid)) {
@@ -401,7 +422,7 @@ mod tests {
     #[test]
     fn tools_call_unknown_tool() {
         let server = make_server();
-        let sid = server.session_store.create(None);
+        let sid = server.session_store.create().expect("under cap");
         let body =
             br#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"nonexistent"}}"#;
         match server.handle_request(body, Some(&sid)) {
@@ -419,7 +440,7 @@ mod tests {
     #[test]
     fn unknown_method_returns_error() {
         let server = make_server();
-        let sid = server.session_store.create(None);
+        let sid = server.session_store.create().expect("under cap");
         let body = br#"{"jsonrpc":"2.0","id":4,"method":"resources/list"}"#;
         match server.handle_request(body, Some(&sid)) {
             McpResult::Response {
@@ -446,7 +467,7 @@ mod tests {
     #[test]
     fn ping_returns_empty_result() {
         let server = make_server();
-        let sid = server.session_store.create(None);
+        let sid = server.session_store.create().expect("under cap");
         let body = br#"{"jsonrpc":"2.0","id":5,"method":"ping"}"#;
         match server.handle_request(body, Some(&sid)) {
             McpResult::Response {
@@ -560,7 +581,7 @@ mod tests {
     #[test]
     fn tools_call_missing_name_field() {
         let server = make_server();
-        let sid = server.session_store.create(None);
+        let sid = server.session_store.create().expect("under cap");
         let body = br#"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{}}"#;
         match server.handle_request(body, Some(&sid)) {
             McpResult::Response {
@@ -614,7 +635,7 @@ mod tests {
             server_version: None,
         };
         let server = McpServer::new(&ops, &config);
-        let sid = server.session_store.create(None);
+        let sid = server.session_store.create().expect("under cap");
 
         let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"getUser","arguments":{"id":"123"}}}"#;
         match server.handle_request(body, Some(&sid)) {
@@ -627,6 +648,20 @@ mod tests {
                 assert_eq!(path, "/users/123");
             }
             _ => panic!("expected NeedsDispatch"),
+        }
+
+        // MCP-1: a path-traversal argument is rejected before dispatch, so it can
+        // never reach an upstream resource that isn't exposed as a tool.
+        let evil = br#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"getUser","arguments":{"id":"../admin/secrets"}}}"#;
+        match server.handle_request(evil, Some(&sid)) {
+            McpResult::Response {
+                body: resp_body, ..
+            } => {
+                let json: serde_json::Value =
+                    serde_json::from_slice(&resp_body).expect("valid json");
+                assert_eq!(json["error"]["code"], INVALID_PARAMS);
+            }
+            _ => panic!("expected INVALID_PARAMS Response, not dispatch"),
         }
     }
 }

--- a/crates/barbacane/src/mcp/session.rs
+++ b/crates/barbacane/src/mcp/session.rs
@@ -4,9 +4,20 @@ use std::time::{Duration, Instant};
 use parking_lot::Mutex;
 use uuid::Uuid;
 
+/// Maximum number of concurrent MCP sessions. `initialize` is unauthenticated,
+/// so without a cap a remote client could create sessions without bound and
+/// exhaust memory before TTL eviction runs (MCP-2). When the cap is reached we
+/// first drop expired sessions; if the store is still full, `create` fails
+/// closed rather than growing unbounded.
+const MAX_SESSIONS: usize = 10_000;
+
 /// MCP session state.
+///
+/// Deliberately holds no client-supplied data: the `clientInfo` blob from
+/// `initialize` is attacker-controlled and was previously retained here unused,
+/// amplifying the unauthenticated-session memory-exhaustion vector (MCP-2). Only
+/// the activity timestamp needed for TTL eviction is kept.
 struct McpSession {
-    _client_info: Option<serde_json::Value>,
     last_active: Instant,
 }
 
@@ -24,15 +35,26 @@ impl SessionStore {
         }
     }
 
-    /// Create a new session and return its ID.
-    pub fn create(&self, client_info: Option<serde_json::Value>) -> String {
+    /// Create a new session and return its ID, or `None` if the session cap is
+    /// reached even after evicting expired sessions (fail closed).
+    pub fn create(&self) -> Option<String> {
+        let mut sessions = self.sessions.lock();
+        if sessions.len() >= MAX_SESSIONS {
+            // Reclaim expired sessions before giving up.
+            let now = Instant::now();
+            sessions.retain(|_, session| now.duration_since(session.last_active) < self.ttl);
+            if sessions.len() >= MAX_SESSIONS {
+                return None;
+            }
+        }
         let id = Uuid::new_v4().to_string();
-        let session = McpSession {
-            _client_info: client_info,
-            last_active: Instant::now(),
-        };
-        self.sessions.lock().insert(id.clone(), session);
-        id
+        sessions.insert(
+            id.clone(),
+            McpSession {
+                last_active: Instant::now(),
+            },
+        );
+        Some(id)
     }
 
     /// Touch a session (update last_active). Returns false if session doesn't exist.
@@ -79,7 +101,7 @@ mod tests {
     #[test]
     fn create_and_touch() {
         let store = SessionStore::new(Duration::from_secs(60));
-        let id = store.create(None);
+        let id = store.create().expect("under cap");
         assert!(store.touch(&id));
         assert!(!store.touch("nonexistent"));
         assert_eq!(store.len(), 1);
@@ -88,7 +110,7 @@ mod tests {
     #[test]
     fn remove_session() {
         let store = SessionStore::new(Duration::from_secs(60));
-        let id = store.create(None);
+        let id = store.create().expect("under cap");
         assert_eq!(store.len(), 1);
         store.remove(&id);
         assert_eq!(store.len(), 0);
@@ -98,11 +120,46 @@ mod tests {
     #[test]
     fn evict_expired() {
         let store = SessionStore::new(Duration::from_millis(1));
-        store.create(None);
-        store.create(None);
+        store.create().expect("under cap");
+        store.create().expect("under cap");
         assert_eq!(store.len(), 2);
         std::thread::sleep(Duration::from_millis(10));
         store.evict_expired();
         assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn create_fails_closed_at_cap_but_reclaims_expired() {
+        // A tiny TTL so every existing session is expired and reclaimable.
+        let store = SessionStore::new(Duration::from_millis(1));
+        {
+            let mut sessions = store.sessions.lock();
+            for _ in 0..MAX_SESSIONS {
+                sessions.insert(
+                    Uuid::new_v4().to_string(),
+                    McpSession {
+                        last_active: Instant::now(),
+                    },
+                );
+            }
+        }
+        std::thread::sleep(Duration::from_millis(10));
+        // At the cap, but the expired entries are reclaimed so create succeeds.
+        assert!(store.create().is_some());
+
+        // Now fill to the cap with fresh (non-expired) sessions: create fails closed.
+        let store = SessionStore::new(Duration::from_secs(3600));
+        {
+            let mut sessions = store.sessions.lock();
+            for _ in 0..MAX_SESSIONS {
+                sessions.insert(
+                    Uuid::new_v4().to_string(),
+                    McpSession {
+                        last_active: Instant::now(),
+                    },
+                );
+            }
+        }
+        assert!(store.create().is_none());
     }
 }

--- a/crates/barbacane/src/mcp/tools.rs
+++ b/crates/barbacane/src/mcp/tools.rs
@@ -164,13 +164,28 @@ fn build_output_schema(op: &CompiledOperation) -> Option<serde_json::Value> {
     None
 }
 
+/// Decomposed HTTP request components: (resolved_path, query_string, body_json).
+type DecomposedRequest = (String, Option<String>, Option<Vec<u8>>);
+
 /// Decompose MCP tool call arguments back into HTTP request components.
 ///
-/// Returns (resolved_path, query_string, body_json).
+/// Returns `Ok((resolved_path, query_string, body_json))`, or `Err(message)`
+/// when a path-parameter value is unsafe.
+///
+/// MCP callers bypass the HTTP router, which normally guarantees a non-wildcard
+/// path parameter is a single URL segment (it splits the request line on `/`).
+/// Substituting a raw MCP value straight into the path template would let a
+/// caller inject `/` or `..` and reach an upstream resource never exposed as a
+/// tool, or forge the `request.path` that prefix-based authz middleware inspects
+/// (MCP-1). We therefore validate + percent-encode each substituted segment:
+///   * non-wildcard `{name}` — reject `/`, `\`, `?`, `#`, and any `..`; the
+///     value must be a single segment, then percent-encode it;
+///   * wildcard `{name+}` — may span segments (`/` allowed), but reject `?`,
+///     `#`, `\`, and any `..` path segment so it cannot traverse upward.
 pub fn decompose_arguments(
     entry: &ToolEntry,
     arguments: &serde_json::Value,
-) -> (String, Option<String>, Option<Vec<u8>>) {
+) -> Result<DecomposedRequest, String> {
     let args = arguments.as_object().cloned().unwrap_or_default();
 
     let mut path = entry.path.clone();
@@ -185,9 +200,14 @@ pub fn decompose_arguments(
                     serde_json::Value::String(s) => s.clone(),
                     other => other.to_string(),
                 };
-                path = path.replace(&format!("{{{}}}", param.name), &val_str);
-                // Also handle wildcard params {name+}
-                path = path.replace(&format!("{{{}+}}", param.name), &val_str);
+                let wildcard_placeholder = format!("{{{}+}}", param.name);
+                let is_wildcard = path.contains(&wildcard_placeholder);
+                let substituted = sanitize_path_param(&param.name, &val_str, is_wildcard)?;
+                if is_wildcard {
+                    path = path.replace(&wildcard_placeholder, &substituted);
+                } else {
+                    path = path.replace(&format!("{{{}}}", param.name), &substituted);
+                }
                 consumed_keys.insert(param.name.clone());
             }
         } else if param.location == "query" {
@@ -225,7 +245,44 @@ pub fn decompose_arguments(
         serde_json::to_vec(&remaining).ok()
     };
 
-    (path, query, body)
+    Ok((path, query, body))
+}
+
+/// Validate and encode a value being substituted into a path template segment.
+///
+/// Returns the substitution string, or an error message if the value would
+/// break out of its intended segment(s). See [`decompose_arguments`] for the
+/// rationale (MCP-1).
+fn sanitize_path_param(name: &str, value: &str, is_wildcard: bool) -> Result<String, String> {
+    // Control characters (incl. CR/LF) are never valid in a path.
+    if value.chars().any(|c| c.is_control()) {
+        return Err(format!(
+            "path parameter '{name}' contains control characters"
+        ));
+    }
+    if value.contains(['?', '#', '\\']) {
+        return Err(format!(
+            "path parameter '{name}' contains a disallowed character (?, #, or \\)"
+        ));
+    }
+    if is_wildcard {
+        // Wildcards may span segments; reject upward traversal in any segment.
+        if value.split('/').any(|seg| seg == "..") {
+            return Err(format!(
+                "path parameter '{name}' contains a '..' path segment"
+            ));
+        }
+        Ok(value.to_string())
+    } else {
+        // Non-wildcard params must be a single segment: no '/', no '..'.
+        if value.contains('/') {
+            return Err(format!("path parameter '{name}' must not contain '/'"));
+        }
+        if value == ".." || value == "." {
+            return Err(format!("path parameter '{name}' must not be '.' or '..'"));
+        }
+        Ok(percent_encode(value))
+    }
 }
 
 /// Minimal percent-encoding for query string components.
@@ -450,7 +507,7 @@ mod tests {
             ],
         };
         let args = serde_json::json!({"id": "123", "fields": "name,email"});
-        let (path, query, body) = decompose_arguments(&entry, &args);
+        let (path, query, body) = decompose_arguments(&entry, &args).expect("valid args");
         assert_eq!(path, "/users/123");
         assert_eq!(query, Some("fields=name%2Cemail".to_string()));
         assert!(body.is_none());
@@ -471,7 +528,7 @@ mod tests {
             parameters: vec![],
         };
         let args = serde_json::json!({"items": [{"id": "a"}], "note": "rush"});
-        let (path, query, body) = decompose_arguments(&entry, &args);
+        let (path, query, body) = decompose_arguments(&entry, &args).expect("valid args");
         assert_eq!(path, "/orders");
         assert!(query.is_none());
         let body = body.expect("body should be present");
@@ -522,7 +579,7 @@ mod tests {
             }],
         };
         let args = serde_json::json!({"path": "docs/2024/report.pdf"});
-        let (path, query, body) = decompose_arguments(&entry, &args);
+        let (path, query, body) = decompose_arguments(&entry, &args).expect("valid args");
         assert_eq!(path, "/files/docs/2024/report.pdf");
         assert!(query.is_none());
         assert!(body.is_none());
@@ -549,7 +606,7 @@ mod tests {
         };
         // Numeric value instead of string
         let args = serde_json::json!({"id": 42});
-        let (path, _, _) = decompose_arguments(&entry, &args);
+        let (path, _, _) = decompose_arguments(&entry, &args).expect("valid args");
         assert_eq!(path, "/users/42");
     }
 
@@ -574,8 +631,85 @@ mod tests {
         };
         // Missing "id" argument
         let args = serde_json::json!({});
-        let (path, _, _) = decompose_arguments(&entry, &args);
+        let (path, _, _) = decompose_arguments(&entry, &args).expect("valid args");
         assert_eq!(path, "/users/{id}");
+    }
+
+    fn user_id_entry() -> ToolEntry {
+        ToolEntry {
+            tool: McpTool {
+                name: "getUser".to_string(),
+                description: "Get user".to_string(),
+                input_schema: serde_json::json!({}),
+                output_schema: None,
+            },
+            operation_index: 0,
+            method: "GET".to_string(),
+            path: "/users/{id}".to_string(),
+            parameters: vec![Parameter {
+                name: "id".to_string(),
+                location: "path".to_string(),
+                required: true,
+                schema: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn decompose_rejects_traversal_in_non_wildcard_param() {
+        // MCP-1: a non-wildcard path param must not break out of its segment.
+        let entry = user_id_entry();
+        for evil in [
+            "../admin/secrets",
+            "..",
+            "a/b",
+            "x?inject=1",
+            "y#frag",
+            "back\\slash",
+        ] {
+            let args = serde_json::json!({ "id": evil });
+            assert!(
+                decompose_arguments(&entry, &args).is_err(),
+                "value {evil:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn decompose_percent_encodes_non_wildcard_segment() {
+        // Reserved but non-structural characters are encoded, not rejected, so
+        // the value stays a single opaque segment.
+        let entry = user_id_entry();
+        let args = serde_json::json!({"id": "a b:c"});
+        let (path, _, _) = decompose_arguments(&entry, &args).expect("encodable");
+        assert_eq!(path, "/users/a%20b%3Ac");
+    }
+
+    #[test]
+    fn decompose_rejects_traversal_segment_in_wildcard_param() {
+        // Wildcards may contain '/', but not an upward-traversal segment.
+        let entry = ToolEntry {
+            tool: McpTool {
+                name: "getFile".to_string(),
+                description: "Get file".to_string(),
+                input_schema: serde_json::json!({}),
+                output_schema: None,
+            },
+            operation_index: 0,
+            method: "GET".to_string(),
+            path: "/files/{path+}".to_string(),
+            parameters: vec![Parameter {
+                name: "path".to_string(),
+                location: "path".to_string(),
+                required: true,
+                schema: None,
+            }],
+        };
+        let args = serde_json::json!({"path": "docs/../../etc/passwd"});
+        assert!(decompose_arguments(&entry, &args).is_err());
+        // A legitimate deep path with no traversal is still allowed.
+        let ok = serde_json::json!({"path": "docs/2024/report.pdf"});
+        assert!(decompose_arguments(&entry, &ok).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Closes barbacane-dev/private#11 (H1 + M3, from the internal security review).

## MCP-1 — path-parameter injection (HIGH)

`decompose_arguments` percent-encoded query-param values but substituted **path-param** values into the path template raw. MCP callers bypass the HTTP router (which guarantees a non-wildcard path param is a single `/`-delimited segment) and skip the OpenAPI validator, so:

- `{id:"../admin/secrets"}` → `/users/../admin/secrets` → normalizes to an upstream resource never exposed as a tool (the SSRF host guard constrains host/DNS, not path);
- a forged `request.path` also defeats prefix-based authz middleware.

**Fix:** path-param values are validated and encoded before substitution:

- non-wildcard `{name}` — reject `/`, `\`, `?`, `#`, and `.`/`..`; the value must be a single segment, then percent-encode it;
- wildcard `{name+}` — may span segments (`/` allowed), but reject `?`, `#`, `\`, and any `..` path segment.

Invalid values return `INVALID_PARAMS` before dispatch.

## MCP-2 — unauthenticated session exhaustion (MEDIUM)

`initialize` requires no auth and inserted into an uncapped session map while retaining the attacker-supplied `clientInfo` blob (otherwise unused) for the 30-min TTL.

**Fix:** `SessionStore` now caps at `MAX_SESSIONS` (10k), reclaiming expired sessions first and failing closed (`create() -> None` → `INTERNAL_ERROR`) when still full. `clientInfo` is no longer stored (the `McpSession` struct holds only the activity timestamp).

## Tests

Added regressions: traversal rejection for wildcard and non-wildcard params, single-segment percent-encoding, end-to-end `INVALID_PARAMS` on a `tools/call` with a traversal arg, and the session cap (fail-closed + expired-reclaim). All 41 MCP tests pass; workspace clippy clean, fmt applied.
