### PR TITLE
fix(wasm,telemetry): isolate shared per-plugin host state (cache, rate limiter, metrics)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "parking_lot",
  "prometheus-client",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/barbacane-telemetry/Cargo.toml
+++ b/crates/barbacane-telemetry/Cargo.toml
@@ -25,6 +25,7 @@ prometheus-client = { workspace = true }
 # Utilities
 uuid = { workspace = true }
 thiserror = { workspace = true }
+parking_lot = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/barbacane-telemetry/src/metrics.rs
+++ b/crates/barbacane-telemetry/src/metrics.rs
@@ -2,11 +2,26 @@
 //!
 //! Implements all metrics per ADR-0010 and SPEC-005.
 
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+
+use parking_lot::Mutex;
 use prometheus_client::{
     encoding::EncodeLabelSet,
     metrics::{counter::Counter, family::Family, gauge::Gauge, histogram::Histogram},
     registry::Registry,
 };
+
+/// Untrusted plugins emit metrics across the WASM boundary. Bound what they can
+/// allocate on the host heap (plugin metric storage is never evicted):
+/// Maximum length of a plugin-supplied metric name.
+const MAX_PLUGIN_METRIC_NAME_LEN: usize = 128;
+/// Maximum length of a plugin-supplied `labels_json` string.
+const MAX_PLUGIN_LABELS_JSON_LEN: usize = 1024;
+/// Maximum number of distinct metric series (name + labels) a single plugin may
+/// create. Further new series are dropped (existing ones keep updating).
+const MAX_PLUGIN_METRIC_CARDINALITY: usize = 1000;
 
 /// Duration histogram buckets (in seconds).
 /// Covers 1ms to 10s range with exponential growth.
@@ -70,11 +85,23 @@ pub struct ConnectionLabels {
     pub api: String,
 }
 
-/// Plugin metric labels (user-defined).
+/// Plugin metric labels (user-defined). `plugin` and `metric` are kept as
+/// separate label fields: concatenating them (`"{plugin}_{name}"`) let a plugin
+/// forge another plugin's series (e.g. plugin `a`/metric `b_c` collided with
+/// plugin `a_b`/metric `c`).
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub struct PluginMetricLabels {
     pub plugin: String,
+    pub metric: String,
     pub labels_json: String,
+}
+
+/// Labels for the drop counter that records rejected plugin metric writes.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct PluginMetricDropLabels {
+    pub plugin: String,
+    /// Why the write was dropped: `oversize`, `cardinality`, or `non_finite`.
+    pub reason: String,
 }
 
 /// Metrics registry holding all Barbacane metrics.
@@ -113,6 +140,13 @@ pub struct MetricsRegistry {
     // Plugin metrics (dynamically registered)
     pub plugin_counters: Family<PluginMetricLabels, Counter>,
     pub plugin_histograms: Family<PluginMetricLabels, Histogram>,
+    /// Count of plugin metric writes rejected by the guards (per plugin/reason).
+    pub plugin_metrics_dropped_total: Family<PluginMetricDropLabels, Counter>,
+
+    /// Per-plugin set of admitted series fingerprints, enforcing
+    /// [`MAX_PLUGIN_METRIC_CARDINALITY`]. Not a Prometheus metric — internal
+    /// accounting so a plugin cannot grow the registry without bound.
+    plugin_series: Mutex<HashMap<String, HashSet<u64>>>,
 }
 
 impl MetricsRegistry {
@@ -259,6 +293,13 @@ impl MetricsRegistry {
             plugin_histograms.clone(),
         );
 
+        let plugin_metrics_dropped_total = Family::<PluginMetricDropLabels, Counter>::default();
+        registry.register(
+            "barbacane_plugin_metrics_dropped_total",
+            "Plugin metric writes rejected by cardinality/size/finite guards",
+            plugin_metrics_dropped_total.clone(),
+        );
+
         Self {
             registry,
             requests_total,
@@ -277,6 +318,8 @@ impl MetricsRegistry {
             deprecated_route_requests_total,
             plugin_counters,
             plugin_histograms,
+            plugin_metrics_dropped_total,
+            plugin_series: Mutex::new(HashMap::new()),
         }
     }
 
@@ -406,10 +449,53 @@ impl MetricsRegistry {
         self.active_connections.dec();
     }
 
+    /// Record that a plugin metric write was dropped by a guard.
+    fn record_plugin_metric_dropped(&self, plugin: &str, reason: &str) {
+        self.plugin_metrics_dropped_total
+            .get_or_create(&PluginMetricDropLabels {
+                plugin: plugin.to_string(),
+                reason: reason.to_string(),
+            })
+            .inc();
+    }
+
+    /// Whether a plugin may create/update the given series, enforcing the size
+    /// and per-plugin cardinality caps. Returns `false` (and records a drop) when
+    /// the write must be rejected; an already-seen series is always admitted so
+    /// existing metrics keep updating.
+    fn admit_plugin_series(&self, plugin: &str, name: &str, labels_json: &str) -> bool {
+        if name.len() > MAX_PLUGIN_METRIC_NAME_LEN || labels_json.len() > MAX_PLUGIN_LABELS_JSON_LEN
+        {
+            self.record_plugin_metric_dropped(plugin, "oversize");
+            return false;
+        }
+        let mut hasher = DefaultHasher::new();
+        name.hash(&mut hasher);
+        labels_json.hash(&mut hasher);
+        let fingerprint = hasher.finish();
+
+        let mut series = self.plugin_series.lock();
+        let seen = series.entry(plugin.to_string()).or_default();
+        if seen.contains(&fingerprint) {
+            return true;
+        }
+        if seen.len() >= MAX_PLUGIN_METRIC_CARDINALITY {
+            drop(series);
+            self.record_plugin_metric_dropped(plugin, "cardinality");
+            return false;
+        }
+        seen.insert(fingerprint);
+        true
+    }
+
     /// Increment a plugin counter metric.
     pub fn plugin_counter_inc(&self, plugin: &str, name: &str, labels_json: &str, value: u64) {
+        if !self.admit_plugin_series(plugin, name, labels_json) {
+            return;
+        }
         let labels = PluginMetricLabels {
-            plugin: format!("{}_{}", plugin, name),
+            plugin: plugin.to_string(),
+            metric: name.to_string(),
             labels_json: labels_json.to_string(),
         };
         self.plugin_counters.get_or_create(&labels).inc_by(value);
@@ -423,8 +509,17 @@ impl MetricsRegistry {
         labels_json: &str,
         value: f64,
     ) {
+        // A non-finite observation permanently poisons the series' _sum.
+        if !value.is_finite() {
+            self.record_plugin_metric_dropped(plugin, "non_finite");
+            return;
+        }
+        if !self.admit_plugin_series(plugin, name, labels_json) {
+            return;
+        }
         let labels = PluginMetricLabels {
-            plugin: format!("{}_{}", plugin, name),
+            plugin: plugin.to_string(),
+            metric: name.to_string(),
             labels_json: labels_json.to_string(),
         };
         self.plugin_histograms.get_or_create(&labels).observe(value);
@@ -498,5 +593,87 @@ mod tests {
                 .get(),
             1
         );
+    }
+
+    fn dropped(registry: &MetricsRegistry, plugin: &str, reason: &str) -> u64 {
+        registry
+            .plugin_metrics_dropped_total
+            .get_or_create(&PluginMetricDropLabels {
+                plugin: plugin.to_string(),
+                reason: reason.to_string(),
+            })
+            .get()
+    }
+
+    #[test]
+    fn plugin_metric_name_and_plugin_do_not_collide() {
+        // Regression: "{plugin}_{name}" concatenation let plugin `a`/metric `b_c`
+        // forge plugin `a_b`/metric `c`. Separate label fields keep them distinct.
+        let registry = MetricsRegistry::new();
+        registry.plugin_counter_inc("a", "b_c", "{}", 1);
+        registry.plugin_counter_inc("a_b", "c", "{}", 1);
+        assert_eq!(
+            registry
+                .plugin_counters
+                .get_or_create(&PluginMetricLabels {
+                    plugin: "a".to_string(),
+                    metric: "b_c".to_string(),
+                    labels_json: "{}".to_string(),
+                })
+                .get(),
+            1
+        );
+        assert_eq!(
+            registry
+                .plugin_counters
+                .get_or_create(&PluginMetricLabels {
+                    plugin: "a_b".to_string(),
+                    metric: "c".to_string(),
+                    labels_json: "{}".to_string(),
+                })
+                .get(),
+            1
+        );
+    }
+
+    #[test]
+    fn plugin_metric_oversize_is_dropped() {
+        let registry = MetricsRegistry::new();
+        let long_name = "n".repeat(MAX_PLUGIN_METRIC_NAME_LEN + 1);
+        registry.plugin_counter_inc("p", &long_name, "{}", 1);
+        let long_labels = "x".repeat(MAX_PLUGIN_LABELS_JSON_LEN + 1);
+        registry.plugin_counter_inc("p", "ok", &long_labels, 1);
+        assert_eq!(dropped(&registry, "p", "oversize"), 2);
+    }
+
+    #[test]
+    fn plugin_metric_cardinality_is_capped() {
+        let registry = MetricsRegistry::new();
+        // Fill the budget with distinct label sets, then exceed it.
+        for i in 0..MAX_PLUGIN_METRIC_CARDINALITY {
+            registry.plugin_counter_inc("p", "m", &format!("{{\"i\":{i}}}"), 1);
+        }
+        assert_eq!(dropped(&registry, "p", "cardinality"), 0);
+        registry.plugin_counter_inc("p", "m", "{\"i\":999999}", 1);
+        assert_eq!(dropped(&registry, "p", "cardinality"), 1);
+        // An already-admitted series still updates after the cap is reached.
+        registry.plugin_counter_inc("p", "m", "{\"i\":0}", 5);
+        let v = registry
+            .plugin_counters
+            .get_or_create(&PluginMetricLabels {
+                plugin: "p".to_string(),
+                metric: "m".to_string(),
+                labels_json: "{\"i\":0}".to_string(),
+            })
+            .get();
+        assert_eq!(v, 6); // 1 (initial) + 5
+    }
+
+    #[test]
+    fn plugin_histogram_rejects_non_finite() {
+        let registry = MetricsRegistry::new();
+        registry.plugin_histogram_observe("p", "h", "{}", f64::NAN);
+        registry.plugin_histogram_observe("p", "h", "{}", f64::INFINITY);
+        assert_eq!(dropped(&registry, "p", "non_finite"), 2);
     }
 }

--- a/crates/barbacane-wasm/src/instance.rs
+++ b/crates/barbacane-wasm/src/instance.rs
@@ -53,6 +53,17 @@ pub(crate) struct PluginHttpRequest {
     pub(crate) timeout_ms: Option<u64>,
 }
 
+/// Prefix a plugin-controlled key (cache key, rate-limit partition) with the
+/// calling plugin's name so plugins sharing an Arc-backed store (`ResponseCache`,
+/// `RateLimiter`) cannot read, poison, or collide on each other's entries.
+///
+/// The NUL byte is used as the separator: plugin names come from the trusted
+/// manifest and never contain NUL, so the first NUL unambiguously delimits the
+/// namespace regardless of the (attacker-controlled) key contents.
+fn namespace_key(plugin_name: &str, key: &str) -> String {
+    format!("{plugin_name}\u{0}{key}")
+}
+
 /// Per-request context passed to plugins.
 #[derive(Debug, Clone, Default)]
 pub struct RequestContext {
@@ -1627,8 +1638,13 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                     }
                 };
 
+                // Namespace the partition key by the calling plugin so one plugin
+                // cannot exhaust the shared partition table for another, or collide
+                // on another plugin's victim key (rate-limiter isolation).
+                let namespaced = namespace_key(&caller.data().plugin_name, &key);
+
                 // Check the rate limit
-                let result = rate_limiter.check(&key, quota, window_secs as u64);
+                let result = rate_limiter.check(&namespaced, quota, window_secs as u64);
 
                 // Serialize the result
                 match serde_json::to_vec(&result) {
@@ -1687,8 +1703,13 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                     }
                 };
 
+                // Namespace the key by the calling plugin so one plugin cannot
+                // read or poison another plugin's cached responses (WA cache
+                // isolation). The NUL separator cannot appear in a plugin name.
+                let namespaced = namespace_key(&caller.data().plugin_name, &key);
+
                 // Check the cache
-                let result = cache.get(&key);
+                let result = cache.get(&namespaced);
 
                 // Serialize the result
                 match serde_json::to_vec(&result) {
@@ -1758,8 +1779,12 @@ fn add_host_functions(linker: &mut Linker<PluginState>) -> Result<(), WasmError>
                     }
                 };
 
+                // Namespace by the calling plugin (see host_cache_get) so a plugin
+                // cannot poison an entry another plugin will read.
+                let namespaced = namespace_key(&caller.data().plugin_name, &key);
+
                 // Store in cache
-                cache.set(&key, entry, ttl_secs as u64);
+                cache.set(&namespaced, entry, ttl_secs as u64);
                 0 // Success
             },
         )
@@ -2332,6 +2357,25 @@ mod tests {
         assert_eq!(ctx.trace_id, "trace-123");
         assert_eq!(ctx.request_id, "req-456");
         assert!(ctx.values.is_empty());
+    }
+
+    #[test]
+    fn namespace_key_isolates_plugins() {
+        // Same key, different plugins → different namespaced keys.
+        assert_ne!(
+            namespace_key("plugin-a", "GET:/x"),
+            namespace_key("plugin-b", "GET:/x")
+        );
+        // Same plugin + key is stable.
+        assert_eq!(
+            namespace_key("plugin-a", "GET:/x"),
+            namespace_key("plugin-a", "GET:/x")
+        );
+        // Distinct keys under one plugin stay distinct.
+        assert_ne!(
+            namespace_key("plugin-a", "GET:/x"),
+            namespace_key("plugin-a", "GET:/y")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes barbacane-dev/private#12 (H2 + M2, from the internal security review).

Root cause: the per-plugin isolation introduced for secrets (`SecretsStore::scoped`) was never extended to the other Arc-shared host resources, so co-resident untrusted plugins could poison or exhaust each other's state.

## H2 — response cache poisoning/disclosure (HIGH)

`ResponseCache` is one Arc-shared map; `host_cache_get`/`host_cache_set` used the plugin-controlled key verbatim. A co-resident plugin (only needs `cache=true`) could compute another plugin's key and poison the entry (stored XSS, injected `Set-Cookie`/redirect served to real clients) or read its cached responses.

**Fix:** both host functions now namespace the key by the calling plugin's name (`namespace_key`, NUL separator — trusted plugin names never contain NUL), so keyspaces are disjoint per plugin.

## M2b — rate-limiter cross-plugin DoS (LOW)

`host_rate_limit_check` partitioned the shared 100k-entry table on the raw plugin key. **Fix:** same per-plugin namespacing, so one plugin can't exhaust the table for another or collide on a victim key.

## M2a — metrics host-heap exhaustion + integrity (MEDIUM)

Plugin metric writes land on the never-evicted host heap with no bounds. **Fixes in `MetricsRegistry`:**

- hard caps: metric name ≤128B, `labels_json` ≤1KB;
- per-plugin cardinality budget: ≤1000 distinct series; further **new** series are dropped (existing ones keep updating);
- reject non-finite histogram observations (`NaN`/`Inf` permanently poison `_sum`);
- rejected writes counted in `barbacane_plugin_metrics_dropped_total{plugin,reason}`;
- `plugin` and `metric` are now separate label fields instead of `format!("{}_{}")`, which let plugin `a`/metric `b_c` forge plugin `a_b`/metric `c`.

## Tests

Unit tests for key namespacing (isolation + stability) and every metrics guard (oversize, cardinality cap with existing-series still updating, non-finite rejection, plugin/metric non-collision). telemetry + wasm lib tests pass; workspace clippy clean, fmt applied. Adds `parking_lot` to `barbacane-telemetry` for the cardinality tracker mutex.
