### PR TITLE
fix(wasm): pin egress DNS resolution for WS/NATS/Kafka (DNS-rebinding)

### DIFF
--- a/crates/barbacane-wasm/src/http_client.rs
+++ b/crates/barbacane-wasm/src/http_client.rs
@@ -479,6 +479,7 @@ pub(crate) fn ip_is_internal(ip: &IpAddr) -> bool {
 
 /// Outcome of an SSRF host check that distinguishes a policy rejection from a
 /// resolution failure so callers can map each to their own error type.
+#[derive(Debug)]
 pub(crate) enum HostGuardError {
     /// The host resolves to an internal/non-routable/metadata address.
     Blocked(String),
@@ -531,6 +532,48 @@ pub(crate) async fn guard_external_host(
         )));
     }
     Ok(())
+}
+
+/// Resolve `host`:`port` to the set of addresses a plugin is permitted to
+/// connect to, dropping internal/metadata addresses unless `allow_internal`.
+///
+/// Unlike [`guard_external_host`], which only *checks* and lets the client
+/// resolve again at connect time (leaving a DNS-rebinding TOCTOU window), this
+/// returns the vetted addresses so the caller can **pin** the connection to
+/// them. Errors distinguish a policy block from a resolution failure.
+pub(crate) async fn resolve_permitted_addrs(
+    host: &str,
+    port: u16,
+    allow_internal: bool,
+) -> Result<Vec<SocketAddr>, HostGuardError> {
+    let host_clean = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+
+    if let Ok(ip) = host_clean.parse::<IpAddr>() {
+        let addrs = permitted_addrs(std::iter::once(SocketAddr::new(ip, port)), allow_internal);
+        if addrs.is_empty() {
+            return Err(HostGuardError::Blocked(host.to_string()));
+        }
+        return Ok(addrs);
+    }
+
+    let resolved: Vec<SocketAddr> = tokio::net::lookup_host((host_clean, port))
+        .await
+        .map_err(|e| HostGuardError::Resolve(e.to_string()))?
+        .collect();
+    if resolved.is_empty() {
+        return Err(HostGuardError::Resolve(format!(
+            "no DNS records for {host}"
+        )));
+    }
+    let addrs = permitted_addrs(resolved.into_iter(), allow_internal);
+    if addrs.is_empty() {
+        // Records existed but every one was internal → policy block.
+        return Err(HostGuardError::Blocked(host.to_string()));
+    }
+    Ok(addrs)
 }
 
 /// Headers a plugin may not set on an outbound HTTP request. `host` is derived
@@ -775,6 +818,26 @@ mod option_duration_serde {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn resolve_permitted_addrs_pins_public_literal_and_blocks_internal() {
+        // Public IP literal → returned as a pinnable address with the given port.
+        let addrs = resolve_permitted_addrs("8.8.8.8", 443, false)
+            .await
+            .expect("public literal permitted");
+        assert_eq!(addrs, vec!["8.8.8.8:443".parse().unwrap()]);
+
+        // Internal literal → blocked when egress is disallowed...
+        assert!(matches!(
+            resolve_permitted_addrs("169.254.169.254", 80, false).await,
+            Err(HostGuardError::Blocked(_))
+        ));
+        // ...but permitted (and pinned) once internal egress is allowed.
+        let addrs = resolve_permitted_addrs("10.0.0.5", 9092, true)
+            .await
+            .expect("internal permitted when egress allowed");
+        assert_eq!(addrs, vec!["10.0.0.5:9092".parse().unwrap()]);
+    }
 
     #[test]
     fn ssrf_classifier_blocks_internal_targets() {

--- a/crates/barbacane-wasm/src/kafka_client.rs
+++ b/crates/barbacane-wasm/src/kafka_client.rs
@@ -128,14 +128,29 @@ impl KafkaPublisher {
         // Parse broker addresses (comma-separated)
         let broker_list: Vec<String> = brokers.split(',').map(|s| s.trim().to_string()).collect();
 
-        // SSRF guard: refuse to connect to internal/metadata targets unless the
-        // operator has opted into internal egress.
+        // SSRF guard: resolve each bootstrap broker once and pin the connection to
+        // the vetted IPs, refusing internal/metadata targets unless the operator
+        // opted into internal egress. Pinning (vs. letting rskafka resolve again at
+        // connect time) closes the DNS-rebinding TOCTOU window for the bootstrap
+        // connection. The Kafka client here is plaintext, so connecting by IP is
+        // transparent.
+        //
+        // Residual (rskafka 0.6 limitation): after bootstrap, rskafka discovers the
+        // cluster's *advertised* broker addresses from metadata and connects to
+        // those directly. rskafka exposes no resolver/socket hook, so those
+        // addresses cannot be filtered here; a hostile broker advertising an
+        // internal listener is not fully mitigated. Tracked as follow-up.
+        let mut pinned_brokers: Vec<String> = Vec::new();
         for broker in &broker_list {
             let (host, port) = crate::broker::split_host_port(broker, DEFAULT_KAFKA_PORT);
-            match crate::http_client::guard_external_host(&host, port, self.allow_internal_egress)
-                .await
+            match crate::http_client::resolve_permitted_addrs(
+                &host,
+                port,
+                self.allow_internal_egress,
+            )
+            .await
             {
-                Ok(()) => {}
+                Ok(addrs) => pinned_brokers.extend(addrs.iter().map(|a| a.to_string())),
                 Err(crate::http_client::HostGuardError::Blocked(h)) => {
                     return Err(BrokerError::Blocked(h));
                 }
@@ -150,7 +165,7 @@ impl KafkaPublisher {
             deadline: Some(Duration::from_secs(5)),
             ..Default::default()
         };
-        let client = ClientBuilder::new(broker_list)
+        let client = ClientBuilder::new(pinned_brokers)
             .backoff_config(backoff)
             .build()
             .await

--- a/crates/barbacane-wasm/src/nats_client.rs
+++ b/crates/barbacane-wasm/src/nats_client.rs
@@ -112,25 +112,47 @@ impl NatsPublisher {
             }
         }
 
-        // SSRF guard: refuse to connect to internal/metadata targets unless the
-        // operator has opted into internal egress.
+        // SSRF guard: resolve once and refuse internal/metadata targets unless the
+        // operator has opted into internal egress. We keep the vetted addresses so
+        // the connection can be pinned to them (closing the DNS-rebinding window
+        // async_nats would otherwise reopen by resolving again at connect time).
         let (host, port) = crate::broker::split_host_port(url, DEFAULT_NATS_PORT);
-        match crate::http_client::guard_external_host(&host, port, self.allow_internal_egress).await
+        let addrs = match crate::http_client::resolve_permitted_addrs(
+            &host,
+            port,
+            self.allow_internal_egress,
+        )
+        .await
         {
-            Ok(()) => {}
+            Ok(a) => a,
             Err(crate::http_client::HostGuardError::Blocked(h)) => {
                 return Err(BrokerError::Blocked(h));
             }
             Err(crate::http_client::HostGuardError::Resolve(m)) => {
                 return Err(BrokerError::ConnectionFailed(m));
             }
-        }
+        };
 
-        // Connect (outside the lock) with a bounded timeout.
-        let client = tokio::time::timeout(CONNECT_TIMEOUT, async_nats::connect(url))
-            .await
-            .map_err(|_| BrokerError::Timeout)?
-            .map_err(|e| BrokerError::ConnectionFailed(e.to_string()))?;
+        // Pin plaintext (`nats://`) connections to the vetted IPs. For `tls://`
+        // we keep the hostname so TLS SNI/cert validation still works; the
+        // pre-connect resolution above already blocked internal targets, leaving
+        // only a narrow rebinding window for a TLS broker (which would need a
+        // valid cert on the rebound internal target to be usable).
+        let is_tls = url.trim_start().starts_with("tls://");
+        let client = if is_tls {
+            tokio::time::timeout(CONNECT_TIMEOUT, async_nats::connect(url.to_string())).await
+        } else {
+            let pinned: Vec<async_nats::ServerAddr> = addrs
+                .iter()
+                .map(|a| format!("nats://{a}").parse())
+                .collect::<Result<_, _>>()
+                .map_err(|e| {
+                    BrokerError::ConnectionFailed(format!("invalid pinned NATS address: {e}"))
+                })?;
+            tokio::time::timeout(CONNECT_TIMEOUT, async_nats::connect(pinned)).await
+        }
+        .map_err(|_| BrokerError::Timeout)?
+        .map_err(|e| BrokerError::ConnectionFailed(e.to_string()))?;
 
         tracing::info!(url = %url, "established NATS connection");
 

--- a/crates/barbacane-wasm/src/ws_client.rs
+++ b/crates/barbacane-wasm/src/ws_client.rs
@@ -37,17 +37,19 @@ pub async fn connect_upstream(
 ) -> Result<UpstreamWsStream, String> {
     // SSRF guard: resolve the upstream host and refuse internal / loopback /
     // link-local / cloud-metadata targets unless egress is explicitly allowed.
-    // Mirrors the HTTP and broker guards so a plugin can't reach internal
-    // services over ws:// / wss://.
+    // We resolve ONCE here and pin the connection to a vetted address below,
+    // rather than letting tokio-tungstenite resolve again at connect time — that
+    // second resolution is the DNS-rebinding TOCTOU window the HTTP client closes
+    // via its custom resolver, and which this mirrors for ws:// / wss://.
     let parsed = reqwest::Url::parse(&req.url)
         .map_err(|e| format!("invalid WebSocket URL '{}': {}", req.url, e))?;
     let host = parsed
         .host_str()
         .ok_or_else(|| format!("WebSocket URL '{}' has no host", req.url))?;
     let port = parsed.port_or_known_default().unwrap_or(0);
-    if let Err(e) = crate::http_client::guard_external_host(host, port, allow_internal_egress).await
-    {
-        return Err(match e {
+    let addrs = crate::http_client::resolve_permitted_addrs(host, port, allow_internal_egress)
+        .await
+        .map_err(|e| match e {
             crate::http_client::HostGuardError::Blocked(h) => format!(
                 "WebSocket target '{h}' is an internal address; set \
                  BARBACANE_ALLOW_INTERNAL_EGRESS to allow"
@@ -55,10 +57,11 @@ pub async fn connect_upstream(
             crate::http_client::HostGuardError::Resolve(m) => {
                 format!("WebSocket target resolution failed: {m}")
             }
-        });
-    }
+        })?;
 
-    // Build the request with custom headers
+    // Build the request with custom headers. The request carries the original
+    // host, so TLS SNI and the Host header stay correct even though we connect
+    // to a pinned IP.
     let mut ws_request = req
         .url
         .as_str()
@@ -75,13 +78,36 @@ pub async fn connect_upstream(
         }
     }
 
-    // Connect with timeout
-    let connect_future = tokio_tungstenite::connect_async(ws_request);
     let timeout = Duration::from_millis(req.connect_timeout_ms);
+    let connect_future = async move {
+        // Connect the TCP socket to a vetted address (try each in turn), then run
+        // the WebSocket/TLS handshake over that pinned stream.
+        let mut last_err: Option<String> = None;
+        let mut tcp = None;
+        for addr in &addrs {
+            match tokio::net::TcpStream::connect(addr).await {
+                Ok(stream) => {
+                    tcp = Some(stream);
+                    break;
+                }
+                Err(e) => last_err = Some(e.to_string()),
+            }
+        }
+        let tcp = tcp.ok_or_else(|| {
+            format!(
+                "WebSocket connection failed: {}",
+                last_err.unwrap_or_else(|| "no reachable address".to_string())
+            )
+        })?;
+
+        tokio_tungstenite::client_async_tls(ws_request, tcp)
+            .await
+            .map(|(ws_stream, _response)| ws_stream)
+            .map_err(|e| format!("WebSocket connection failed: {}", e))
+    };
 
     match tokio::time::timeout(timeout, connect_future).await {
-        Ok(Ok((ws_stream, _response))) => Ok(ws_stream),
-        Ok(Err(e)) => Err(format!("WebSocket connection failed: {}", e)),
+        Ok(result) => result,
         Err(_) => Err(format!(
             "WebSocket connection timed out after {}ms",
             req.connect_timeout_ms


### PR DESCRIPTION
Closes barbacane-dev/private#13 (M1, from the internal security review).

## Problem

The HTTP client closes the DNS-rebinding TOCTOU window with a custom reqwest resolver that pins vetted IPs. The WS/NATS/Kafka egress paths only ran `guard_external_host` (one resolution) and then let the client library resolve the host **again** at connect time, so a rebinding DNS answer could pass the guard with a public IP and connect to an internal one.

## Fix

New `http_client::resolve_permitted_addrs` resolves once and returns the non-internal addresses, so callers can **pin** the connection:

- **WS** — connect the TCP socket to a vetted address and run the handshake via `client_async_tls`; the request still carries the original host, so TLS SNI and the `Host` header stay correct. **Fully closes the gap.**
- **NATS** — pin plaintext `nats://` connections to the vetted IPs. `tls://` keeps the hostname for SNI/cert validation and relies on the pre-connect resolution (**narrow residual window** for a TLS broker, which would need a valid cert on the rebound internal target to be usable — documented).
- **Kafka** — pin the **bootstrap** brokers to vetted IPs (the client is plaintext, so connecting by IP is transparent).

## Residual (documented in code)

rskafka 0.6 exposes no resolver/socket hook, so cluster-**advertised** broker addresses discovered after bootstrap cannot be filtered — a hostile broker advertising an internal listener is not fully mitigated. This is the one sub-item of #13 that a library limitation prevents closing now; called out as follow-up. Everything else (all three rebinding windows + Kafka bootstrap) is closed.

## Tests

Added a `resolve_permitted_addrs` unit test (pins public literal, blocks internal, permits internal under egress-allowed). Existing WS/NATS/Kafka SSRF-block tests still pass. 194 wasm + 20 telemetry lib tests pass; workspace clippy clean, fmt applied.

## Note on verification

The pinning changes touch the WS/NATS/Kafka connection paths, which unit tests exercise only up to the SSRF check / connection-refused. Real handshake behavior (TLS SNI over pinned IP, multi-address failover) is covered only by CI integration tests. Flagging for review attention.
