### PR TITLE
fix: hygiene batch (query HPP, data_plane row growth, E1070 coverage, plugin download cap)

### DIFF
--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -621,7 +621,17 @@ fn compile_inner(
             // Warn on plaintext secrets in config (E1070): a field the plugin's
             // schema marks `writeOnly` but that holds a literal gets baked into
             // the artifact. Recommend env:// / file:// references.
-            if let Some(fields) = plugin_secret_fields.get(dispatch.name.as_str()) {
+            //
+            // `plugin_secret_fields` is keyed by the normalized plugin name, but
+            // a spec may reference a plugin with a version suffix
+            // (e.g. "jwt-auth@1.0.0"); normalize the reference before lookup so
+            // version-pinned plugins are still scanned.
+            //
+            // Note: `plugin_secret_fields` only contains path-sourced plugins;
+            // URL-sourced plugins carry no `secret_fields` (their schema is not
+            // fetched at compile time), so E1070 cannot cover them.
+            let dispatch_key = crate::manifest::normalize_plugin_name(&dispatch.name);
+            if let Some(fields) = plugin_secret_fields.get(dispatch_key.as_str()) {
                 scan_plaintext_secrets(
                     &dispatch.config,
                     &dispatch.name,
@@ -631,7 +641,8 @@ fn compile_inner(
                 );
             }
             for mw in &middlewares {
-                if let Some(fields) = plugin_secret_fields.get(mw.name.as_str()) {
+                let mw_key = crate::manifest::normalize_plugin_name(&mw.name);
+                if let Some(fields) = plugin_secret_fields.get(mw_key.as_str()) {
                     scan_plaintext_secrets(&mw.config, &mw.name, fields, &location, &mut warnings);
                 }
             }

--- a/crates/barbacane-compiler/src/download.rs
+++ b/crates/barbacane-compiler/src/download.rs
@@ -1,8 +1,18 @@
 //! HTTP download logic for remote plugins.
 
+use std::io::Read;
 use std::time::Duration;
 
 use crate::error::CompileError;
+
+/// Maximum size of a downloaded plugin `.wasm` body. A remote (untrusted) host
+/// could otherwise stream an arbitrarily large body and OOM the compile/CI host,
+/// since the whole body is buffered in memory.
+const MAX_PLUGIN_WASM_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Maximum size of a downloaded `plugin.toml`. It is small config; cap it so a
+/// hostile host cannot exhaust memory via the sidecar fetch either.
+const MAX_PLUGIN_TOML_BYTES: u64 = 1024 * 1024;
 
 /// Result of downloading a remote plugin.
 #[derive(Debug)]
@@ -68,27 +78,49 @@ pub fn download_plugin(url: &str) -> Result<DownloadResult, CompileError> {
         )));
     }
 
-    let wasm_bytes = response.bytes().map_err(|e| {
-        CompileError::PluginResolution(format!(
-            "failed to read plugin response body from {url}: {e}"
-        ))
-    })?;
+    // Reject early if the server declares an oversize body...
+    if let Some(len) = response.content_length() {
+        if len > MAX_PLUGIN_WASM_BYTES {
+            return Err(CompileError::PluginResolution(format!(
+                "plugin at {url} is {len} bytes, exceeds the {MAX_PLUGIN_WASM_BYTES}-byte limit"
+            )));
+        }
+    }
+    // ...and cap the actual read so a missing or lying Content-Length can't OOM
+    // the host: read at most limit+1 bytes, then reject if the limit is exceeded.
+    let mut wasm_bytes = Vec::new();
+    response
+        .take(MAX_PLUGIN_WASM_BYTES + 1)
+        .read_to_end(&mut wasm_bytes)
+        .map_err(|e| {
+            CompileError::PluginResolution(format!(
+                "failed to read plugin response body from {url}: {e}"
+            ))
+        })?;
+    if wasm_bytes.len() as u64 > MAX_PLUGIN_WASM_BYTES {
+        return Err(CompileError::PluginResolution(format!(
+            "plugin body from {url} exceeds the {MAX_PLUGIN_WASM_BYTES}-byte limit"
+        )));
+    }
 
-    // Best-effort: try to fetch plugin.toml from candidate URLs
+    // Best-effort: try to fetch plugin.toml from candidate URLs (also bounded).
     let plugin_toml = derive_plugin_toml_urls(url)
         .into_iter()
         .find_map(|toml_url| {
             tracing::debug!(url = %toml_url, "attempting to fetch plugin.toml");
             let resp = client.get(&toml_url).send().ok()?;
-            if resp.status().is_success() {
-                resp.text().ok()
-            } else {
-                None
+            if !resp.status().is_success() {
+                return None;
             }
+            let mut buf = String::new();
+            resp.take(MAX_PLUGIN_TOML_BYTES)
+                .read_to_string(&mut buf)
+                .ok()?;
+            Some(buf)
         });
 
     Ok(DownloadResult {
-        wasm_bytes: wasm_bytes.to_vec(),
+        wasm_bytes,
         plugin_toml,
     })
 }

--- a/crates/barbacane-compiler/src/manifest.rs
+++ b/crates/barbacane-compiler/src/manifest.rs
@@ -483,7 +483,7 @@ pub fn extract_plugin_names(specs: &[ApiSpec]) -> HashSet<String> {
 /// Normalize a plugin name by stripping version suffix.
 ///
 /// Handles formats like "rate-limit@1.0.0" -> "rate-limit".
-fn normalize_plugin_name(name: &str) -> String {
+pub(crate) fn normalize_plugin_name(name: &str) -> String {
     match name.split_once('@') {
         Some((base, _version)) => base.to_string(),
         None => name.to_string(),

--- a/crates/barbacane-control/src/db/data_planes.rs
+++ b/crates/barbacane-control/src/db/data_planes.rs
@@ -145,6 +145,29 @@ impl DataPlanesRepository {
         Ok(result.rows_affected())
     }
 
+    /// Hard-delete data planes that have been offline beyond the retention
+    /// window. Each WebSocket registration INSERTs a new row that is only marked
+    /// offline (never deleted) on disconnect, so a client holding a valid
+    /// `data-plane:connect` key could loop connect/register/disconnect and grow
+    /// the table without bound. Reaping long-offline rows bounds that growth to
+    /// roughly (reconnect rate x retention window).
+    pub async fn delete_offline_older_than(
+        &self,
+        retention_minutes: i64,
+    ) -> Result<u64, sqlx::Error> {
+        let cutoff = Utc::now() - chrono::Duration::minutes(retention_minutes);
+        let result = sqlx::query(
+            r#"
+            DELETE FROM data_planes
+            WHERE status = 'offline' AND last_seen < $1
+            "#,
+        )
+        .bind(cutoff)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     /// Update the artifact hash reported by a data plane and reset drift status.
     pub async fn update_artifact_hash(
         &self,

--- a/crates/barbacane-control/src/server.rs
+++ b/crates/barbacane-control/src/server.rs
@@ -17,6 +17,11 @@ const STALE_SWEEP_INTERVAL_SECS: u64 = 60;
 /// Data planes not seen for this many minutes are marked offline.
 const STALE_THRESHOLD_MINUTES: i64 = 2;
 
+/// Offline data planes older than this are hard-deleted by the sweep, bounding
+/// unbounded row growth from repeated connect/register/disconnect cycles while
+/// still retaining recent offline history.
+const OFFLINE_RETENTION_MINUTES: i64 = 24 * 60;
+
 /// Server configuration.
 pub struct ServerConfig {
     pub listen_addr: SocketAddr,
@@ -86,6 +91,18 @@ async fn run_stale_sweep(pool: PgPool) {
             }
             Err(e) => {
                 tracing::error!(error = %e, "Failed to sweep stale data planes");
+            }
+        }
+        match repo
+            .delete_offline_older_than(OFFLINE_RETENTION_MINUTES)
+            .await
+        {
+            Ok(0) => {}
+            Ok(count) => {
+                tracing::info!(count, "Deleted long-offline data planes past retention");
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to reap offline data planes");
             }
         }
     }

--- a/crates/barbacane/src/validator.rs
+++ b/crates/barbacane/src/validator.rs
@@ -455,17 +455,42 @@ impl OperationValidator {
         &self,
         query_string: Option<&str>,
     ) -> Result<(), Vec<ValidationError2>> {
-        let param_map: HashMap<String, String> = query_string
+        // Parse pairs, tracking how many times each key occurs. The raw query
+        // string is forwarded verbatim to the dispatcher/upstream, but this
+        // validator only sees the collapsed (last-wins) value — so a repeated
+        // declared parameter is an HTTP-parameter-pollution vector: the check
+        // would pass on one value while a different value the upstream may
+        // consume rides along unvalidated. Reject duplicates of declared query
+        // params rather than validate a value the upstream might not use.
+        let mut param_map: HashMap<String, String> = HashMap::new();
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for pair in query_string
             .unwrap_or("")
             .split('&')
             .filter(|s| !s.is_empty())
-            .filter_map(|pair| {
-                let mut parts = pair.splitn(2, '=');
-                let key = parts.next()?;
-                let value = parts.next().unwrap_or("");
-                Some((percent_decode(key), percent_decode(value)))
+        {
+            let mut parts = pair.splitn(2, '=');
+            let Some(key) = parts.next() else { continue };
+            let value = parts.next().unwrap_or("");
+            let key = percent_decode(key);
+            *counts.entry(key.clone()).or_insert(0) += 1;
+            param_map.insert(key, percent_decode(value));
+        }
+
+        let mut errors: Vec<ValidationError2> = self
+            .query_params
+            .iter()
+            .filter(|p| counts.get(&p.name).copied().unwrap_or(0) > 1)
+            .map(|p| ValidationError2::InvalidParameter {
+                name: p.name.clone(),
+                location: "query".into(),
+                reason: "duplicate query parameter is not allowed".into(),
             })
             .collect();
+        if !errors.is_empty() {
+            errors.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
+            return Err(errors);
+        }
 
         validate_params(
             &self.query_params,
@@ -722,6 +747,30 @@ mod tests {
         // Missing optional is OK
         let result = validator.validate_query_params(Some(""));
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn duplicate_declared_query_param_is_rejected() {
+        // HTTP parameter pollution: a declared param with an enum constraint is
+        // sent twice. The validator collapses to last-wins ("user", which passes)
+        // while the raw query forwarded to the upstream still carries "admin".
+        // Reject the ambiguity rather than validate a value the upstream may not
+        // use.
+        let schema = serde_json::json!({"type": "string", "enum": ["user"]});
+        let params = vec![make_param("role", "query", false, Some(schema))];
+        let validator = OperationValidator::new(&params, None);
+
+        let result = validator.validate_query_params(Some("role=admin&role=user"));
+        assert!(result.is_err(), "duplicate declared param must be rejected");
+
+        // A single occurrence still validates normally.
+        assert!(validator.validate_query_params(Some("role=user")).is_ok());
+
+        // A duplicated *undeclared* param does not trip the guard (only declared
+        // params carry constraints the divergence could bypass).
+        assert!(validator
+            .validate_query_params(Some("other=1&other=2&role=user"))
+            .is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Closes barbacane-dev/private#15 (L1–L4, from the internal security review). All defense-in-depth / hygiene; batched into one PR.

## L1 — query-param HPP (`crates/barbacane/src/validator.rs`)

`validate_query_params` collapsed the query to last-wins while the raw query is forwarded verbatim to the dispatcher/upstream. `?role=admin&role=user` validated as `role=user` (passes an enum constraint) while `role=admin` rode along. Duplicate occurrences of a **declared** query parameter are now rejected (undeclared duplicates are left alone — only declared params carry the constraints the divergence could bypass).

## L2 — unbounded `data_planes` row growth (`barbacane-control`)

Each WS registration `INSERT`s a row that is only marked offline (never deleted) on disconnect, so a holder of a valid `data-plane:connect` key could loop connect/register/disconnect and grow the table without bound. New `delete_offline_older_than` reaps rows offline past a 24h retention window, wired into the existing stale sweep. Bounds growth to ~(reconnect rate × retention).

## L3 — E1070 skipped for versioned refs (`barbacane-compiler`)

The plaintext-secret scan looked up `plugin_secret_fields` by the raw spec reference, which keeps any `@version` suffix, so `jwt-auth@1.0.0` missed the `jwt-auth` key and was never scanned. The reference is now normalized (`normalize_plugin_name`, the same fn that builds the map keys) before lookup. URL-sourced plugins remain uncovered (their schema isn't fetched at compile time) — documented in code.

## L4 — unbounded plugin download (`barbacane-compiler`)

`download_plugin` buffered the whole response body with no cap, letting an untrusted plugin host OOM the compile/CI host. Now rejects an oversize declared `Content-Length` and caps the actual read at 64 MiB (wasm) / 1 MiB (`plugin.toml`) via a bounded reader, so a missing/lying length can't OOM either.

## Tests

Added the duplicate-query-param rejection test; compiler + validator suites pass; workspace clippy clean, fmt applied.
