### PR TITLE
fix(telemetry): valid W3C root trace-id and non-panicking metrics render (#88)

### DIFF
--- a/crates/barbacane-telemetry/src/prometheus.rs
+++ b/crates/barbacane-telemetry/src/prometheus.rs
@@ -9,9 +9,15 @@ use prometheus_client::encoding::text::encode;
 pub const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
 
 /// Render the metrics registry to Prometheus text format.
+///
+/// Runs on every `/__barbacane/metrics` scrape, so it must never panic: on the
+/// (practically unreachable) encoding error, log and return what was rendered so
+/// far rather than aborting the scrape handler.
 pub fn render_metrics(registry: &MetricsRegistry) -> String {
     let mut buffer = String::new();
-    encode(&mut buffer, &registry.registry).expect("encoding metrics should not fail");
+    if let Err(e) = encode(&mut buffer, &registry.registry) {
+        tracing::error!(error = %e, "failed to encode Prometheus metrics");
+    }
     buffer
 }
 

--- a/crates/barbacane-telemetry/src/tracing.rs
+++ b/crates/barbacane-telemetry/src/tracing.rs
@@ -8,12 +8,12 @@
 use opentelemetry::{
     global,
     propagation::{Extractor, Injector, TextMapPropagator},
-    trace::{SpanKind, TraceContextExt, Tracer},
+    trace::{SpanContext, SpanKind, TraceContextExt, TraceFlags, TraceState, Tracer},
     Context, KeyValue,
 };
 use opentelemetry_sdk::{
     propagation::TraceContextPropagator,
-    trace::{Sampler, TracerProvider},
+    trace::{IdGenerator, RandomIdGenerator, Sampler, TracerProvider},
     Resource,
 };
 use std::collections::HashMap;
@@ -130,10 +130,24 @@ impl TracingContext {
     }
 
     /// Create a new root tracing context (no parent).
+    ///
+    /// Generates a real 16-byte W3C/OTel `TraceId` and installs it as the
+    /// context's span context, so spans created under this context correlate and
+    /// the trace id propagates on outbound requests. A UUID-v4 string is not a
+    /// valid W3C trace id, so it must not be used here.
     pub fn new_root() -> Self {
         let request_id = Uuid::new_v4().to_string();
-        let context = Context::current();
-        let trace_id = Uuid::new_v4().to_string();
+
+        let generator = RandomIdGenerator::default();
+        let span_context = SpanContext::new(
+            generator.new_trace_id(),
+            generator.new_span_id(),
+            TraceFlags::SAMPLED,
+            false,
+            TraceState::default(),
+        );
+        let trace_id = span_context.trace_id().to_string();
+        let context = Context::current().with_remote_span_context(span_context);
 
         Self {
             context,
@@ -303,6 +317,27 @@ mod tests {
         // Should have injected x-request-id
         assert!(headers.contains_key("x-request-id"));
         assert_eq!(headers.get("x-request-id").unwrap(), &ctx.request_id);
+    }
+
+    #[test]
+    fn new_root_has_valid_w3c_trace_id() {
+        let ctx = TracingContext::new_root();
+        // A W3C/OTel trace id is 16 bytes = 32 lowercase hex chars, no dashes
+        // (a UUID-v4 string would be 36 chars with dashes and is invalid here).
+        assert_eq!(ctx.trace_id.len(), 32, "trace_id must be 32 hex chars");
+        assert!(ctx.trace_id.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(!ctx.trace_id.contains('-'));
+        // Must be non-zero (the all-zero id is the OTel "invalid" sentinel).
+        assert_ne!(ctx.trace_id, "0".repeat(32));
+        // The context's span context carries the same id, so child spans
+        // correlate and it propagates on outbound requests.
+        assert_eq!(
+            ctx.context.span().span_context().trace_id().to_string(),
+            ctx.trace_id
+        );
+
+        // Two roots get distinct ids.
+        assert_ne!(ctx.trace_id, TracingContext::new_root().trace_id);
     }
 
     #[test]


### PR DESCRIPTION
Addresses two of the three items in #88 (the third, deprecated-OTel-API / stack migration, is a dependency major-bump tracked separately — see the issue thread).

## Root trace-id (`tracing.rs`)
`TracingContext::new_root()` stored a UUID-v4 string in `trace_id`, which is **not** a valid 16-byte W3C/OTel trace id — spans created under a root context did not correlate and the id did not propagate. It now generates a real `TraceId` via `RandomIdGenerator` and installs it as the context's span context (mirroring `from_headers`), so children correlate and it propagates on outbound requests.

## `/metrics` panic (`prometheus.rs`)
`render_metrics()` ran `encode(...).expect(...)` on every `/__barbacane/metrics` scrape; it now logs and returns the partial buffer instead of panicking the scrape handler.

## Tests
- `new_root_has_valid_w3c_trace_id`: 32 hex chars, non-zero, context carries the same id, distinct per root.
- Existing telemetry tests pass; workspace clippy clean, fmt applied.

Does **not** bump the OTel stack — deferred pending a decision on timing (a major dependency upgrade right before a release).