### PR TITLE
chore(ci): supply-chain hardening — pin actions, least-priv permissions, full cargo-deny gate (#87)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,26 @@
+name: Scheduled Supply-chain Audit
+
+# The CI `audit` job runs cargo-deny only when code changes. This scheduled run
+# catches newly-published advisories against the pinned dependency tree even when
+# the repo is otherwise idle.
+on:
+  schedule:
+    # Mondays at 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Run supply-chain checks (advisories, licenses, bans, sources)
+        run: cargo deny check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Least privilege by default: jobs only read the repo. Elevate per-job if ever needed.
+permissions:
+  contents: read
+
 jobs:
   # Detect what files changed to skip unnecessary jobs
   changes:
@@ -24,7 +28,7 @@ jobs:
       ui: ${{ steps.filter.outputs.ui }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         with:
           filters: |
@@ -98,8 +102,8 @@ jobs:
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
 
-      - name: Run security audit
-        run: cargo deny check advisories
+      - name: Run supply-chain checks (advisories, licenses, bans, sources)
+        run: cargo deny check
 
   # Build workspace and plugins, upload artifacts for test job
   build:
@@ -373,10 +377,14 @@ jobs:
   benchmarks:
     name: Benchmark Check
     runs-on: ubuntu-latest
+    # The issue_comment path checks out and runs PR-head code, so restrict the
+    # "/bench" trigger to trusted commenters (OWNER/MEMBER/COLLABORATOR); a
+    # drive-by comment from an outside contributor must not run arbitrary code.
     if: >-
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-benchmarks'))
       || (github.event_name == 'issue_comment' && github.event.issue.pull_request
-          && contains(github.event.comment.body, '/bench'))
+          && contains(github.event.comment.body, '/bench')
+          && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v2
+        uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2
         with:
-          mdbook-version: 'latest'
+          mdbook-version: '0.5.4'
 
       - name: Build documentation
         run: mdbook build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Least privilege by default; jobs that push images / upload SARIF / create the
+# release elevate via their own per-job `permissions:` blocks below.
+permissions:
+  contents: read
+
 jobs:
   # Validate that the tag matches the version in Cargo.toml
   validate-version:
@@ -149,23 +154,23 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push data plane
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile
@@ -178,7 +183,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=barbacane-${{ matrix.suffix }}
 
       - name: Build and push control plane
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile.control
@@ -191,7 +196,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=barbacane-control-${{ matrix.suffix }}
 
       - name: Build and push standalone
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile.standalone
@@ -226,14 +231,14 @@ jobs:
           echo "minor=$MINOR" >> $GITHUB_OUTPUT
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -315,7 +320,7 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -323,7 +328,7 @@ jobs:
 
       # Security scan images
       - name: Scan data plane image
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/barbacane:${{ steps.tag.outputs.version }}
           format: 'sarif'
@@ -331,7 +336,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Scan control plane image
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/barbacane-control:${{ steps.tag.outputs.version }}
           format: 'sarif'
@@ -353,7 +358,7 @@ jobs:
           category: 'trivy-control-plane'
 
       - name: Scan standalone image
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/barbacane-standalone:${{ steps.tag.outputs.version }}
           format: 'sarif'
@@ -578,7 +583,7 @@ jobs:
           cat release-notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           name: Barbacane v${{ steps.tag.outputs.version }}
           body_path: release-notes.md

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,7 @@
 # cargo-deny configuration
 # https://embarkstudios.github.io/cargo-deny/
+#
+# CI runs the full `cargo deny check` (advisories + licenses + bans + sources).
 
 [advisories]
 ignore = [
@@ -9,3 +11,44 @@ ignore = [
     # instant crate unmaintained — pinned by notify 7.x (transitive via notify-types), no safe upgrade
     "RUSTSEC-2024-0384",
 ]
+
+[licenses]
+# Allow-list of SPDX licenses permitted in the dependency tree. Dual-licensed
+# crates (e.g. `ittapi` = BSD-3-Clause OR GPL-2.0-only, `r-efi` = MIT OR
+# Apache-2.0 OR LGPL-2.1-or-later) are satisfied by the permissive alternative
+# below, so GPL/LGPL do not need to be allowed.
+allow = [
+    # Barbacane's own crates.
+    "AGPL-3.0-only",
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.9
+# Our own crates are AGPL-3.0-only; don't license-check the workspace members.
+private = { ignore = true }
+
+[bans]
+# Duplicate major versions are tracked but not yet a hard failure: several exist
+# today (axum 0.7+0.8, tower 0.4+0.5, ...) and are being deduped separately.
+# Flip to "deny" once the tree is clean.
+multiple-versions = "warn"
+wildcards = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
Addresses most of #87 (SBOM/cosign signing deferred — see bottom).

## Pinned third-party actions (to commit SHAs)
- `aquasecurity/trivy-action` — was **`@master`** (×3 in `release.yml`) → `v0.36.0` SHA. This is the headline supply-chain risk in the issue.
- `peaceiris/actions-mdbook` → SHA, and `mdbook-version` pinned `latest` → `0.5.4`.
- `dorny/paths-filter`, `docker/{setup-buildx,login,build-push}-action`, `softprops/action-gh-release` → SHAs.
- `dtolnay/rust-toolchain` **intentionally left on `@stable`**: its git ref *is* the toolchain selector, so SHA-pinning requires adding an explicit `toolchain:` input to all ~13 call sites — a separate mechanical change, noted as follow-up. `actions/*` and `github/codeql-action` (GitHub-owned) left on major tags.

## Least-privilege permissions
- Top-level `permissions: contents: read` added to `ci.yml` and `release.yml`. The image-push / SARIF-upload / release-creation jobs already carry their own per-job `packages: write` / `security-events: write` / `contents: write` blocks, so they're unaffected.

## `/bench` gating
- The `issue_comment` `/bench` trigger checks out and runs **PR-head code**. It's now gated on `author_association ∈ {OWNER, MEMBER, COLLABORATOR}`, so an outside contributor's comment can't run arbitrary code with the workflow token.

## Full cargo-deny gate
- CI promoted from `cargo deny check advisories` to full `cargo deny check` (advisories + licenses + bans + sources).
- `deny.toml` now has a complete policy: a permissive SPDX allow-list (dual-licensed GPL/LGPL crates like `ittapi`/`r-efi` are satisfied via their permissive alternative), `[bans] multiple-versions = "warn"` (duplicates exist today — flip to `deny` after #89's dedupe), and a locked-down `[sources]`.
- **Verified locally**: `cargo deny check` → advisories/licenses/bans/sources all pass.
- New `audit.yml`: weekly scheduled `cargo deny check`.

## Deferred (issue stays open, scoped)
SBOM generation + cosign/SLSA image signing. These need a signing-identity/OIDC decision and a real release run to validate (can't be exercised by PR CI), so they belong in a focused release-workflow PR rather than the pre-release burn-down.

## Verification note
`ci.yml` changes are exercised by this PR's CI (incl. the full cargo-deny gate). `release.yml`/`audit.yml`/`docs.yml` changes are not triggered by a PR; they were validated by YAML parse + local `cargo deny check` + SHA resolution against upstream.
