### PR TITLE
chore(deps): narrow workspace tokio features from "full" (#89)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4647,7 +4647,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,20 @@ serde_json = "1"
 serde_yaml = "0.9"
 
 # Async runtime
-tokio = { version = "1", features = ["full"] }
+# Narrowed from "full": only the features the workspace actually uses (rt +
+# multi/current-thread runtimes, macros, timers, sync primitives, net, async IO,
+# fs, and signal for graceful shutdown). Dependencies request their own tokio
+# features independently, so this does not affect them.
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "macros",
+    "time",
+    "sync",
+    "net",
+    "io-util",
+    "fs",
+    "signal",
+] }
 
 # HTTP
 hyper = { version = "1", features = ["server", "http1", "http2"] }


### PR DESCRIPTION
Partially addresses #89.

## Narrowed tokio features
The workspace declared `tokio = { features = ["full"] }`, pulling process / signal / all-IO / etc. into every crate. Narrowed to the set the workspace actually uses:
`rt-multi-thread, macros, time, sync, net, io-util, fs, signal`.

Determined by auditing `tokio::` usage across all crates: no `tokio::process`, no `io-std`; both multi- and current-thread runtimes + `spawn_blocking` + `signal` (graceful shutdown) are used. Dependencies request their own tokio features independently, so this doesn't affect them. Verified with `cargo check --workspace --all-targets`.

## Duplicate axum/tower NOT addressed here (blocked)
Investigated with `cargo tree`: the axum 0.7 / tower 0.4 / matchit duplicates come **solely from `tonic` via `opentelemetry-otlp` 0.27** — our own crates already use axum 0.8. So there is no "older consumer of ours" to align; deduping requires bumping the **OTel stack** (the migration tracked in #88, deferred). `deny.toml` `[bans] multiple-versions` stays `warn` until that lands.

#89 stays open, rescoped to the dedup (blocked on #88's OTel bump).