### PR TITLE
feat(plugin-sdk): shared building blocks (errors, log, http, jwt) (#90 part 2)

### DIFF
--- a/crates/barbacane-plugin-sdk/Cargo.toml
+++ b/crates/barbacane-plugin-sdk/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+serde_json = { workspace = true }
 base64 = { workspace = true }
 barbacane-plugin-macros = { workspace = true }
 

--- a/crates/barbacane-plugin-sdk/src/errors.rs
+++ b/crates/barbacane-plugin-sdk/src/errors.rs
@@ -1,0 +1,126 @@
+//! RFC 9457 `application/problem+json` error responses.
+//!
+//! Plugins repeatedly hand-rolled the same `problem+json` body + content-type.
+//! [`ProblemDetails`] builds that consistently and converts to a [`Response`].
+//!
+//! ```
+//! use barbacane_plugin_sdk::errors::ProblemDetails;
+//! let resp = ProblemDetails::new(403, "urn:barbacane:error:acl-denied", "Forbidden")
+//!     .detail("Access denied by ACL policy")
+//!     .with("consumer", "alice")
+//!     .into_response();
+//! assert_eq!(resp.status, 403);
+//! assert_eq!(resp.headers.get("content-type").unwrap(), "application/problem+json");
+//! ```
+
+use std::collections::BTreeMap;
+
+use crate::types::Response;
+
+/// Builder for an RFC 9457 problem-details error response.
+#[derive(Debug, Clone)]
+pub struct ProblemDetails {
+    status: u16,
+    type_uri: String,
+    title: String,
+    detail: Option<String>,
+    /// Extra members merged into the problem object (RFC 9457 §3.2).
+    extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl ProblemDetails {
+    /// Start a problem with the given HTTP status, `type` URI, and title.
+    pub fn new(status: u16, type_uri: impl Into<String>, title: impl Into<String>) -> Self {
+        Self {
+            status,
+            type_uri: type_uri.into(),
+            title: title.into(),
+            detail: None,
+            extensions: BTreeMap::new(),
+        }
+    }
+
+    /// Set the human-readable `detail` member.
+    pub fn detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    /// Add an extension member (any JSON-serializable value).
+    pub fn with(mut self, key: impl Into<String>, value: impl Into<serde_json::Value>) -> Self {
+        self.extensions.insert(key.into(), value.into());
+        self
+    }
+
+    /// Serialize to the problem-details JSON object.
+    pub fn to_json(&self) -> serde_json::Value {
+        let mut obj = serde_json::Map::new();
+        obj.insert("type".into(), self.type_uri.clone().into());
+        obj.insert("title".into(), self.title.clone().into());
+        obj.insert("status".into(), self.status.into());
+        if let Some(detail) = &self.detail {
+            obj.insert("detail".into(), detail.clone().into());
+        }
+        for (k, v) in &self.extensions {
+            obj.insert(k.clone(), v.clone());
+        }
+        serde_json::Value::Object(obj)
+    }
+
+    /// Build the `Response`, setting status, `content-type: application/problem+json`,
+    /// and the serialized body. Extra response headers can be added afterward.
+    pub fn into_response(self) -> Response {
+        let mut headers = BTreeMap::new();
+        headers.insert(
+            "content-type".to_string(),
+            "application/problem+json".to_string(),
+        );
+        // A problem object always serializes; fall back to a minimal body if not.
+        let body = serde_json::to_vec(&self.to_json()).unwrap_or_else(|_| {
+            format!(
+                r#"{{"type":"{}","title":"{}","status":{}}}"#,
+                self.type_uri, self.title, self.status
+            )
+            .into_bytes()
+        });
+        Response {
+            status: self.status,
+            headers,
+            body: Some(body),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_problem_response() {
+        let resp = ProblemDetails::new(403, "urn:barbacane:error:acl-denied", "Forbidden")
+            .detail("Access denied by ACL policy")
+            .with("consumer", "alice")
+            .into_response();
+
+        assert_eq!(resp.status, 403);
+        assert_eq!(
+            resp.headers.get("content-type").unwrap(),
+            "application/problem+json"
+        );
+        let body: serde_json::Value = serde_json::from_slice(resp.body.as_ref().unwrap()).unwrap();
+        assert_eq!(body["type"], "urn:barbacane:error:acl-denied");
+        assert_eq!(body["title"], "Forbidden");
+        assert_eq!(body["status"], 403);
+        assert_eq!(body["detail"], "Access denied by ACL policy");
+        assert_eq!(body["consumer"], "alice");
+    }
+
+    #[test]
+    fn omits_detail_when_unset() {
+        let json =
+            ProblemDetails::new(429, "urn:barbacane:error:rate-limited", "Too Many Requests")
+                .to_json();
+        assert_eq!(json.get("detail"), None);
+        assert_eq!(json["status"], 429);
+    }
+}

--- a/crates/barbacane-plugin-sdk/src/http.rs
+++ b/crates/barbacane-plugin-sdk/src/http.rs
@@ -1,0 +1,159 @@
+//! Outbound HTTP via the `host_http_call` import.
+//!
+//! Plugins each redeclared the `host_http_call` / `host_http_read_result`
+//! externs and the request/response types + call orchestration. This centralizes
+//! them. The request/response body travels via the side-channel body functions
+//! in [`crate::body`], not in the JSON.
+//!
+//! On non-wasm targets (unit tests) [`call`] returns [`HttpError::Unsupported`].
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+// Only used by the wasm `call` implementation below.
+#[cfg(target_arch = "wasm32")]
+use crate::body;
+
+/// An outbound HTTP request. The body is passed separately to [`call`] and sent
+/// via the side-channel, so it is not part of this JSON.
+#[derive(Debug, Clone, Serialize)]
+pub struct HttpRequest {
+    pub method: String,
+    pub url: String,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+}
+
+impl HttpRequest {
+    /// Build a request with method + url and no headers/timeout.
+    pub fn new(method: impl Into<String>, url: impl Into<String>) -> Self {
+        Self {
+            method: method.into(),
+            url: url.into(),
+            headers: BTreeMap::new(),
+            timeout_ms: None,
+        }
+    }
+
+    /// Add a header.
+    pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.insert(name.into(), value.into());
+        self
+    }
+
+    /// Set the request timeout in milliseconds.
+    pub fn timeout_ms(mut self, ms: u64) -> Self {
+        self.timeout_ms = Some(ms);
+        self
+    }
+}
+
+/// An HTTP response from the host. The body is read from the side-channel and
+/// attached by [`call`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct HttpResponse {
+    pub status: u16,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+    #[serde(skip)]
+    pub body: Option<Vec<u8>>,
+}
+
+impl HttpResponse {
+    /// The response body as a UTF-8 string, if present and valid.
+    pub fn body_str(&self) -> Option<&str> {
+        self.body
+            .as_deref()
+            .and_then(|b| std::str::from_utf8(b).ok())
+    }
+}
+
+/// Failure modes of [`call`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HttpError {
+    /// The host could not reach the target (`host_http_call` < 0).
+    Unreachable,
+    /// The host returned an empty result.
+    Empty,
+    /// Reading the result buffer returned an unexpected length.
+    ReadFailed,
+    /// The result was not a valid `HttpResponse` JSON.
+    InvalidResponse,
+    /// Called on a non-wasm target (no host available).
+    Unsupported,
+}
+
+/// Perform an outbound HTTP request through the host. `body` (if any) is sent via
+/// the side-channel; the response body is read back the same way.
+#[cfg(target_arch = "wasm32")]
+pub fn call(request: &HttpRequest, body_bytes: Option<&[u8]>) -> Result<HttpResponse, HttpError> {
+    #[link(wasm_import_module = "barbacane")]
+    extern "C" {
+        fn host_http_call(req_ptr: i32, req_len: i32) -> i32;
+        fn host_http_read_result(buf_ptr: i32, buf_len: i32) -> i32;
+    }
+
+    body::set_http_request_body(body_bytes.unwrap_or(&[]));
+
+    let serialized = serde_json::to_vec(request).map_err(|_| HttpError::InvalidResponse)?;
+    let result_len = unsafe { host_http_call(serialized.as_ptr() as i32, serialized.len() as i32) };
+    if result_len < 0 {
+        return Err(HttpError::Unreachable);
+    }
+    if result_len == 0 {
+        return Err(HttpError::Empty);
+    }
+
+    let mut buf = vec![0u8; result_len as usize];
+    let bytes_read = unsafe { host_http_read_result(buf.as_mut_ptr() as i32, result_len) };
+    if bytes_read != result_len {
+        return Err(HttpError::ReadFailed);
+    }
+
+    let mut resp: HttpResponse =
+        serde_json::from_slice(&buf).map_err(|_| HttpError::InvalidResponse)?;
+    resp.body = body::read_http_response_body();
+    Ok(resp)
+}
+
+/// Non-wasm stub: no host to call.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn call(_request: &HttpRequest, _body_bytes: Option<&[u8]>) -> Result<HttpResponse, HttpError> {
+    Err(HttpError::Unsupported)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_serializes_without_body_field() {
+        let req = HttpRequest::new("POST", "https://upstream/x")
+            .header("content-type", "application/json")
+            .timeout_ms(5000);
+        let v: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["method"], "POST");
+        assert_eq!(v["url"], "https://upstream/x");
+        assert_eq!(v["headers"]["content-type"], "application/json");
+        assert_eq!(v["timeout_ms"], 5000);
+        assert!(v.get("body").is_none());
+    }
+
+    #[test]
+    fn timeout_omitted_when_unset() {
+        let v: serde_json::Value =
+            serde_json::to_value(HttpRequest::new("GET", "https://x")).unwrap();
+        assert!(v.get("timeout_ms").is_none());
+    }
+
+    #[test]
+    fn call_is_unsupported_on_native() {
+        assert!(matches!(
+            call(&HttpRequest::new("GET", "https://x"), None),
+            Err(HttpError::Unsupported)
+        ));
+    }
+}

--- a/crates/barbacane-plugin-sdk/src/jwt.rs
+++ b/crates/barbacane-plugin-sdk/src/jwt.rs
@@ -1,0 +1,146 @@
+//! JWT parsing helpers shared by the auth plugins.
+//!
+//! These cover the *parsing* that jwt-auth / oidc-auth / oauth2-auth each
+//! duplicated: Bearer extraction, base64url segment decoding, an `aud` claim
+//! that may be a string or array, and decoding the payload for inspection.
+//!
+//! Signature verification is **not** done here — that is the host's job
+//! (`host_verify_signature`) or the introspection endpoint's. These helpers only
+//! decode; callers still verify before trusting claims.
+
+use base64::Engine;
+use serde::Deserialize;
+
+/// The JWT `aud` claim: a single audience or a list (RFC 7519 §4.1.3).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum Audience {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl Audience {
+    /// Whether `value` is among the audience(s).
+    pub fn contains(&self, value: &str) -> bool {
+        match self {
+            Audience::Single(s) => s == value,
+            Audience::Multiple(v) => v.iter().any(|s| s == value),
+        }
+    }
+}
+
+/// Errors decoding a JWT's structure (not signature validity).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JwtDecodeError {
+    /// The token is not three `.`-separated segments.
+    Malformed,
+    /// A segment was not valid base64url.
+    InvalidBase64,
+    /// The decoded payload was not valid JSON for the target type.
+    InvalidJson,
+}
+
+/// Extract the token from an `Authorization` header value, if it uses the
+/// `Bearer` scheme (case-insensitive per RFC 7235). Returns `None` otherwise.
+pub fn bearer_token(authorization: &str) -> Option<&str> {
+    let (scheme, rest) = authorization.split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return None;
+    }
+    let token = rest.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token)
+    }
+}
+
+/// Split a compact JWT into its three base64url segments (header, payload,
+/// signature). Returns `None` if the token is not exactly three segments.
+pub fn split(token: &str) -> Option<(&str, &str, &str)> {
+    let mut parts = token.split('.');
+    let header = parts.next()?;
+    let payload = parts.next()?;
+    let signature = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((header, payload, signature))
+}
+
+/// Decode a single base64url (no padding) JWT segment to bytes.
+pub fn decode_segment(segment: &str) -> Result<Vec<u8>, JwtDecodeError> {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(segment)
+        .map_err(|_| JwtDecodeError::InvalidBase64)
+}
+
+/// Decode the payload (claims) of a compact JWT **without verifying the
+/// signature**. Use only after the signature has been verified elsewhere.
+pub fn decode_claims_unverified<T>(token: &str) -> Result<T, JwtDecodeError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let (_, payload, _) = split(token).ok_or(JwtDecodeError::Malformed)?;
+    let bytes = decode_segment(payload)?;
+    serde_json::from_slice(&bytes).map_err(|_| JwtDecodeError::InvalidJson)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audience_matches_single_and_multiple() {
+        assert!(Audience::Single("a".into()).contains("a"));
+        assert!(!Audience::Single("a".into()).contains("b"));
+        let multi = Audience::Multiple(vec!["a".into(), "b".into()]);
+        assert!(multi.contains("b"));
+        assert!(!multi.contains("c"));
+    }
+
+    #[test]
+    fn audience_deserializes_string_or_array() {
+        let s: Audience = serde_json::from_str(r#""api""#).unwrap();
+        assert_eq!(s, Audience::Single("api".into()));
+        let m: Audience = serde_json::from_str(r#"["a","b"]"#).unwrap();
+        assert_eq!(m, Audience::Multiple(vec!["a".into(), "b".into()]));
+    }
+
+    #[test]
+    fn bearer_extraction_is_case_insensitive() {
+        assert_eq!(bearer_token("Bearer abc"), Some("abc"));
+        assert_eq!(bearer_token("bearer  abc "), Some("abc"));
+        assert_eq!(bearer_token("BEARER xyz"), Some("xyz"));
+        assert_eq!(bearer_token("Basic abc"), None);
+        assert_eq!(bearer_token("Bearer "), None);
+        assert_eq!(bearer_token("token"), None);
+    }
+
+    #[test]
+    fn decode_claims_reads_payload_without_verifying() {
+        // {"sub":"u1","aud":"api"} as base64url, dummy header/sig.
+        let payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"sub":"u1","aud":"api"}"#);
+        let token = format!("aGVhZGVy.{payload}.c2ln");
+
+        #[derive(Deserialize)]
+        struct Claims {
+            sub: String,
+            aud: Audience,
+        }
+        let claims: Claims = decode_claims_unverified(&token).unwrap();
+        assert_eq!(claims.sub, "u1");
+        assert!(claims.aud.contains("api"));
+    }
+
+    #[test]
+    fn malformed_tokens_rejected() {
+        assert_eq!(split("a.b"), None);
+        assert_eq!(split("a.b.c.d"), None);
+        assert_eq!(
+            decode_claims_unverified::<serde_json::Value>("a.b"),
+            Err(JwtDecodeError::Malformed)
+        );
+    }
+}

--- a/crates/barbacane-plugin-sdk/src/lib.rs
+++ b/crates/barbacane-plugin-sdk/src/lib.rs
@@ -28,6 +28,10 @@
 //! ```
 
 pub mod body;
+pub mod errors;
+pub mod http;
+pub mod jwt;
+pub mod log;
 pub mod types;
 
 /// Re-export proc macros for plugin development.
@@ -35,6 +39,9 @@ pub use barbacane_plugin_macros::{barbacane_dispatcher, barbacane_middleware};
 
 pub mod prelude {
     pub use crate::body::*;
+    pub use crate::errors::ProblemDetails;
     pub use crate::types::*;
     pub use crate::{barbacane_dispatcher, barbacane_middleware};
+    // `http`, `jwt`, and `log` are used via their module path (e.g. `log::warn`,
+    // `jwt::Audience`, `http::call`) to keep the prelude unambiguous.
 }

--- a/crates/barbacane-plugin-sdk/src/log.rs
+++ b/crates/barbacane-plugin-sdk/src/log.rs
@@ -1,0 +1,65 @@
+//! Host logging via the `host_log` import.
+//!
+//! Plugins each redeclared the `host_log` extern + a wasm/native cfg wrapper.
+//! This centralizes it. On non-wasm targets (unit tests) logging is a no-op.
+//!
+//! ```
+//! use barbacane_plugin_sdk::log;
+//! log::warn("rate limit exceeded");
+//! ```
+
+/// Log levels understood by the host (`host_log` level argument).
+pub const LEVEL_ERROR: i32 = 0;
+pub const LEVEL_WARN: i32 = 1;
+pub const LEVEL_INFO: i32 = 2;
+pub const LEVEL_DEBUG: i32 = 3;
+
+/// Emit a log line at the given level via the host.
+#[cfg(target_arch = "wasm32")]
+pub fn log(level: i32, msg: &str) {
+    #[link(wasm_import_module = "barbacane")]
+    extern "C" {
+        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
+    }
+    unsafe {
+        host_log(level, msg.as_ptr() as i32, msg.len() as i32);
+    }
+}
+
+/// No-op on non-wasm targets (native unit tests).
+#[cfg(not(target_arch = "wasm32"))]
+pub fn log(_level: i32, _msg: &str) {}
+
+/// Log at ERROR level.
+pub fn error(msg: &str) {
+    log(LEVEL_ERROR, msg);
+}
+
+/// Log at WARN level.
+pub fn warn(msg: &str) {
+    log(LEVEL_WARN, msg);
+}
+
+/// Log at INFO level.
+pub fn info(msg: &str) {
+    log(LEVEL_INFO, msg);
+}
+
+/// Log at DEBUG level.
+pub fn debug(msg: &str) {
+    log(LEVEL_DEBUG, msg);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_is_noop_on_native() {
+        // Just exercises the native path; must not panic.
+        error("e");
+        warn("w");
+        info("i");
+        debug("d");
+    }
+}

--- a/plugins/ip-restriction/Cargo.lock
+++ b/plugins/ip-restriction/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]


### PR DESCRIPTION
Second part of #90 (after the macro fix #118). **Purely additive** — adds shared helpers to `barbacane-plugin-sdk`; no plugin is changed yet. The migrations that delete the duplicated copies follow in batched PRs.

New modules:
- **`errors::ProblemDetails`** — RFC 9457 `application/problem+json` builder → `Response` (`.detail()`, `.with(k,v)` extensions, `.into_response()`). Replaces the hand-rolled copies in ~20 plugins.
- **`log`** — `host_log` wrapper with wasm/native cfg + `error/warn/info/debug` (~18 plugins each redeclared the extern).
- **`http`** — `host_http_call`/`host_http_read_result` wrapper with `HttpRequest`/`HttpResponse`; body via the existing side-channel body fns (9 plugins). Matches the confirmed host JSON + buffer protocol.
- **`jwt`** — `Audience` (string-or-array), `bearer_token` (case-insensitive), base64url `decode_segment`, and `decode_claims_unverified` (auth plugins). **Parsing only** — signature verification stays host-side.

Tests: unit tests for the pure helpers (errors, jwt incl. round-trip decode, http request shaping); native stubs make `log`/`http` compile+test off-wasm. Adds `serde_json` to SDK deps. Both clippy gates + fmt clean; SDK compiles for wasm32 (validated via a plugin build).