### PR TITLE
refactor(plugins): adopt SDK ProblemDetails across 18 plugins (#90 part 3a)

### DIFF
--- a/plugins/acl/Cargo.lock
+++ b/plugins/acl/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/acl/src/lib.rs
+++ b/plugins/acl/src/lib.rs
@@ -122,30 +122,16 @@ impl Acl {
 
     /// Generate a 403 Forbidden response in RFC 9457 problem+json format.
     fn forbidden_response(&self, consumer: Option<&str>) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        let mut body = serde_json::json!({
-            "type": "urn:barbacane:error:acl-denied",
-            "title": "Forbidden",
-            "status": 403,
-            "detail": self.message
-        });
+        let mut problem = ProblemDetails::new(403, "urn:barbacane:error:acl-denied", "Forbidden")
+            .detail(self.message.clone());
 
         if !self.hide_consumer_in_errors {
             if let Some(consumer) = consumer {
-                body["consumer"] = serde_json::Value::String(consumer.to_string());
+                problem = problem.with("consumer", consumer.to_string());
             }
         }
 
-        Response {
-            status: 403,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        problem.into_response()
     }
 }
 

--- a/plugins/ai-prompt-guard/Cargo.lock
+++ b/plugins/ai-prompt-guard/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/ai-prompt-guard/src/lib.rs
+++ b/plugins/ai-prompt-guard/src/lib.rs
@@ -306,47 +306,29 @@ impl AiPromptGuard {
 // ---------------------------------------------------------------------------
 
 fn misconfig_response(default_profile: &str) -> Response {
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:ai-prompt-guard-misconfigured",
-        "title": "Internal Server Error",
-        "status": 500,
-        "detail": format!(
-            "ai-prompt-guard default_profile '{}' does not exist in the profiles map; fix the plugin configuration.",
-            default_profile
-        ),
-    });
-    Response {
-        status: 500,
-        headers,
-        body: Some(body.to_string().into_bytes()),
-    }
+    ProblemDetails::new(
+        500,
+        "urn:barbacane:error:ai-prompt-guard-misconfigured",
+        "Internal Server Error",
+    )
+    .detail(format!(
+        "ai-prompt-guard default_profile '{}' does not exist in the profiles map; fix the plugin configuration.",
+        default_profile
+    ))
+    .into_response()
 }
 
 fn regex_compile_error_response(profile_name: &str, detail: &str) -> Response {
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:ai-prompt-guard-misconfigured",
-        "title": "Internal Server Error",
-        "status": 500,
-        "detail": format!(
-            "ai-prompt-guard profile '{}' has an invalid regex: {}",
-            profile_name, detail
-        ),
-    });
-    Response {
-        status: 500,
-        headers,
-        body: Some(body.to_string().into_bytes()),
-    }
+    ProblemDetails::new(
+        500,
+        "urn:barbacane:error:ai-prompt-guard-misconfigured",
+        "Internal Server Error",
+    )
+    .detail(format!(
+        "ai-prompt-guard profile '{}' has an invalid regex: {}",
+        profile_name, detail
+    ))
+    .into_response()
 }
 
 // ---------------------------------------------------------------------------
@@ -354,22 +336,13 @@ fn regex_compile_error_response(profile_name: &str, detail: &str) -> Response {
 // ---------------------------------------------------------------------------
 
 fn reject(profile: &PromptProfile, detail: &str) -> Response {
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:ai-prompt-guard",
-        "title": "Bad Request",
-        "status": profile.reject_status,
-        "detail": detail,
-    });
-    Response {
-        status: profile.reject_status,
-        headers,
-        body: Some(body.to_string().into_bytes()),
-    }
+    ProblemDetails::new(
+        profile.reject_status,
+        "urn:barbacane:error:ai-prompt-guard",
+        "Bad Request",
+    )
+    .detail(detail)
+    .into_response()
 }
 
 /// Extract a string representation of a message's `content` field.

--- a/plugins/ai-proxy/Cargo.lock
+++ b/plugins/ai-proxy/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/ai-proxy/src/lib.rs
+++ b/plugins/ai-proxy/src/lib.rs
@@ -281,7 +281,11 @@ impl AiProxy {
         };
         host::context_set(
             protocols::responses::CTX_STORE_DOWNGRADE,
-            if preflight.store_downgrade { "true" } else { "false" },
+            if preflight.store_downgrade {
+                "true"
+            } else {
+                "false"
+            },
         );
 
         let client_model = match extract_client_model(&req.body) {
@@ -626,51 +630,27 @@ pub(crate) fn extract_client_model(body: &Option<Vec<u8>>) -> Option<String> {
 /// provider contracts (OpenAI Chat Completions and Responses both require
 /// `model`) and ADR-0030 §0's caller-owned-model principle.
 pub(crate) fn model_required_response() -> Response {
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:model_required",
-        "title": "Bad Request",
-        "status": 400,
-        "code": "model_required",
-        "detail": "ai-proxy: request body is missing a non-empty `model` field. \
+    ProblemDetails::new(400, "urn:barbacane:error:model_required", "Bad Request")
+        .detail(
+            "ai-proxy: request body is missing a non-empty `model` field. \
                    The gateway does not pick a default model — see ADR-0030 §0.",
-    });
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    Response {
-        status: 400,
-        headers,
-        body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-    }
+        )
+        .with("code", "model_required")
+        .into_response()
 }
 
 /// 400 problem+json when `routes` was declared but no entry matches and there
 /// is no `default_target` / flat fallthrough — the operator's catalog doesn't
 /// cover the model the client requested. ADR-0030 §3.
 pub(crate) fn no_route_response(client_model: &str) -> Response {
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:no_route",
-        "title": "Bad Request",
-        "status": 400,
-        "code": "no_route",
-        "detail": format!(
+    ProblemDetails::new(400, "urn:barbacane:error:no_route", "Bad Request")
+        .detail(format!(
             "ai-proxy: no route matched model {:?}. Add a `routes` entry, set `default_target`, \
              or configure a flat `provider`. See ADR-0030 §3.",
             client_model
-        ),
-    });
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    Response {
-        status: 400,
-        headers,
-        body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-    }
+        ))
+        .with("code", "no_route")
+        .into_response()
 }
 
 /// 403 problem+json when a resolved target's `allow` / `deny` rules reject
@@ -688,23 +668,10 @@ pub(crate) fn model_not_permitted_response(client_model: &str, reason: PolicyDen
             client_model
         ),
     };
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:model_not_permitted",
-        "title": "Forbidden",
-        "status": 403,
-        "code": "model_not_permitted",
-        "detail": detail,
-    });
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    Response {
-        status: 403,
-        headers,
-        body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-    }
+    ProblemDetails::new(403, "urn:barbacane:error:model_not_permitted", "Forbidden")
+        .detail(detail)
+        .with("code", "model_not_permitted")
+        .into_response()
 }
 
 /// Reason a target's catalog policy rejected the client's model.
@@ -819,22 +786,9 @@ pub(crate) fn error_response(status: u16, detail: &str) -> Response {
         502 => ("urn:barbacane:error:upstream-unavailable", "Bad Gateway"),
         _ => ("urn:barbacane:error:internal", "Internal Server Error"),
     };
-    let body = serde_json::json!({
-        "type": error_type,
-        "title": title,
-        "status": status,
-        "detail": detail
-    });
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    Response {
-        status,
-        headers,
-        body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-    }
+    ProblemDetails::new(status, error_type, title)
+        .detail(detail)
+        .into_response()
 }
 
 /// Build a JSON labels string with one key-value pair.

--- a/plugins/ai-proxy/src/protocols/models.rs
+++ b/plugins/ai-proxy/src/protocols/models.rs
@@ -29,7 +29,7 @@
 //!   their `specs/` folder. Tracked as PR-6 in the implementation plan.
 
 use crate::providers::openai::openai_headers;
-use crate::{build_response, http_call, host, AiProxy, HttpRequest, Provider, Response};
+use crate::{build_response, host, http_call, AiProxy, HttpRequest, Provider, Response};
 use barbacane_plugin_sdk::prelude::*;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -84,17 +84,11 @@ pub(crate) fn handle(plugin: &AiProxy, req: &Request) -> Response {
     if !warnings.is_empty() {
         let obj = body.as_object_mut().expect("object literal");
         obj.insert("partial".to_string(), serde_json::Value::Bool(true));
-        obj.insert(
-            "warnings".to_string(),
-            serde_json::Value::Array(warnings),
-        );
+        obj.insert("warnings".to_string(), serde_json::Value::Array(warnings));
     }
 
     let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/json".to_string(),
-    );
+    headers.insert("content-type".to_string(), "application/json".to_string());
     Response {
         status: 200,
         headers,
@@ -132,10 +126,10 @@ fn collect_unique_providers(plugin: &AiProxy) -> Vec<UpstreamProvider> {
     let mut out: Vec<UpstreamProvider> = Vec::new();
 
     let push = |provider: &Provider,
-                    api_key: Option<&str>,
-                    base_url: Option<&str>,
-                    seen: &mut BTreeSet<(String, String)>,
-                    out: &mut Vec<UpstreamProvider>| {
+                api_key: Option<&str>,
+                base_url: Option<&str>,
+                seen: &mut BTreeSet<(String, String)>,
+                out: &mut Vec<UpstreamProvider>| {
         let resolved_base = base_url
             .filter(|s| !s.is_empty())
             .map(String::from)
@@ -205,10 +199,7 @@ fn fetch_provider_models(
         Provider::Anthropic => {
             let url = format!("{}/v1/models", upstream.base_url.trim_end_matches('/'));
             let mut h = BTreeMap::new();
-            h.insert(
-                "content-type".to_string(),
-                "application/json".to_string(),
-            );
+            h.insert("content-type".to_string(), "application/json".to_string());
             h.insert(
                 "anthropic-version".to_string(),
                 crate::providers::anthropic::ANTHROPIC_API_VERSION.to_string(),
@@ -254,11 +245,10 @@ fn fetch_provider_models(
     }
 
     let body_str = resp.body_str().unwrap_or("");
-    let body: serde_json::Value =
-        serde_json::from_str(body_str).map_err(|e| UpstreamFailure {
-            status: resp.status,
-            detail: format!("invalid JSON from upstream: {}", e),
-        })?;
+    let body: serde_json::Value = serde_json::from_str(body_str).map_err(|e| UpstreamFailure {
+        status: resp.status,
+        detail: format!("invalid JSON from upstream: {}", e),
+    })?;
 
     Ok(translate_models_response(upstream.provider.clone(), &body))
 }
@@ -296,9 +286,8 @@ pub(crate) fn translate_models_response(
                 // Normalize so clients can group consistently.
                 let mut o = item;
                 if let Some(obj) = o.as_object_mut() {
-                    obj.entry("owned_by".to_string()).or_insert_with(|| {
-                        serde_json::Value::String(provider.name().to_string())
-                    });
+                    obj.entry("owned_by".to_string())
+                        .or_insert_with(|| serde_json::Value::String(provider.name().to_string()));
                 }
                 o
             })
@@ -326,24 +315,16 @@ pub(crate) fn translate_models_response(
 // ---------------------------------------------------------------------------
 
 fn method_not_allowed_response() -> Response {
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:method_not_allowed",
-        "title": "Method Not Allowed",
-        "status": 405,
-        "code": "method_not_allowed",
-        "detail": "ai-proxy: /v1/models accepts GET only.",
-    });
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    headers.insert("allow".to_string(), "GET".to_string());
-    Response {
-        status: 405,
-        headers,
-        body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-    }
+    let mut resp = ProblemDetails::new(
+        405,
+        "urn:barbacane:error:method_not_allowed",
+        "Method Not Allowed",
+    )
+    .detail("ai-proxy: /v1/models accepts GET only.")
+    .with("code", "method_not_allowed")
+    .into_response();
+    resp.headers.insert("allow".to_string(), "GET".to_string());
+    resp
 }
 
 #[cfg(test)]
@@ -533,8 +514,7 @@ mod tests {
         };
         let resp = handle(&plugin, &req);
         assert_eq!(resp.status, 405);
-        let body: serde_json::Value =
-            serde_json::from_slice(resp.body.as_ref().unwrap()).unwrap();
+        let body: serde_json::Value = serde_json::from_slice(resp.body.as_ref().unwrap()).unwrap();
         assert_eq!(body["code"], "method_not_allowed");
         assert_eq!(resp.headers.get("allow").map(|s| s.as_str()), Some("GET"));
     }

--- a/plugins/ai-proxy/src/protocols/responses.rs
+++ b/plugins/ai-proxy/src/protocols/responses.rs
@@ -22,7 +22,7 @@
 
 use crate::providers::openai::{openai_headers, openai_url};
 use crate::{
-    error_response, host, http_call, host_http_stream, AiProxy, HttpRequest, Provider, Response,
+    error_response, host, host_http_stream, http_call, AiProxy, HttpRequest, Provider, Response,
     TargetConfig,
 };
 use barbacane_plugin_sdk::prelude::*;
@@ -56,7 +56,11 @@ impl ResponsesPreflight {
             Ok(v) => v,
             // Malformed JSON — let downstream handlers handle their own
             // shape errors (the dispatch layer doesn't try to parse here).
-            Err(_) => return Ok(Self { store_downgrade: false }),
+            Err(_) => {
+                return Ok(Self {
+                    store_downgrade: false,
+                })
+            }
         };
 
         if v.get("previous_response_id").is_some()
@@ -90,7 +94,9 @@ pub(crate) fn handle(
 ) -> Result<Response, String> {
     match target.provider {
         Provider::OpenAI => openai_passthrough(plugin, target, req, streaming),
-        Provider::Ollama => Ok(responses_not_supported_for_provider_response(Provider::Ollama)),
+        Provider::Ollama => Ok(responses_not_supported_for_provider_response(
+            Provider::Ollama,
+        )),
         Provider::Anthropic => {
             // Parse the body for translation. The preflight already confirmed
             // `previous_response_id` is absent and stashed `store_downgrade`
@@ -104,12 +110,8 @@ pub(crate) fn handle(
                 .map(|v| v == "true")
                 .unwrap_or(true);
 
-            let translation = ResponsesToAnthropic::translate(
-                &body,
-                client_model,
-                streaming,
-                plugin.max_tokens,
-            )?;
+            let translation =
+                ResponsesToAnthropic::translate(&body, client_model, streaming, plugin.max_tokens)?;
 
             // Buffered Anthropic call — true SSE translation deferred per
             // ADR-0030 §2; mirror the Chat Completions buffering behavior.
@@ -118,7 +120,8 @@ pub(crate) fn handle(
                     "ai-proxy: Anthropic streaming for Responses not yet supported; buffering response",
                 );
             }
-            let raw_resp = plugin.anthropic_messages_call_raw(target, translation.body.as_bytes())?;
+            let raw_resp =
+                plugin.anthropic_messages_call_raw(target, translation.body.as_bytes())?;
 
             // 4xx/5xx pass through as-is (don't mangle upstream errors).
             if !(200..300).contains(&raw_resp.status) {
@@ -132,7 +135,11 @@ pub(crate) fn handle(
             // operators can quantify both "this client sends store: true" and
             // "this client sends reasoning items we dropped".
             let mut headers = raw_resp.headers;
-            attach_warnings(&mut headers, store_downgrade, translation.dropped_reasoning_count > 0);
+            attach_warnings(
+                &mut headers,
+                store_downgrade,
+                translation.dropped_reasoning_count > 0,
+            );
 
             if store_downgrade {
                 host::metric_counter_inc(
@@ -195,8 +202,7 @@ fn openai_passthrough(
         // we'd need to parse and rewrite mid-stream. True SSE handling is
         // already deferred for both protocols — see ADR-0030 §2 "Streaming".
         let req_json = serde_json::to_vec(&http_req).map_err(|e| e.to_string())?;
-        let result =
-            unsafe { host_http_stream(req_json.as_ptr() as i32, req_json.len() as i32) };
+        let result = unsafe { host_http_stream(req_json.as_ptr() as i32, req_json.len() as i32) };
         if result < 0 {
             return Err("upstream stream failed".to_string());
         }
@@ -301,7 +307,11 @@ impl ResponsesToAnthropic {
                         }
                     } else {
                         if current_role.as_deref() != Some(role) {
-                            flush_message(current_role.as_deref(), &mut current_blocks, &mut messages);
+                            flush_message(
+                                current_role.as_deref(),
+                                &mut current_blocks,
+                                &mut messages,
+                            );
                             current_role = Some(role.to_string());
                         }
                         current_blocks.extend(blocks);
@@ -379,7 +389,10 @@ impl ResponsesToAnthropic {
             .unwrap_or(4096);
 
         let mut anthropic = serde_json::Map::new();
-        anthropic.insert("model".to_string(), serde_json::Value::String(client_model.to_string()));
+        anthropic.insert(
+            "model".to_string(),
+            serde_json::Value::String(client_model.to_string()),
+        );
         anthropic.insert("messages".to_string(), serde_json::Value::Array(messages));
         if !system_parts.is_empty() {
             anthropic.insert(
@@ -441,7 +454,10 @@ fn build_text_or_array_blocks(value: Option<&serde_json::Value>) -> Vec<serde_js
         Some(serde_json::Value::Array(parts)) => parts
             .iter()
             .filter_map(|part| {
-                let pt = part.get("type").and_then(|v| v.as_str()).unwrap_or("input_text");
+                let pt = part
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("input_text");
                 match pt {
                     "input_text" | "text" => part
                         .get("text")
@@ -663,51 +679,35 @@ fn attach_warnings(
 // ---------------------------------------------------------------------------
 
 fn previous_response_id_not_supported_response() -> Response {
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:previous_response_id_not_supported",
-        "title": "Bad Request",
-        "status": 400,
-        "code": "previous_response_id_not_supported",
-        "detail": "ai-proxy: this gateway is stateless. \
+    ProblemDetails::new(
+        400,
+        "urn:barbacane:error:previous_response_id_not_supported",
+        "Bad Request",
+    )
+    .detail(
+        "ai-proxy: this gateway is stateless. \
                    `previous_response_id` requires server-side conversation \
                    storage that ADR-0030 §2 explicitly defers. Resend the \
                    full `input[]` each turn.",
-    });
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    Response {
-        status: 400,
-        headers,
-        body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-    }
+    )
+    .with("code", "previous_response_id_not_supported")
+    .into_response()
 }
 
 fn responses_not_supported_for_provider_response(provider: Provider) -> Response {
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:responses_not_supported_for_provider",
-        "title": "Bad Request",
-        "status": 400,
-        "code": "responses_not_supported_for_provider",
-        "detail": format!(
-            "ai-proxy: provider {:?} does not implement the OpenAI Responses API \
+    ProblemDetails::new(
+        400,
+        "urn:barbacane:error:responses_not_supported_for_provider",
+        "Bad Request",
+    )
+    .detail(format!(
+        "ai-proxy: provider {:?} does not implement the OpenAI Responses API \
              (no upstream surface to translate to or passthrough). Use \
              `/v1/chat/completions` instead, or route to OpenAI/Anthropic.",
-            provider.name()
-        ),
-    });
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    Response {
-        status: 400,
-        headers,
-        body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-    }
+        provider.name()
+    ))
+    .with("code", "responses_not_supported_for_provider")
+    .into_response()
 }
 
 // Re-export so dispatch can use the same helper without duplicating the
@@ -741,8 +741,7 @@ mod tests {
             Err(r) => r,
         };
         assert_eq!(resp.status, 400);
-        let body: serde_json::Value =
-            serde_json::from_slice(resp.body.as_ref().unwrap()).unwrap();
+        let body: serde_json::Value = serde_json::from_slice(resp.body.as_ref().unwrap()).unwrap();
         assert_eq!(body["code"], "previous_response_id_not_supported");
         assert_eq!(
             body["type"],
@@ -761,13 +760,21 @@ mod tests {
     #[test]
     fn preflight_store_true_triggers_downgrade() {
         let body = Some(br#"{"input":[],"store":true}"#.to_vec());
-        assert!(ResponsesPreflight::from_body(&body).unwrap().store_downgrade);
+        assert!(
+            ResponsesPreflight::from_body(&body)
+                .unwrap()
+                .store_downgrade
+        );
     }
 
     #[test]
     fn preflight_store_false_skips_downgrade() {
         let body = Some(br#"{"input":[],"store":false}"#.to_vec());
-        assert!(!ResponsesPreflight::from_body(&body).unwrap().store_downgrade);
+        assert!(
+            !ResponsesPreflight::from_body(&body)
+                .unwrap()
+                .store_downgrade
+        );
     }
 
     #[test]
@@ -775,7 +782,11 @@ mod tests {
         // OpenAI server-side default for store is true; clients that don't
         // send it expect server-side persistence. We downgrade.
         let body = Some(br#"{"input":[]}"#.to_vec());
-        assert!(ResponsesPreflight::from_body(&body).unwrap().store_downgrade);
+        assert!(
+            ResponsesPreflight::from_body(&body)
+                .unwrap()
+                .store_downgrade
+        );
     }
 
     // --- Responses → Anthropic translation ---
@@ -788,9 +799,8 @@ mod tests {
 
     #[test]
     fn translate_in_input_text_becomes_text_block() {
-        let res = translate_in(
-            r#"{"input":[{"type":"input_text","role":"user","content":"Hello"}]}"#,
-        );
+        let res =
+            translate_in(r#"{"input":[{"type":"input_text","role":"user","content":"Hello"}]}"#);
         let body: serde_json::Value = serde_json::from_str(&res.body).unwrap();
         let messages = body["messages"].as_array().unwrap();
         assert_eq!(messages.len(), 1);
@@ -1035,7 +1045,11 @@ mod tests {
             r#"{"id":"msg","model":"x","content":[],"usage":{"input_tokens":0,"output_tokens":0}}"#,
         );
         let id = v["id"].as_str().unwrap();
-        assert!(id.starts_with("resp_"), "id should start with resp_, got {}", id);
+        assert!(
+            id.starts_with("resp_"),
+            "id should start with resp_, got {}",
+            id
+        );
         // After the prefix is a 36-character UUID dashed-hex form.
         let uuid_part = id.trim_start_matches("resp_");
         assert_eq!(uuid_part.len(), 36, "{}", uuid_part);
@@ -1076,8 +1090,7 @@ mod tests {
     fn responses_not_supported_for_provider_shape() {
         let resp = responses_not_supported_for_provider_response(Provider::Ollama);
         assert_eq!(resp.status, 400);
-        let body: serde_json::Value =
-            serde_json::from_slice(resp.body.as_ref().unwrap()).unwrap();
+        let body: serde_json::Value = serde_json::from_slice(resp.body.as_ref().unwrap()).unwrap();
         assert_eq!(body["code"], "responses_not_supported_for_provider");
         assert_eq!(
             body["type"],
@@ -1122,4 +1135,3 @@ mod tests {
         assert!(headers.get("warning").is_none());
     }
 }
-

--- a/plugins/ai-response-guard/Cargo.lock
+++ b/plugins/ai-response-guard/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/ai-response-guard/src/lib.rs
+++ b/plugins/ai-response-guard/src/lib.rs
@@ -239,47 +239,29 @@ impl AiResponseGuard {
 // ---------------------------------------------------------------------------
 
 fn misconfig_response(default_profile: &str) -> Response {
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:ai-response-guard-misconfigured",
-        "title": "Internal Server Error",
-        "status": 500,
-        "detail": format!(
-            "ai-response-guard default_profile '{}' does not exist in the profiles map; fix the plugin configuration.",
-            default_profile
-        ),
-    });
-    Response {
-        status: 500,
-        headers,
-        body: Some(body.to_string().into_bytes()),
-    }
+    ProblemDetails::new(
+        500,
+        "urn:barbacane:error:ai-response-guard-misconfigured",
+        "Internal Server Error",
+    )
+    .detail(format!(
+        "ai-response-guard default_profile '{}' does not exist in the profiles map; fix the plugin configuration.",
+        default_profile
+    ))
+    .into_response()
 }
 
 fn regex_compile_error_response(profile_name: &str, detail: &str) -> Response {
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:ai-response-guard-misconfigured",
-        "title": "Internal Server Error",
-        "status": 500,
-        "detail": format!(
-            "ai-response-guard profile '{}' has an invalid regex: {}",
-            profile_name, detail
-        ),
-    });
-    Response {
-        status: 500,
-        headers,
-        body: Some(body.to_string().into_bytes()),
-    }
+    ProblemDetails::new(
+        500,
+        "urn:barbacane:error:ai-response-guard-misconfigured",
+        "Internal Server Error",
+    )
+    .detail(format!(
+        "ai-response-guard profile '{}' has an invalid regex: {}",
+        profile_name, detail
+    ))
+    .into_response()
 }
 
 // ---------------------------------------------------------------------------
@@ -323,22 +305,13 @@ fn apply_redactions(input: &str, rules: &[CompiledRedact]) -> String {
 // ---------------------------------------------------------------------------
 
 fn blocked_response() -> Response {
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:ai-response-blocked",
-        "title": "Bad Gateway",
-        "status": 502,
-        "detail": "Upstream response was blocked by content policy.",
-    });
-    Response {
-        status: 502,
-        headers,
-        body: Some(body.to_string().into_bytes()),
-    }
+    ProblemDetails::new(
+        502,
+        "urn:barbacane:error:ai-response-blocked",
+        "Bad Gateway",
+    )
+    .detail("Upstream response was blocked by content policy.")
+    .into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/ai-token-limit/Cargo.lock
+++ b/plugins/ai-token-limit/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/ai-token-limit/src/lib.rs
+++ b/plugins/ai-token-limit/src/lib.rs
@@ -249,20 +249,26 @@ impl AiTokenLimit {
         profile: &TokenProfile,
         result: &RateLimitResult,
     ) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
+        let mut resp = ProblemDetails::new(
+            429,
+            "urn:barbacane:error:ai-token-limit-exceeded",
+            "Too Many Requests",
+        )
+        .detail(format!(
+            "Token budget exhausted under profile '{}' (quota: {} tokens per {} seconds).",
+            profile_name, profile.quota, profile.window
+        ))
+        .with("profile", profile_name)
+        .into_response();
 
-        headers.insert(
+        resp.headers.insert(
             "ratelimit-policy".to_string(),
             format!(
                 "{}-{};q={};w={}",
                 self.policy_name, profile_name, profile.quota, profile.window
             ),
         );
-        headers.insert(
+        resp.headers.insert(
             "ratelimit".to_string(),
             format!(
                 "limit={}, remaining=0, reset={}",
@@ -270,25 +276,11 @@ impl AiTokenLimit {
             ),
         );
         if let Some(retry_after) = result.retry_after {
-            headers.insert("retry-after".to_string(), retry_after.to_string());
+            resp.headers
+                .insert("retry-after".to_string(), retry_after.to_string());
         }
 
-        let body = serde_json::json!({
-            "type": "urn:barbacane:error:ai-token-limit-exceeded",
-            "title": "Too Many Requests",
-            "status": 429,
-            "detail": format!(
-                "Token budget exhausted under profile '{}' (quota: {} tokens per {} seconds).",
-                profile_name, profile.quota, profile.window
-            ),
-            "profile": profile_name,
-        });
-
-        Response {
-            status: 429,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        resp
     }
 }
 
@@ -299,22 +291,13 @@ impl AiTokenLimit {
 /// 503 response returned when the host rate limiter is unavailable and the
 /// plugin is configured to fail closed (the default).
 fn unavailable_response() -> Response {
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:ai-token-limit-unavailable",
-        "title": "Service Unavailable",
-        "status": 503,
-        "detail": "Token-budget limiter is unavailable; request rejected (fail closed).",
-    });
-    Response {
-        status: 503,
-        headers,
-        body: Some(body.to_string().into_bytes()),
-    }
+    ProblemDetails::new(
+        503,
+        "urn:barbacane:error:ai-token-limit-unavailable",
+        "Service Unavailable",
+    )
+    .detail("Token-budget limiter is unavailable; request rejected (fail closed).")
+    .into_response()
 }
 
 /// 500 response returned when `default_profile` isn't in the `profiles` map.
@@ -329,25 +312,16 @@ fn misconfig_response(default_profile: &str) -> Response {
             default_profile
         ),
     );
-    let mut headers = BTreeMap::new();
-    headers.insert(
-        "content-type".to_string(),
-        "application/problem+json".to_string(),
-    );
-    let body = serde_json::json!({
-        "type": "urn:barbacane:error:ai-token-limit-misconfigured",
-        "title": "Internal Server Error",
-        "status": 500,
-        "detail": format!(
-            "ai-token-limit default_profile '{}' does not exist in the profiles map; fix the plugin configuration.",
-            default_profile
-        ),
-    });
-    Response {
-        status: 500,
-        headers,
-        body: Some(body.to_string().into_bytes()),
-    }
+    ProblemDetails::new(
+        500,
+        "urn:barbacane:error:ai-token-limit-misconfigured",
+        "Internal Server Error",
+    )
+    .detail(format!(
+        "ai-token-limit default_profile '{}' does not exist in the profiles map; fix the plugin configuration.",
+        default_profile
+    ))
+    .into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/bot-detection/Cargo.lock
+++ b/plugins/bot-detection/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/bot-detection/src/lib.rs
+++ b/plugins/bot-detection/src/lib.rs
@@ -6,7 +6,6 @@
 
 use barbacane_plugin_sdk::prelude::*;
 use serde::Deserialize;
-use std::collections::BTreeMap;
 
 /// Bot detection middleware configuration.
 #[barbacane_middleware]
@@ -93,34 +92,22 @@ impl BotDetection {
 
     /// Build the blocked response.
     fn blocked_response(&self, user_agent: Option<&str>) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        let mut body = serde_json::json!({
-            "type": "urn:barbacane:error:bot-detected",
-            "title": "Forbidden",
-            "status": self.status,
-            "detail": self.message,
-        });
+        let mut problem =
+            ProblemDetails::new(self.status, "urn:barbacane:error:bot-detected", "Forbidden")
+                .detail(self.message.clone());
 
         if let Some(ua) = user_agent {
-            body["user_agent"] = serde_json::Value::String(ua.to_string());
+            problem = problem.with("user_agent", ua.to_string());
         }
 
-        Response {
-            status: self.status,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        problem.into_response()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     fn make_request(ua: Option<&str>) -> Request {
         let mut headers = BTreeMap::new();

--- a/plugins/cel/Cargo.lock
+++ b/plugins/cel/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/cel/src/lib.rs
+++ b/plugins/cel/src/lib.rs
@@ -169,10 +169,7 @@ impl CelPolicy {
             "query".to_string(),
             str_val(req.query.as_deref().unwrap_or("")),
         );
-        request_map.insert(
-            "body".to_string(),
-            str_val(req.body_str().unwrap_or("")),
-        );
+        request_map.insert("body".to_string(), str_val(req.body_str().unwrap_or("")));
         request_map.insert("body_json".to_string(), parse_body_json(req));
         request_map.insert("client_ip".to_string(), str_val(&req.client_ip));
 
@@ -207,24 +204,9 @@ impl CelPolicy {
 
     /// 403 Forbidden response for policy denial.
     fn denied_response(&self) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        let body = serde_json::json!({
-            "type": "urn:barbacane:error:cel-denied",
-            "title": "Forbidden",
-            "status": 403,
-            "detail": self.deny_message
-        });
-
-        Response {
-            status: 403,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        ProblemDetails::new(403, "urn:barbacane:error:cel-denied", "Forbidden")
+            .detail(self.deny_message.as_str())
+            .into_response()
     }
 
     /// problem+json response for `on_match.deny`. The configured `code` becomes
@@ -243,69 +225,36 @@ impl CelPolicy {
             .clone()
             .unwrap_or_else(|| action.code.clone());
 
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        let body = serde_json::json!({
-            "type": format!("urn:barbacane:error:{}", action.code),
-            "title": title,
-            "status": status,
-            "code": action.code,
-            "detail": detail,
-        });
-
-        Response {
+        ProblemDetails::new(
             status,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+            format!("urn:barbacane:error:{}", action.code),
+            title,
+        )
+        .detail(detail)
+        .with("code", action.code.clone())
+        .into_response()
     }
 
     /// 500 Internal Server Error for CEL configuration errors (bad expression).
     fn config_error_response(&self, detail: &str) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        let body = serde_json::json!({
-            "type": "urn:barbacane:error:cel-config",
-            "title": "Internal Server Error",
-            "status": 500,
-            "detail": detail
-        });
-
-        Response {
-            status: 500,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        ProblemDetails::new(
+            500,
+            "urn:barbacane:error:cel-config",
+            "Internal Server Error",
+        )
+        .detail(detail)
+        .into_response()
     }
 
     /// 500 Internal Server Error for CEL evaluation errors.
     fn eval_error_response(&self, detail: &str) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        let body = serde_json::json!({
-            "type": "urn:barbacane:error:cel-evaluation",
-            "title": "Internal Server Error",
-            "status": 500,
-            "detail": detail
-        });
-
-        Response {
-            status: 500,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        ProblemDetails::new(
+            500,
+            "urn:barbacane:error:cel-evaluation",
+            "Internal Server Error",
+        )
+        .detail(detail)
+        .into_response()
     }
 }
 
@@ -339,7 +288,12 @@ fn empty_cel_map() -> cel::Value {
 /// would let an attacker take down every downstream policy by sending one bad byte.
 fn parse_body_json(req: &Request) -> cel::Value {
     let content_type = match req.headers.get("content-type") {
-        Some(v) => v.split(';').next().unwrap_or("").trim().to_ascii_lowercase(),
+        Some(v) => v
+            .split(';')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase(),
         None => return empty_cel_map(),
     };
     let is_json = content_type == "application/json"
@@ -519,7 +473,10 @@ mod tests {
         }
     }
 
-    fn create_config_with_on_match(expression: &str, set_context: BTreeMap<String, String>) -> CelPolicy {
+    fn create_config_with_on_match(
+        expression: &str,
+        set_context: BTreeMap<String, String>,
+    ) -> CelPolicy {
         CelPolicy {
             expression: expression.to_string(),
             deny_message: default_deny_message(),
@@ -1022,9 +979,9 @@ mod tests {
         // vacuum validator doesn't recurse into on_match.deny — so the regex
         // is enforced in Rust at first-request time. Returns a config error.
         for bad in [
-            "Bad-Code",          // hyphen
-            "BadCode",           // PascalCase
-            "1leading_digit",    // digit start
+            "Bad-Code",       // hyphen
+            "BadCode",        // PascalCase
+            "1leading_digit", // digit start
             "_leading_underscore",
             "has space",
             "",
@@ -1056,12 +1013,7 @@ mod tests {
 
     #[test]
     fn on_match_deny_accepts_valid_snake_case_codes() {
-        for ok in [
-            "model_not_permitted",
-            "x",
-            "a1",
-            "z9_a_b_c",
-        ] {
+        for ok in ["model_not_permitted", "x", "a1", "z9_a_b_c"] {
             let mut config = CelPolicy {
                 expression: "true".to_string(),
                 deny_message: default_deny_message(),
@@ -1166,7 +1118,9 @@ mod tests {
 
         let warnings = host::take_warnings();
         assert!(
-            warnings.iter().any(|w| w.contains("could not be parsed as JSON")),
+            warnings
+                .iter()
+                .any(|w| w.contains("could not be parsed as JSON")),
             "expected a parse-failure warning, got {:?}",
             warnings
         );
@@ -1347,7 +1301,10 @@ mod tests {
         }
 
         let context = host::get_context();
-        assert_eq!(context.get("ai.target").map(|s| s.as_str()), Some("premium"));
+        assert_eq!(
+            context.get("ai.target").map(|s| s.as_str()),
+            Some("premium")
+        );
     }
 
     #[test]
@@ -1360,7 +1317,9 @@ mod tests {
 
         match config.on_request(req) {
             Action::Continue(_) => {} // no 403 — routing mode
-            Action::ShortCircuit(resp) => panic!("expected continue in routing mode, got {}", resp.status),
+            Action::ShortCircuit(resp) => {
+                panic!("expected continue in routing mode, got {}", resp.status)
+            }
         }
 
         // Context was NOT set (expression was false)
@@ -1380,7 +1339,10 @@ mod tests {
         let _ = config.on_request(req);
 
         let context = host::get_context();
-        assert_eq!(context.get("ai.target").map(|s| s.as_str()), Some("premium"));
+        assert_eq!(
+            context.get("ai.target").map(|s| s.as_str()),
+            Some("premium")
+        );
         assert_eq!(context.get("ai.priority").map(|s| s.as_str()), Some("high"));
     }
 
@@ -1397,7 +1359,10 @@ mod tests {
         let config: CelPolicy = serde_json::from_str(json).expect("should parse");
         assert!(config.on_match.is_some());
         let on_match = config.on_match.unwrap();
-        assert_eq!(on_match.set_context.get("ai.target").map(|s| s.as_str()), Some("premium"));
+        assert_eq!(
+            on_match.set_context.get("ai.target").map(|s| s.as_str()),
+            Some("premium")
+        );
     }
 
     #[test]

--- a/plugins/cors/Cargo.lock
+++ b/plugins/cors/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/cors/src/lib.rs
+++ b/plugins/cors/src/lib.rs
@@ -299,25 +299,16 @@ impl Cors {
 
     /// Generate forbidden response for invalid CORS request.
     fn forbidden_response(&self, origin: &str) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-        headers.insert("vary".to_string(), "Origin".to_string());
-
-        let body = serde_json::json!({
-            "type": "urn:barbacane:error:cors-not-allowed",
-            "title": "CORS Not Allowed",
-            "status": 403,
-            "detail": format!("Origin '{}' is not allowed by CORS policy", origin)
-        });
-
-        Response {
-            status: 403,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        let mut resp = ProblemDetails::new(
+            403,
+            "urn:barbacane:error:cors-not-allowed",
+            "CORS Not Allowed",
+        )
+        .detail(format!("Origin '{}' is not allowed by CORS policy", origin))
+        .into_response();
+        resp.headers
+            .insert("vary".to_string(), "Origin".to_string());
+        resp
     }
 }
 

--- a/plugins/http-upstream/Cargo.lock
+++ b/plugins/http-upstream/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/http-upstream/src/lib.rs
+++ b/plugins/http-upstream/src/lib.rs
@@ -218,24 +218,9 @@ impl HttpUpstreamDispatcher {
 
         let full_detail = format!("{}: {}", detail, debug);
 
-        let body = serde_json::json!({
-            "type": error_type,
-            "title": title,
-            "status": status,
-            "detail": full_detail
-        });
-
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        Response {
-            status,
-            headers,
-            body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-        }
+        ProblemDetails::new(status, error_type, title)
+            .detail(full_detail)
+            .into_response()
     }
 }
 

--- a/plugins/ip-restriction/src/lib.rs
+++ b/plugins/ip-restriction/src/lib.rs
@@ -5,7 +5,6 @@
 
 use barbacane_plugin_sdk::prelude::*;
 use serde::Deserialize;
-use std::collections::BTreeMap;
 use std::net::IpAddr;
 
 /// IP restriction middleware configuration.
@@ -90,25 +89,14 @@ impl IpRestriction {
 
     /// Generate 403 Forbidden response.
     fn forbidden_response(&self, client_ip: &str) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        let body = serde_json::json!({
-            "type": "urn:barbacane:error:ip-restricted",
-            "title": "Forbidden",
-            "status": self.status,
-            "detail": self.message,
-            "client_ip": client_ip
-        });
-
-        Response {
-            status: self.status,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        ProblemDetails::new(
+            self.status,
+            "urn:barbacane:error:ip-restricted",
+            "Forbidden",
+        )
+        .detail(self.message.clone())
+        .with("client_ip", client_ip)
+        .into_response()
     }
 }
 
@@ -169,6 +157,7 @@ fn bits_match(a: &[u8], b: &[u8], prefix_len: u8, max_bits: u8) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     fn test_plugin() -> IpRestriction {
         serde_json::from_value(serde_json::json!({

--- a/plugins/kafka/Cargo.lock
+++ b/plugins/kafka/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/kafka/src/lib.rs
+++ b/plugins/kafka/src/lib.rs
@@ -221,24 +221,9 @@ impl KafkaDispatcher {
             _ => "urn:barbacane:error:internal",
         };
 
-        let body = serde_json::json!({
-            "type": error_type,
-            "title": title,
-            "status": status,
-            "detail": detail
-        });
-
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        Response {
-            status,
-            headers,
-            body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-        }
+        ProblemDetails::new(status, error_type, title)
+            .detail(detail)
+            .into_response()
     }
 }
 

--- a/plugins/lambda/Cargo.lock
+++ b/plugins/lambda/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/lambda/src/lib.rs
+++ b/plugins/lambda/src/lib.rs
@@ -159,24 +159,9 @@ impl LambdaDispatcher {
             _ => "urn:barbacane:error:internal",
         };
 
-        let body = serde_json::json!({
-            "type": error_type,
-            "title": title,
-            "status": status,
-            "detail": detail
-        });
-
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        Response {
-            status,
-            headers,
-            body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-        }
+        ProblemDetails::new(status, error_type, title)
+            .detail(detail)
+            .into_response()
     }
 }
 

--- a/plugins/nats/Cargo.lock
+++ b/plugins/nats/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/nats/src/lib.rs
+++ b/plugins/nats/src/lib.rs
@@ -178,24 +178,9 @@ impl NatsDispatcher {
             _ => "urn:barbacane:error:internal",
         };
 
-        let body = serde_json::json!({
-            "type": error_type,
-            "title": title,
-            "status": status,
-            "detail": detail
-        });
-
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        Response {
-            status,
-            headers,
-            body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-        }
+        ProblemDetails::new(status, error_type, title)
+            .detail(detail)
+            .into_response()
     }
 }
 

--- a/plugins/opa-authz/Cargo.lock
+++ b/plugins/opa-authz/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/opa-authz/src/lib.rs
+++ b/plugins/opa-authz/src/lib.rs
@@ -240,51 +240,26 @@ impl OpaAuthz {
 
     /// 403 Forbidden response for policy denial.
     fn denied_response(&self) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        let body = serde_json::json!({
-            "type": "urn:barbacane:error:opa-denied",
-            "title": "Forbidden",
-            "status": 403,
-            "detail": self.deny_message
-        });
-
-        Response {
-            status: 403,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        ProblemDetails::new(403, "urn:barbacane:error:opa-denied", "Forbidden")
+            .detail(self.deny_message.clone())
+            .into_response()
     }
 
     /// 503 Service Unavailable response for OPA errors.
     fn error_response(&self, error: &OpaError) -> Response {
         let status = error.status_code();
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
 
         let detail = match error {
             OpaError::ServiceError(msg) => msg.clone(),
         };
 
-        let body = serde_json::json!({
-            "type": "urn:barbacane:error:opa-unavailable",
-            "title": "Service Unavailable",
-            "status": status,
-            "detail": detail
-        });
-
-        Response {
+        ProblemDetails::new(
             status,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+            "urn:barbacane:error:opa-unavailable",
+            "Service Unavailable",
+        )
+        .detail(detail)
+        .into_response()
     }
 }
 

--- a/plugins/rate-limit/Cargo.lock
+++ b/plugins/rate-limit/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/rate-limit/src/lib.rs
+++ b/plugins/rate-limit/src/lib.rs
@@ -5,7 +5,6 @@
 
 use barbacane_plugin_sdk::prelude::*;
 use serde::Deserialize;
-use std::collections::BTreeMap;
 
 /// Rate limit middleware configuration.
 #[barbacane_middleware]
@@ -162,22 +161,13 @@ impl RateLimit {
     /// Generate a 503 response used when the limiter is unavailable and the
     /// plugin is configured to fail closed.
     fn unavailable_response(&self) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-        let body = serde_json::json!({
-            "type": "urn:barbacane:error:rate-limiter-unavailable",
-            "title": "Service Unavailable",
-            "status": 503,
-            "detail": "Rate limiter is unavailable; request rejected (fail closed)."
-        });
-        Response {
-            status: 503,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        ProblemDetails::new(
+            503,
+            "urn:barbacane:error:rate-limiter-unavailable",
+            "Service Unavailable",
+        )
+        .detail("Rate limiter is unavailable; request rejected (fail closed).")
+        .into_response()
     }
 
     /// Generate 429 Too Many Requests response.
@@ -186,15 +176,21 @@ impl RateLimit {
         result: &RateLimitResult,
         policy_header: &str,
     ) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
+        let mut resp = ProblemDetails::new(
+            429,
+            "urn:barbacane:error:rate-limit-exceeded",
+            "Too Many Requests",
+        )
+        .detail(format!(
+            "Rate limit exceeded. Limit: {} requests per {} seconds.",
+            self.quota, self.window
+        ))
+        .into_response();
 
         // IETF draft rate limit headers
-        headers.insert("ratelimit-policy".to_string(), policy_header.to_string());
-        headers.insert(
+        resp.headers
+            .insert("ratelimit-policy".to_string(), policy_header.to_string());
+        resp.headers.insert(
             "ratelimit".to_string(),
             format!(
                 "limit={}, remaining=0, reset={}",
@@ -204,24 +200,11 @@ impl RateLimit {
 
         // Retry-After header
         if let Some(retry_after) = result.retry_after {
-            headers.insert("retry-after".to_string(), retry_after.to_string());
+            resp.headers
+                .insert("retry-after".to_string(), retry_after.to_string());
         }
 
-        let body = serde_json::json!({
-            "type": "urn:barbacane:error:rate-limit-exceeded",
-            "title": "Too Many Requests",
-            "status": 429,
-            "detail": format!(
-                "Rate limit exceeded. Limit: {} requests per {} seconds.",
-                self.quota, self.window
-            )
-        });
-
-        Response {
-            status: 429,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        resp
     }
 }
 
@@ -320,6 +303,7 @@ fn log_message(_level: i32, _msg: &str) {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_extract_partition_key_client_ip_from_x_forwarded_for() {

--- a/plugins/request-size-limit/Cargo.lock
+++ b/plugins/request-size-limit/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/request-size-limit/src/lib.rs
+++ b/plugins/request-size-limit/src/lib.rs
@@ -5,7 +5,6 @@
 
 use barbacane_plugin_sdk::prelude::*;
 use serde::Deserialize;
-use std::collections::BTreeMap;
 
 /// Request size limit middleware configuration.
 #[barbacane_middleware]
@@ -62,33 +61,23 @@ impl RequestSizeLimit {
 
     /// Generate 413 Payload Too Large response.
     fn payload_too_large_response(&self, actual_size: u64) -> Response {
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        let body = serde_json::json!({
-            "type": "urn:barbacane:error:payload-too-large",
-            "title": "Payload Too Large",
-            "status": 413,
-            "detail": format!(
-                "Request body size {} bytes exceeds maximum allowed size of {} bytes.",
-                actual_size, self.max_bytes
-            )
-        });
-
-        Response {
-            status: 413,
-            headers,
-            body: Some(body.to_string().into_bytes()),
-        }
+        ProblemDetails::new(
+            413,
+            "urn:barbacane:error:payload-too-large",
+            "Payload Too Large",
+        )
+        .detail(format!(
+            "Request body size {} bytes exceeds maximum allowed size of {} bytes.",
+            actual_size, self.max_bytes
+        ))
+        .into_response()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     fn test_plugin() -> RequestSizeLimit {
         serde_json::from_value(serde_json::json!({

--- a/plugins/s3/Cargo.lock
+++ b/plugins/s3/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/s3/src/lib.rs
+++ b/plugins/s3/src/lib.rs
@@ -386,24 +386,9 @@ impl S3Dispatcher {
         };
 
         let full_detail = format!("{}: {}", detail, debug);
-        let body = serde_json::json!({
-            "type": error_type,
-            "title": title,
-            "status": status,
-            "detail": full_detail,
-        });
-
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        Response {
-            status,
-            headers,
-            body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-        }
+        ProblemDetails::new(status, error_type, title)
+            .detail(full_detail)
+            .into_response()
     }
 }
 

--- a/plugins/ws-upstream/Cargo.lock
+++ b/plugins/ws-upstream/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/ws-upstream/src/lib.rs
+++ b/plugins/ws-upstream/src/lib.rs
@@ -172,24 +172,9 @@ impl WsUpstreamDispatcher {
 
         let full_detail = format!("{}: {}", detail, debug);
 
-        let body = serde_json::json!({
-            "type": error_type,
-            "title": title,
-            "status": status,
-            "detail": full_detail
-        });
-
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/problem+json".to_string(),
-        );
-
-        Response {
-            status,
-            headers,
-            body: Some(serde_json::to_vec(&body).unwrap_or_default()),
-        }
+        ProblemDetails::new(status, error_type, title)
+            .detail(full_detail)
+            .into_response()
     }
 }
 


### PR DESCRIPTION
Part 3, batch A of #90 — migrate plugins onto the SDK helpers added in #119. This batch: the **RFC-9457 `problem+json` builder**, adopted by **18 plugins**, removing ~500 lines of duplication (net −340 in source).

## What changed
Each plugin's hand-rolled `application/problem+json` builder → `ProblemDetails::new(status, type, title).detail(..).with(k,v)..into_response()`.

**Exact output preserved** (these plugins have tests asserting specific fields):
- same status / `type` URI / `title` / `detail` (incl. `format!` interpolation);
- extra members mapped to `.with(...)`: `code` (cel, ai-proxy), `consumer` (acl), `user_agent` (bot-detection), `client_ip` (ip-restriction), `profile` (ai-token-limit);
- extra response headers re-inserted after `into_response()`: `vary` (cors), `allow` (ai-proxy models), `RateLimit-*` + `Retry-After` (rate-limit, ai-token-limit).
- Non-problem+json JSON left untouched: OpenAI-format ai-proxy bodies, `host_http_call` request JSON (opa-authz/lambda).

Plugins: acl, ai-prompt-guard, ai-proxy, ai-response-guard, ai-token-limit, bot-detection, cel, cors, http-upstream, ip-restriction, kafka, lambda, nats, opa-authz, rate-limit, request-size-limit, s3, ws-upstream.

## Validation
All 18 plugins' test suites pass **locally** (exact-field assertions unchanged, 0 warnings); ai-proxy + ip-restriction verified building to `wasm32`. The `plugin-tests` CI job builds/tests all 33 plugins as the gate. Where `BTreeMap` became test-only, its import was scoped to the test module.

Follow-up batches (same #90): `log` (18 plugins), `http::call` (9), `jwt` helpers (4 auth plugins).