### PR TITLE
refactor(plugins): adopt SDK log helper across 18 plugins (#90 part 3b)

### DIFF
--- a/plugins/ai-cost-tracker/Cargo.lock
+++ b/plugins/ai-cost-tracker/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/ai-cost-tracker/src/lib.rs
+++ b/plugins/ai-cost-tracker/src/lib.rs
@@ -9,7 +9,16 @@
 //! Prices are expressed in USD per 1,000 tokens — the industry-standard
 //! notation used by OpenAI, Anthropic, and most vendors.
 
+// On wasm, log via the shared SDK helper. On native, keep a recording shim so
+// the tests that assert on emitted log lines (mock_host::LOGS) still observe them.
+#[cfg(target_arch = "wasm32")]
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
+
+#[cfg(not(target_arch = "wasm32"))]
+fn log_message(level: i32, msg: &str) {
+    mock_host::LOGS.with(|m| m.borrow_mut().push((level, msg.to_string())));
+}
 use serde::Deserialize;
 use std::collections::BTreeMap;
 
@@ -158,15 +167,6 @@ fn metric_counter_add(name: &str, labels_json: &str, value: f64) {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-fn log_message(level: i32, msg: &str) {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-    }
-    unsafe { host_log(level, msg.as_ptr() as i32, msg.len() as i32) }
-}
-
 // ---------------------------------------------------------------------------
 // Native stubs
 // ---------------------------------------------------------------------------
@@ -216,11 +216,6 @@ fn metric_counter_add(name: &str, labels: &str, value: f64) {
         m.borrow_mut()
             .push((name.to_string(), labels.to_string(), value))
     });
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn log_message(level: i32, msg: &str) {
-    mock_host::LOGS.with(|m| m.borrow_mut().push((level, msg.to_string())));
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/ai-prompt-guard/src/lib.rs
+++ b/plugins/ai-prompt-guard/src/lib.rs
@@ -30,6 +30,7 @@
 //! The plugin reads `ai.policy` (overridable via `context_key`). When the key
 //! is absent or names an unknown profile, `default_profile` applies.
 
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
 use regex::Regex;
 use serde::Deserialize;
@@ -436,15 +437,6 @@ fn context_get(key: &str) -> Option<String> {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-fn log_message(level: i32, msg: &str) {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-    }
-    unsafe { host_log(level, msg.as_ptr() as i32, msg.len() as i32) }
-}
-
 // ---------------------------------------------------------------------------
 // Native stubs
 // ---------------------------------------------------------------------------
@@ -473,9 +465,6 @@ mod mock_host {
 fn context_get(key: &str) -> Option<String> {
     mock_host::CONTEXT.with(|m| m.borrow().get(key).cloned())
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-fn log_message(_level: i32, _msg: &str) {}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/plugins/ai-proxy/src/lib.rs
+++ b/plugins/ai-proxy/src/lib.rs
@@ -907,13 +907,8 @@ pub(crate) mod host {
         }
     }
 
-    pub fn log_warn(msg: &str) {
-        #[link(wasm_import_module = "barbacane")]
-        extern "C" {
-            fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-        }
-        unsafe { host_log(2, msg.as_ptr() as i32, msg.len() as i32) }
-    }
+    // Preserves the original level (2 = INFO) that the local `log_warn` emitted.
+    pub use barbacane_plugin_sdk::log::info as log_warn;
 
     pub fn time_now_ms() -> u64 {
         #[link(wasm_import_module = "barbacane")]

--- a/plugins/ai-response-guard/src/lib.rs
+++ b/plugins/ai-response-guard/src/lib.rs
@@ -17,6 +17,7 @@
 //! unchanged. Operators who need strict redaction with streaming must
 //! disable `"stream": true` on those routes.
 
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
 use regex::Regex;
 use serde::Deserialize;
@@ -362,15 +363,6 @@ fn metric_counter_inc(name: &str, labels_json: &str, value: u64) {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-fn log_message(level: i32, msg: &str) {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-    }
-    unsafe { host_log(level, msg.as_ptr() as i32, msg.len() as i32) }
-}
-
 // ---------------------------------------------------------------------------
 // Native stubs
 // ---------------------------------------------------------------------------
@@ -414,9 +406,6 @@ fn metric_counter_inc(name: &str, labels: &str, value: u64) {
             .push((name.to_string(), labels.to_string(), value))
     });
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-fn log_message(_level: i32, _msg: &str) {}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/plugins/ai-token-limit/src/lib.rs
+++ b/plugins/ai-token-limit/src/lib.rs
@@ -25,6 +25,7 @@
 //!   response that already left the gateway cannot be interrupted
 //!   retroactively — the overshoot is absorbed and the *next* request 429s.
 
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -461,15 +462,6 @@ fn host_context_set(key: &str, value: &str) {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-fn log_message(level: i32, msg: &str) {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-    }
-    unsafe { host_log(level, msg.as_ptr() as i32, msg.len() as i32) }
-}
-
 // ---------------------------------------------------------------------------
 // Native stubs (tests)
 // ---------------------------------------------------------------------------
@@ -568,9 +560,6 @@ fn context_get(key: &str) -> Option<String> {
 fn host_context_set(key: &str, value: &str) {
     mock_host::CONTEXT.with(|m| m.borrow_mut().insert(key.into(), value.into()));
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-fn log_message(_level: i32, _msg: &str) {}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/plugins/cache/Cargo.lock
+++ b/plugins/cache/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/cache/src/lib.rs
+++ b/plugins/cache/src/lib.rs
@@ -3,6 +3,7 @@
 //! Caches responses based on TTL configuration and vary headers.
 //! Uses the host's response cache via host_cache_get/set.
 
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -247,18 +248,6 @@ fn call_cache_read_result(buf: &mut [u8]) -> i32 {
     unsafe { host_cache_read_result(buf.as_mut_ptr() as i32, buf.len() as i32) }
 }
 
-/// Log a message via host_log.
-#[cfg(target_arch = "wasm32")]
-fn log_message(level: i32, msg: &str) {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-    }
-    unsafe {
-        host_log(level, msg.as_ptr() as i32, msg.len() as i32);
-    }
-}
-
 #[cfg(not(target_arch = "wasm32"))]
 mod mock_host {
     use std::cell::RefCell;
@@ -331,9 +320,6 @@ fn call_cache_read_result(buf: &mut [u8]) -> i32 {
 fn call_cache_set(key: &str, entry_json: &str, ttl_secs: u32) -> i32 {
     mock_host::cache_set(key, entry_json, ttl_secs)
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-fn log_message(_level: i32, _msg: &str) {}
 
 #[cfg(test)]
 mod tests {

--- a/plugins/cel/src/lib.rs
+++ b/plugins/cel/src/lib.rs
@@ -411,13 +411,8 @@ mod host {
         }
     }
 
-    pub fn log_warn(msg: &str) {
-        #[link(wasm_import_module = "barbacane")]
-        extern "C" {
-            fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-        }
-        unsafe { host_log(2, msg.as_ptr() as i32, msg.len() as i32) }
-    }
+    // Preserves the original level (2 = INFO) that the local `log_warn` emitted.
+    pub use barbacane_plugin_sdk::log::info as log_warn;
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/plugins/correlation-id/Cargo.lock
+++ b/plugins/correlation-id/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/correlation-id/src/lib.rs
+++ b/plugins/correlation-id/src/lib.rs
@@ -4,6 +4,7 @@
 //! The correlation ID is passed to upstream services and optionally included
 //! in the response.
 
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
 use serde::Deserialize;
 
@@ -172,23 +173,6 @@ fn generate_uuid() -> Option<String> {
 #[cfg(not(target_arch = "wasm32"))]
 fn generate_uuid() -> Option<String> {
     mock_host::generate_uuid()
-}
-
-/// Log a message via host_log.
-#[cfg(target_arch = "wasm32")]
-fn log_message(level: i32, msg: &str) {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-    }
-    unsafe {
-        host_log(level, msg.as_ptr() as i32, msg.len() as i32);
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn log_message(_level: i32, _msg: &str) {
-    // No-op on native
 }
 
 /// Store a value in the request context.

--- a/plugins/cors/src/lib.rs
+++ b/plugins/cors/src/lib.rs
@@ -3,6 +3,7 @@
 //! Implements Cross-Origin Resource Sharing (CORS) per the Fetch specification.
 //! Handles preflight OPTIONS requests and adds appropriate CORS headers to responses.
 
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -318,24 +319,6 @@ fn is_simple_header(header: &str) -> bool {
         header,
         "accept" | "accept-language" | "content-language" | "content-type"
     )
-}
-
-/// Log a message via host_log (WASM only).
-#[cfg(target_arch = "wasm32")]
-fn log_message(level: i32, msg: &str) {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-    }
-    unsafe {
-        host_log(level, msg.as_ptr() as i32, msg.len() as i32);
-    }
-}
-
-/// No-op log function for non-WASM targets.
-#[cfg(not(target_arch = "wasm32"))]
-fn log_message(_level: i32, _msg: &str) {
-    // No-op for tests
 }
 
 /// Store a value in the request context (WASM).

--- a/plugins/fire-and-forget/Cargo.lock
+++ b/plugins/fire-and-forget/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/fire-and-forget/src/lib.rs
+++ b/plugins/fire-and-forget/src/lib.rs
@@ -7,6 +7,8 @@
 //! The outbound HTTP call is best-effort: if the upstream is unreachable
 //! or returns an error, the client still receives the configured response.
 
+#[cfg(target_arch = "wasm32")]
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -130,7 +132,10 @@ impl FireAndForgetDispatcher {
     /// Build the configured static response.
     fn build_response(&self) -> Response {
         let mut headers = self.response.headers.clone();
-        headers.insert("content-type".to_string(), self.response.content_type.clone());
+        headers.insert(
+            "content-type".to_string(),
+            self.response.content_type.clone(),
+        );
 
         let body = if self.response.body.is_empty() {
             None
@@ -159,7 +164,6 @@ mod host {
         fn ffi_http_call(req_ptr: i32, req_len: i32) -> i32;
         #[link_name = "host_http_read_result"]
         fn ffi_http_read_result(buf_ptr: i32, buf_len: i32) -> i32;
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
     }
 
     /// Make an outbound HTTP request. Returns Ok(()) on success, Err(()) on failure.
@@ -174,13 +178,6 @@ mod host {
             let mut buf = vec![0u8; result_len as usize];
             ffi_http_read_result(buf.as_mut_ptr() as i32, result_len);
             Ok(())
-        }
-    }
-
-    /// Log a message via host_log.
-    pub fn log_message(level: i32, msg: &str) {
-        unsafe {
-            host_log(level, msg.as_ptr() as i32, msg.len() as i32);
         }
     }
 }
@@ -233,6 +230,7 @@ mod host {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn log_message(level: i32, msg: &str) {
     host::log_message(level, msg);
 }
@@ -407,7 +405,9 @@ mod tests {
 
         // Warning was logged
         let logs = host::get_log_messages();
-        assert!(logs.iter().any(|(level, msg)| *level == 2 && msg.contains("connection error")));
+        assert!(logs
+            .iter()
+            .any(|(level, msg)| *level == 2 && msg.contains("connection error")));
     }
 
     #[test]
@@ -427,8 +427,10 @@ mod tests {
 
         let mut plugin = minimal_plugin();
         let mut req = test_request();
-        req.headers.insert("authorization".to_string(), "Bearer tok".to_string());
-        req.headers.insert("x-custom".to_string(), "value".to_string());
+        req.headers
+            .insert("authorization".to_string(), "Bearer tok".to_string());
+        req.headers
+            .insert("x-custom".to_string(), "value".to_string());
         plugin.dispatch(req);
 
         let calls = host::get_http_calls();

--- a/plugins/http-log/Cargo.lock
+++ b/plugins/http-log/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/http-log/src/lib.rs
+++ b/plugins/http-log/src/lib.rs
@@ -7,6 +7,8 @@
 //! Note: The outbound HTTP call is synchronous. For high-throughput
 //! production use, prefer Kafka or NATS dispatchers for log shipping.
 
+#[cfg(target_arch = "wasm32")]
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -243,17 +245,6 @@ mod host {
         unsafe { host_time_now() as u64 }
     }
 
-    /// Log a message via host_log.
-    pub fn log_message(level: i32, msg: &str) {
-        #[link(wasm_import_module = "barbacane")]
-        extern "C" {
-            fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-        }
-        unsafe {
-            host_log(level, msg.as_ptr() as i32, msg.len() as i32);
-        }
-    }
-
     /// Store a value in the request context.
     pub fn context_set(key: &str, value: &str) {
         #[link(wasm_import_module = "barbacane")]
@@ -383,6 +374,7 @@ mod host {
 fn host_time_now_ms() -> u64 {
     host::time_now_ms()
 }
+#[cfg(not(target_arch = "wasm32"))]
 fn log_message(level: i32, msg: &str) {
     host::log_message(level, msg);
 }

--- a/plugins/jwt-auth/Cargo.lock
+++ b/plugins/jwt-auth/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/jwt-auth/src/lib.rs
+++ b/plugins/jwt-auth/src/lib.rs
@@ -499,12 +499,8 @@ fn warn_once_no_audience() {
     WARNED.with(|w| {
         if !w.get() {
             w.set(true);
-            #[link(wasm_import_module = "barbacane")]
-            extern "C" {
-                fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-            }
             let msg = "jwt-auth: no 'audience' configured; tokens for any audience at this issuer are accepted (confused-deputy risk). Set 'audience' for multi-RP IdPs.";
-            unsafe { host_log(1, msg.as_ptr() as i32, msg.len() as i32) };
+            barbacane_plugin_sdk::log::warn(msg);
         }
     });
 }

--- a/plugins/oauth2-auth/Cargo.lock
+++ b/plugins/oauth2-auth/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/oauth2-auth/src/lib.rs
+++ b/plugins/oauth2-auth/src/lib.rs
@@ -48,12 +48,8 @@ fn warn_once_no_audience() {
     WARNED.with(|w| {
         if !w.get() {
             w.set(true);
-            #[link(wasm_import_module = "barbacane")]
-            extern "C" {
-                fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-            }
             let msg = "oauth2-auth: no 'audience' configured; tokens for any audience at this authorization server are accepted (confused-deputy risk). Set 'audience' for multi-RP setups.";
-            unsafe { host_log(1, msg.as_ptr() as i32, msg.len() as i32) };
+            barbacane_plugin_sdk::log::warn(msg);
         }
     });
 }

--- a/plugins/observability/Cargo.lock
+++ b/plugins/observability/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/observability/src/lib.rs
+++ b/plugins/observability/src/lib.rs
@@ -175,17 +175,9 @@ fn host_time_now_ms() -> u64 {
     mock_host::get_time()
 }
 
-/// Log a message via host_log.
+// Log a message via the shared SDK host logging helper.
 #[cfg(target_arch = "wasm32")]
-fn log_message(level: i32, msg: &str) {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-    }
-    unsafe {
-        host_log(level, msg.as_ptr() as i32, msg.len() as i32);
-    }
-}
+use barbacane_plugin_sdk::log::log as log_message;
 
 #[cfg(not(target_arch = "wasm32"))]
 fn log_message(level: i32, msg: &str) {

--- a/plugins/oidc-auth/Cargo.lock
+++ b/plugins/oidc-auth/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/oidc-auth/src/lib.rs
+++ b/plugins/oidc-auth/src/lib.rs
@@ -154,12 +154,8 @@ fn warn_once_no_audience() {
     WARNED.with(|w| {
         if !w.get() {
             w.set(true);
-            #[link(wasm_import_module = "barbacane")]
-            extern "C" {
-                fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-            }
             let msg = "oidc-auth: no 'audience' configured; tokens for any audience at this issuer are accepted (confused-deputy risk). Set 'audience' for multi-RP IdPs.";
-            unsafe { host_log(1, msg.as_ptr() as i32, msg.len() as i32) };
+            barbacane_plugin_sdk::log::warn(msg);
         }
     });
 }

--- a/plugins/rate-limit/src/lib.rs
+++ b/plugins/rate-limit/src/lib.rs
@@ -3,6 +3,7 @@
 //! Implements rate limiting with IETF draft-ietf-httpapi-ratelimit-headers support.
 //! Uses the host's sliding window rate limiter via host_rate_limit_check.
 
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
 use serde::Deserialize;
 
@@ -232,18 +233,6 @@ fn call_rate_limit_read_result(buf: &mut [u8]) -> i32 {
     unsafe { host_rate_limit_read_result(buf.as_mut_ptr() as i32, buf.len() as i32) }
 }
 
-/// Log a message via host_log.
-#[cfg(target_arch = "wasm32")]
-fn log_message(level: i32, msg: &str) {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-    }
-    unsafe {
-        host_log(level, msg.as_ptr() as i32, msg.len() as i32);
-    }
-}
-
 // ============================================================================
 // Mock host functions (Native)
 // ============================================================================
@@ -292,9 +281,6 @@ fn call_rate_limit_check(key: &str, quota: u32, window_secs: u32) -> i32 {
 fn call_rate_limit_read_result(buf: &mut [u8]) -> i32 {
     mock_host::call_rate_limit_read_result(buf)
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-fn log_message(_level: i32, _msg: &str) {}
 
 // ============================================================================
 // Tests

--- a/plugins/request-transformer/Cargo.lock
+++ b/plugins/request-transformer/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/request-transformer/src/lib.rs
+++ b/plugins/request-transformer/src/lib.rs
@@ -9,6 +9,7 @@
 //! Supports variable interpolation: `$client_ip`, `$path.<name>`, `$header.<name>`,
 //! `$query.<name>`, `context:<key>`
 
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
 use form_urlencoded::{parse as parse_urlencoded, Serializer};
 use jsonptr::{Assign, Delete, Pointer};
@@ -483,22 +484,6 @@ fn to_json_value(s: &str) -> Value {
 // ---------------------------------------------------------------------------
 // Host function bindings
 // ---------------------------------------------------------------------------
-
-#[cfg(target_arch = "wasm32")]
-fn log_message(level: i32, msg: &str) {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-    }
-    unsafe {
-        host_log(level, msg.as_ptr() as i32, msg.len() as i32);
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn log_message(_level: i32, _msg: &str) {
-    // No-op on native
-}
 
 #[cfg(target_arch = "wasm32")]
 fn context_get(key: &str) -> Option<String> {
@@ -1203,8 +1188,7 @@ mod tests {
     #[test]
     fn test_body_remove_nested_field() {
         let req = create_post_request();
-        let body =
-            Some(br#"{"user":"john","metadata":{"internal":true,"public":"yes"}}"#.to_vec());
+        let body = Some(br#"{"user":"john","metadata":{"internal":true,"public":"yes"}}"#.to_vec());
 
         let mut config = BodyConfig::default();
         config.remove.push("/metadata/internal".to_string());
@@ -1281,10 +1265,9 @@ mod tests {
         let body = Some(br#"{"items":[{"oldKey":"val1"},{"oldKey":"val2"}]}"#.to_vec());
 
         let mut config = BodyConfig::default();
-        config.rename.insert(
-            "/items/0/oldKey".to_string(),
-            "/items/0/newKey".to_string(),
-        );
+        config
+            .rename
+            .insert("/items/0/oldKey".to_string(), "/items/0/newKey".to_string());
 
         let result = transform_body(&body, &config, &req);
         let json: Value =

--- a/plugins/response-transformer/Cargo.lock
+++ b/plugins/response-transformer/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/response-transformer/src/lib.rs
+++ b/plugins/response-transformer/src/lib.rs
@@ -5,6 +5,7 @@
 //! - Headers (add, set, remove, rename)
 //! - JSON body (add, remove, rename using JSON Pointer — RFC 6901)
 
+use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
 use jsonptr::{Assign, Delete, Pointer};
 use serde::Deserialize;
@@ -242,26 +243,6 @@ fn transform_body(body: &Option<Vec<u8>>, config: &BodyConfig) -> Option<Vec<u8>
             body.clone()
         }
     }
-}
-
-// ---------------------------------------------------------------------------
-// Host function bindings
-// ---------------------------------------------------------------------------
-
-#[cfg(target_arch = "wasm32")]
-fn log_message(level: i32, msg: &str) {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        fn host_log(level: i32, msg_ptr: i32, msg_len: i32);
-    }
-    unsafe {
-        host_log(level, msg.as_ptr() as i32, msg.len() as i32);
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn log_message(_level: i32, _msg: &str) {
-    // No-op on native
 }
 
 // ---------------------------------------------------------------------------
@@ -580,8 +561,7 @@ mod tests {
 
     #[test]
     fn test_body_remove_nested_field() {
-        let body =
-            Some(br#"{"user":"john","metadata":{"internal":true,"public":"yes"}}"#.to_vec());
+        let body = Some(br#"{"user":"john","metadata":{"internal":true,"public":"yes"}}"#.to_vec());
 
         let mut config = BodyConfig::default();
         config.remove.push("/metadata/internal".to_string());
@@ -742,10 +722,9 @@ mod tests {
         let body = Some(br#"{"items":[{"oldKey":"val1"},{"oldKey":"val2"}]}"#.to_vec());
 
         let mut config = BodyConfig::default();
-        config.rename.insert(
-            "/items/0/oldKey".to_string(),
-            "/items/0/newKey".to_string(),
-        );
+        config
+            .rename
+            .insert("/items/0/oldKey".to_string(), "/items/0/newKey".to_string());
 
         let result = transform_body(&body, &config);
         let json: Value =
@@ -759,8 +738,7 @@ mod tests {
 
     #[test]
     fn test_body_remove_array_element_field() {
-        let body =
-            Some(br#"{"items":[{"id":1,"secret":"x"},{"id":2,"secret":"y"}]}"#.to_vec());
+        let body = Some(br#"{"items":[{"id":1,"secret":"x"},{"id":2,"secret":"y"}]}"#.to_vec());
 
         let mut config = BodyConfig::default();
         config.remove.push("/items/0/secret".to_string());


### PR DESCRIPTION
Part 3, batch B of #90 — migrate the **18 plugins** that each redeclared the `host_log` FFI + a cfg wasm/native logging wrapper onto `barbacane_plugin_sdk::log` (added in #119). Net −163 lines.

Most plugins alias `use barbacane_plugin_sdk::log::log as log_message;` so call sites and exact level ints are unchanged.

## Behavior-preserving nuances (caught during migration)
- **Native test-recording wrappers kept**: ai-cost-tracker, fire-and-forget, http-log, observability have a *native* `log_message` that records to a thread-local the tests assert on. Those keep the native recording shim; only the **wasm** path is aliased to the SDK.
- **Exact level preserved**: ai-proxy/cel's local `log_warn` actually emitted level **2 (INFO)**, not WARN — aliased to `log::info` so the emitted level is unchanged (the `log_warn` name is a pre-existing misnomer, left as-is).
- **Inline externs**: jwt-auth/oauth2-auth/oidc-auth declared `host_log` inline inside `warn_once_no_audience` (level 1 = WARN) → now `log::warn`.

## Validation
All 18 plugins build + their test suites pass locally (0 warnings), incl. the mock_host log-recording tests (ai-cost-tracker 13, fire-and-forget 12, observability 17). `plugin-tests` CI builds/tests all 33 as the gate.

Remaining #90 batches: `http::call` (9 plugins), `jwt` helpers (4 auth plugins).