### PR TITLE
refactor(plugins): adopt SDK http::call across 8 plugins (#90 part 3c)

### DIFF
--- a/plugins/fire-and-forget/src/lib.rs
+++ b/plugins/fire-and-forget/src/lib.rs
@@ -7,10 +7,11 @@
 //! The outbound HTTP call is best-effort: if the upstream is unreachable
 //! or returns an error, the client still receives the configured response.
 
+use barbacane_plugin_sdk::http;
 #[cfg(target_arch = "wasm32")]
 use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::BTreeMap;
 
 /// Fire-and-forget dispatcher configuration.
@@ -72,11 +73,12 @@ fn default_content_type() -> String {
     "application/json".to_string()
 }
 
-/// HTTP request format for host_http_call.
-///
-/// Body travels via side-channel (`set_http_request_body`), not in JSON.
-#[derive(Serialize)]
-#[cfg_attr(test, derive(serde::Deserialize))]
+/// Mirror of [`barbacane_plugin_sdk::http::HttpRequest`] used only by the native
+/// test mock to deserialize the request bytes captured by `host::http_call`.
+/// The SDK's own `HttpRequest` is `Serialize`-only, so tests keep this local
+/// `Deserialize` copy.
+#[cfg(test)]
+#[derive(serde::Deserialize)]
 struct HttpRequest {
     method: String,
     url: String,
@@ -97,31 +99,17 @@ impl FireAndForgetDispatcher {
     /// Forward the incoming request to the configured upstream URL.
     /// Errors are logged but never affect the client response.
     fn forward_to_upstream(&self, req: &Request) {
-        // Send request body via side-channel
-        if let Some(ref body) = req.body {
-            set_http_request_body(body);
-        }
-
-        let http_request = HttpRequest {
+        let request = http::HttpRequest {
             method: req.method.clone(),
             url: self.url.clone(),
             headers: req.headers.clone(),
             timeout_ms: Some(self.timeout_ms),
         };
 
-        let request_json = match serde_json::to_vec(&http_request) {
-            Ok(json) => json,
-            Err(e) => {
-                log_message(
-                    2, // WARN
-                    &format!("fire-and-forget: failed to serialize request: {e}"),
-                );
-                return;
-            }
-        };
-
-        // Call upstream — read and discard the response
-        if let Err(()) = host::http_call(&request_json) {
+        // Best-effort: the request body travels via the side-channel inside
+        // `http::call`, and the response is ignored (fire-and-forget). A
+        // connection failure is logged but never affects the client response.
+        if host::http_call(&request, req.body.as_deref()).is_err() {
             log_message(
                 2, // WARN
                 "fire-and-forget: upstream call failed (connection error)",
@@ -158,27 +146,15 @@ impl FireAndForgetDispatcher {
 
 #[cfg(target_arch = "wasm32")]
 mod host {
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        #[link_name = "host_http_call"]
-        fn ffi_http_call(req_ptr: i32, req_len: i32) -> i32;
-        #[link_name = "host_http_read_result"]
-        fn ffi_http_read_result(buf_ptr: i32, buf_len: i32) -> i32;
-    }
-
-    /// Make an outbound HTTP request. Returns Ok(()) on success, Err(()) on failure.
-    /// The response is read and discarded (fire-and-forget).
-    pub fn http_call(request_json: &[u8]) -> Result<(), ()> {
-        unsafe {
-            let result_len = ffi_http_call(request_json.as_ptr() as i32, request_json.len() as i32);
-            if result_len < 0 {
-                return Err(());
-            }
-            // Read and discard the response
-            let mut buf = vec![0u8; result_len as usize];
-            ffi_http_read_result(buf.as_mut_ptr() as i32, result_len);
-            Ok(())
-        }
+    /// Forward the request through the shared SDK HTTP helper. The response is
+    /// discarded (fire-and-forget); any transport error maps to `Err(())`.
+    pub fn http_call(
+        request: &barbacane_plugin_sdk::http::HttpRequest,
+        body: Option<&[u8]>,
+    ) -> Result<(), ()> {
+        barbacane_plugin_sdk::http::call(request, body)
+            .map(|_| ())
+            .map_err(|_| ())
     }
 }
 
@@ -192,12 +168,18 @@ mod host {
         static HTTP_CALL_SHOULD_FAIL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     }
 
-    /// Mock HTTP call: records the request bytes and returns Ok.
-    pub fn http_call(request_json: &[u8]) -> Result<(), ()> {
+    /// Mock HTTP call: serializes and records the request, returns Ok (or Err
+    /// when `set_http_call_should_fail(true)`). Mirrors the shared SDK helper's
+    /// signature so the production code path is identical on native and wasm.
+    pub fn http_call(
+        request: &barbacane_plugin_sdk::http::HttpRequest,
+        _body: Option<&[u8]>,
+    ) -> Result<(), ()> {
         if HTTP_CALL_SHOULD_FAIL.with(|f| f.get()) {
             return Err(());
         }
-        HTTP_CALLS.with(|calls| calls.borrow_mut().push(request_json.to_vec()));
+        let json = serde_json::to_vec(request).unwrap_or_default();
+        HTTP_CALLS.with(|calls| calls.borrow_mut().push(json));
         Ok(())
     }
 

--- a/plugins/http-log/src/lib.rs
+++ b/plugins/http-log/src/lib.rs
@@ -7,6 +7,7 @@
 //! Note: The outbound HTTP call is synchronous. For high-throughput
 //! production use, prefer Kafka or NATS dispatchers for log shipping.
 
+use barbacane_plugin_sdk::http;
 #[cfg(target_arch = "wasm32")]
 use barbacane_plugin_sdk::log::log as log_message;
 use barbacane_plugin_sdk::prelude::*;
@@ -94,10 +95,12 @@ struct ResponseLog {
     body_size: Option<usize>,
 }
 
-/// HTTP request format for host_http_call.
-///
-/// Body travels via side-channel (`set_http_request_body`), not in JSON.
-#[derive(Serialize, Deserialize)]
+/// Mirror of [`barbacane_plugin_sdk::http::HttpRequest`] used only by the native
+/// test mock to deserialize the request bytes captured by `host::http_call`.
+/// The SDK's own `HttpRequest` is `Serialize`-only, so tests keep this local
+/// `Deserialize` copy.
+#[cfg(test)]
+#[derive(Deserialize)]
 struct HttpRequest {
     method: String,
     url: String,
@@ -202,28 +205,16 @@ impl HttpLog {
         let mut headers = BTreeMap::new();
         headers.insert("content-type".to_string(), self.content_type.clone());
 
-        // Send body via side-channel
-        set_http_request_body(payload.as_bytes());
-
-        let http_request = HttpRequest {
+        let request = http::HttpRequest {
             method: self.method.clone(),
             url: self.endpoint.clone(),
             headers,
             timeout_ms: Some(self.timeout_ms),
         };
 
-        let request_json = match serde_json::to_vec(&http_request) {
-            Ok(json) => json,
-            Err(e) => {
-                log_message(
-                    2, // WARN
-                    &format!("http-log: failed to serialize request: {}", e),
-                );
-                return;
-            }
-        };
-
-        if let Err(()) = host::http_call(&request_json) {
+        // Best-effort: the payload travels via the side-channel inside
+        // `http::call`; a failure is logged but never affects the response.
+        if host::http_call(&request, Some(payload.as_bytes())).is_err() {
             log_message(2, "http-log: failed to send log entry (connection error)");
         }
     }
@@ -285,27 +276,15 @@ mod host {
         }
     }
 
-    #[link(wasm_import_module = "barbacane")]
-    extern "C" {
-        #[link_name = "host_http_call"]
-        fn ffi_http_call(req_ptr: i32, req_len: i32) -> i32;
-        #[link_name = "host_http_read_result"]
-        fn ffi_http_read_result(buf_ptr: i32, buf_len: i32) -> i32;
-    }
-
-    /// Make an outbound HTTP request. Returns Ok(()) on success, Err(()) on failure.
-    /// The response body is discarded (fire-and-forget for logging).
-    pub fn http_call(request_json: &[u8]) -> Result<(), ()> {
-        unsafe {
-            let result_len = ffi_http_call(request_json.as_ptr() as i32, request_json.len() as i32);
-            if result_len < 0 {
-                return Err(());
-            }
-            // Read and discard the response
-            let mut buf = vec![0u8; result_len as usize];
-            ffi_http_read_result(buf.as_mut_ptr() as i32, result_len);
-            Ok(())
-        }
+    /// Send the log entry through the shared SDK HTTP helper. The response is
+    /// discarded (best-effort logging); any transport error maps to `Err(())`.
+    pub fn http_call(
+        request: &barbacane_plugin_sdk::http::HttpRequest,
+        body: Option<&[u8]>,
+    ) -> Result<(), ()> {
+        barbacane_plugin_sdk::http::call(request, body)
+            .map(|_| ())
+            .map_err(|_| ())
     }
 }
 
@@ -337,9 +316,15 @@ mod host {
         CONTEXT.with(|ctx| ctx.borrow().get(key).cloned())
     }
 
-    /// Mock HTTP call: records the request bytes and returns Ok.
-    pub fn http_call(request_json: &[u8]) -> Result<(), ()> {
-        HTTP_CALLS.with(|calls| calls.borrow_mut().push(request_json.to_vec()));
+    /// Mock HTTP call: serializes and records the request, returns Ok. Mirrors
+    /// the shared SDK helper's signature so the production code path is identical
+    /// on native and wasm.
+    pub fn http_call(
+        request: &barbacane_plugin_sdk::http::HttpRequest,
+        _body: Option<&[u8]>,
+    ) -> Result<(), ()> {
+        let json = serde_json::to_vec(request).unwrap_or_default();
+        HTTP_CALLS.with(|calls| calls.borrow_mut().push(json));
         Ok(())
     }
 

--- a/plugins/http-upstream/src/lib.rs
+++ b/plugins/http-upstream/src/lib.rs
@@ -6,6 +6,7 @@
 //! - Header forwarding
 //! - Configurable timeouts
 
+use barbacane_plugin_sdk::http;
 use barbacane_plugin_sdk::prelude::*;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -30,26 +31,6 @@ pub struct HttpUpstreamDispatcher {
 
 fn default_timeout() -> f64 {
     30.0
-}
-
-/// HTTP request format for host_http_call.
-///
-/// Body travels via side-channel (`set_http_request_body`), not in JSON.
-/// This eliminates the ~3.65x memory overhead of base64 encoding.
-#[derive(serde::Serialize)]
-struct HttpRequest {
-    method: String,
-    url: String,
-    headers: BTreeMap<String, String>,
-    timeout_ms: u64,
-}
-
-/// HTTP response metadata from host_http_call.
-/// Body is read separately via `read_http_response_body()`.
-#[derive(Deserialize)]
-struct HttpResponse {
-    status: u16,
-    headers: BTreeMap<String, String>,
 }
 
 impl HttpUpstreamDispatcher {
@@ -110,74 +91,42 @@ impl HttpUpstreamDispatcher {
 
         let timeout_ms = (self.timeout * 1000.0) as u64;
 
-        // Send request body via side-channel (avoids base64 encoding).
-        if let Some(ref b) = body {
-            barbacane_plugin_sdk::body::set_http_request_body(b);
-        }
-
-        let http_request = HttpRequest {
+        // Body travels via the side-channel; `http::call` sends it and reads the
+        // response body back the same way.
+        let http_request = http::HttpRequest {
             method,
             url: full_url,
             headers,
-            timeout_ms,
+            timeout_ms: Some(timeout_ms),
         };
 
-        let request_json = match serde_json::to_vec(&http_request) {
-            Ok(j) => j,
-            Err(e) => {
-                let msg = e.to_string();
+        let http_response = match http::call(&http_request, body.as_deref()) {
+            Ok(resp) => resp,
+            Err(http::HttpError::Unreachable) | Err(http::HttpError::Unsupported) => {
                 return self.error_response(
-                    500,
+                    502,
                     "Bad Gateway",
-                    "failed to serialize request",
-                    &msg,
+                    "upstream connection failed",
+                    "host_http_call returned error",
                 );
             }
-        };
-
-        // Call upstream via host_http_call
-        let result_len =
-            unsafe { host_http_call(request_json.as_ptr() as i32, request_json.len() as i32) };
-
-        if result_len < 0 {
-            return self.error_response(
-                502,
-                "Bad Gateway",
-                "upstream connection failed",
-                "host_http_call returned error",
-            );
-        }
-
-        // Read the response metadata
-        let mut response_buf = vec![0u8; result_len as usize];
-        let bytes_read =
-            unsafe { host_http_read_result(response_buf.as_mut_ptr() as i32, result_len) };
-
-        if bytes_read <= 0 {
-            return self.error_response(
-                502,
-                "Bad Gateway",
-                "upstream connection failed",
-                "failed to read response",
-            );
-        }
-
-        let http_response: HttpResponse = match serde_json::from_slice(
-            &response_buf[..(bytes_read as usize).min(response_buf.len())],
-        ) {
-            Ok(resp) => resp,
-            Err(e) => {
+            Err(http::HttpError::Empty) | Err(http::HttpError::ReadFailed) => {
+                return self.error_response(
+                    502,
+                    "Bad Gateway",
+                    "upstream connection failed",
+                    "failed to read response",
+                );
+            }
+            Err(http::HttpError::InvalidResponse) => {
                 return self.error_response(
                     502,
                     "Bad Gateway",
                     "invalid upstream response",
-                    &e.to_string(),
+                    "failed to parse upstream response",
                 );
             }
         };
-
-        // Read response body from side-channel.
-        let response_body = barbacane_plugin_sdk::body::read_http_response_body();
 
         // Build the response, filtering hop-by-hop headers
         let mut response_headers: BTreeMap<String, String> = BTreeMap::new();
@@ -194,7 +143,7 @@ impl HttpUpstreamDispatcher {
         Response {
             status: http_response.status,
             headers: response_headers,
-            body: response_body,
+            body: http_response.body,
         }
     }
 
@@ -222,24 +171,6 @@ impl HttpUpstreamDispatcher {
             .detail(full_detail)
             .into_response()
     }
-}
-
-// Host function declarations
-#[cfg(target_arch = "wasm32")]
-#[link(wasm_import_module = "barbacane")]
-extern "C" {
-    fn host_http_call(req_ptr: i32, req_len: i32) -> i32;
-    fn host_http_read_result(buf_ptr: i32, buf_len: i32) -> i32;
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_call(_req_ptr: i32, _req_len: i32) -> i32 {
-    -1
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_read_result(_buf_ptr: i32, _buf_len: i32) -> i32 {
-    0
 }
 
 #[cfg(test)]

--- a/plugins/lambda/src/lib.rs
+++ b/plugins/lambda/src/lib.rs
@@ -3,8 +3,9 @@
 //! Invokes AWS Lambda functions via Lambda Function URLs.
 //! Supports passing request headers and body to Lambda.
 
+use barbacane_plugin_sdk::http::{self, HttpError, HttpRequest};
 use barbacane_plugin_sdk::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::BTreeMap;
 
 /// Lambda dispatcher configuration.
@@ -29,25 +30,6 @@ fn default_timeout() -> f64 {
 
 fn default_pass_through_headers() -> bool {
     true
-}
-
-/// HTTP request format for host_http_call.
-///
-/// Body travels via side-channel (`set_http_request_body`), not in JSON.
-#[derive(Serialize)]
-struct HttpRequest {
-    method: String,
-    url: String,
-    headers: BTreeMap<String, String>,
-    timeout_ms: Option<u64>,
-}
-
-/// HTTP response metadata from host_http_call.
-/// Body is read separately via `read_http_response_body()`.
-#[derive(Deserialize)]
-struct HttpResponse {
-    status: u16,
-    headers: BTreeMap<String, String>,
 }
 
 impl LambdaDispatcher {
@@ -80,12 +62,8 @@ impl LambdaDispatcher {
             headers.insert("content-type".to_string(), "application/json".to_string());
         }
 
-        // Send request body via side-channel (avoids base64 encoding).
-        if let Some(ref b) = req.body {
-            set_http_request_body(b);
-        }
-
-        // Build the HTTP request to Lambda
+        // Build the HTTP request to Lambda. The request body travels via the
+        // SDK side-channel inside `http::call`, not embedded in JSON.
         let http_request = HttpRequest {
             method: req.method.clone(),
             url: self.url.clone(),
@@ -93,47 +71,34 @@ impl LambdaDispatcher {
             timeout_ms: Some((self.timeout * 1000.0) as u64),
         };
 
-        // Serialize request
-        let request_json = match serde_json::to_vec(&http_request) {
-            Ok(json) => json,
-            Err(e) => {
-                return self.error_response(500, "failed to serialize request", &e.to_string());
-            }
-        };
-
-        // Call Lambda via host_http_call
-        let result_len =
-            unsafe { host_http_call(request_json.as_ptr() as i32, request_json.len() as i32) };
-
-        if result_len < 0 {
-            return self.error_response(
-                502,
-                "Lambda invocation failed",
-                "host_http_call returned error",
-            );
-        }
-
-        // Read the response
-        let mut response_buf = vec![0u8; result_len as usize];
-        let bytes_read =
-            unsafe { host_http_read_result(response_buf.as_mut_ptr() as i32, result_len) };
-
-        if bytes_read <= 0 {
-            return self.error_response(502, "Lambda invocation failed", "failed to read response");
-        }
-
-        // Parse the HTTP response
-        let http_response: HttpResponse = match serde_json::from_slice(
-            &response_buf[..(bytes_read as usize).min(response_buf.len())],
-        ) {
+        // Call Lambda via the shared SDK HTTP helper.
+        let http_response = match http::call(&http_request, req.body.as_deref()) {
             Ok(resp) => resp,
-            Err(e) => {
-                return self.error_response(502, "invalid Lambda response", &e.to_string());
+            Err(HttpError::Unreachable) | Err(HttpError::Unsupported) => {
+                return self.error_response(
+                    502,
+                    "Lambda invocation failed",
+                    "host_http_call returned error",
+                );
+            }
+            Err(HttpError::Empty) | Err(HttpError::ReadFailed) => {
+                return self.error_response(
+                    502,
+                    "Lambda invocation failed",
+                    "failed to read response",
+                );
+            }
+            Err(HttpError::InvalidResponse) => {
+                return self.error_response(
+                    502,
+                    "invalid Lambda response",
+                    "failed to parse response",
+                );
             }
         };
 
-        // Read response body from side-channel.
-        let response_body = read_http_response_body();
+        // Read response body attached by `http::call` via the side-channel.
+        let response_body = http_response.body;
 
         // Build the response
         let mut response_headers = http_response.headers;
@@ -163,28 +128,6 @@ impl LambdaDispatcher {
             .detail(detail)
             .into_response()
     }
-}
-
-// Host function declarations
-#[cfg(target_arch = "wasm32")]
-#[link(wasm_import_module = "barbacane")]
-extern "C" {
-    /// Make an HTTP request. Returns the response length, or -1 on error.
-    fn host_http_call(req_ptr: i32, req_len: i32) -> i32;
-
-    /// Read the HTTP response into the provided buffer. Returns bytes read.
-    fn host_http_read_result(buf_ptr: i32, buf_len: i32) -> i32;
-}
-
-// Native stubs for testing
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_call(_req_ptr: i32, _req_len: i32) -> i32 {
-    -1
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_read_result(_buf_ptr: i32, _buf_len: i32) -> i32 {
-    0
 }
 
 #[cfg(test)]

--- a/plugins/oauth2-auth/src/lib.rs
+++ b/plugins/oauth2-auth/src/lib.rs
@@ -3,6 +3,7 @@
 //! Validates Bearer tokens via RFC 7662 token introspection and rejects
 //! unauthenticated requests with 401 Unauthorized or 403 Forbidden.
 
+use barbacane_plugin_sdk::http::{call, HttpError, HttpRequest};
 use barbacane_plugin_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -56,26 +57,6 @@ fn warn_once_no_audience() {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn warn_once_no_audience() {}
-
-/// HTTP request format for host_http_call.
-///
-/// Body travels via side-channel (`set_http_request_body`), not in JSON.
-#[derive(Serialize)]
-struct HttpRequest {
-    method: String,
-    url: String,
-    headers: BTreeMap<String, String>,
-    timeout_ms: Option<u64>,
-}
-
-/// HTTP response metadata from host_http_call.
-/// Body is read separately via `read_http_response_body()`.
-#[derive(Deserialize)]
-struct HttpResponse {
-    status: u16,
-    #[allow(dead_code)]
-    headers: BTreeMap<String, String>,
-}
 
 /// RFC 7662 Token Introspection Response.
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -302,64 +283,31 @@ impl OAuth2Auth {
 
     /// Call the introspection endpoint to validate the token.
     fn introspect_token(&self, token: &str) -> Result<IntrospectionResponse, OAuth2Error> {
-        // Build request headers
-        let mut headers = BTreeMap::new();
-        headers.insert(
-            "content-type".to_string(),
-            "application/x-www-form-urlencoded".to_string(),
-        );
-        headers.insert("accept".to_string(), "application/json".to_string());
-
         // Add Basic auth header
         let credentials = format!("{}:{}", self.client_id, self.client_secret);
         let encoded = base64_encode(credentials.as_bytes());
-        headers.insert("authorization".to_string(), format!("Basic {}", encoded));
 
         // Build request body (application/x-www-form-urlencoded)
         let body = format!("token={}", url_encode(token));
 
-        // Send request body via side-channel
-        set_http_request_body(body.as_bytes());
+        let http_request = HttpRequest::new("POST", self.introspection_endpoint.clone())
+            .header("content-type", "application/x-www-form-urlencoded")
+            .header("accept", "application/json")
+            .header("authorization", format!("Basic {}", encoded))
+            .timeout_ms((self.timeout * 1000.0) as u64);
 
-        let http_request = HttpRequest {
-            method: "POST".to_string(),
-            url: self.introspection_endpoint.clone(),
-            headers,
-            timeout_ms: Some((self.timeout * 1000.0) as u64),
-        };
-
-        // Serialize request
-        let request_json = serde_json::to_vec(&http_request).map_err(|e| {
-            OAuth2Error::IntrospectionFailed(format!("request serialization: {}", e))
+        // Request body travels via the side-channel inside `call`.
+        let http_response = call(&http_request, Some(body.as_bytes())).map_err(|e| match e {
+            HttpError::Unreachable | HttpError::Unsupported => {
+                OAuth2Error::IntrospectionFailed("connection failed".to_string())
+            }
+            HttpError::Empty | HttpError::ReadFailed => {
+                OAuth2Error::IntrospectionFailed("failed to read response".to_string())
+            }
+            HttpError::InvalidResponse => {
+                OAuth2Error::IntrospectionFailed("invalid response format".to_string())
+            }
         })?;
-
-        // Call introspection endpoint
-        let result_len =
-            unsafe { host_http_call(request_json.as_ptr() as i32, request_json.len() as i32) };
-
-        if result_len < 0 {
-            return Err(OAuth2Error::IntrospectionFailed(
-                "connection failed".to_string(),
-            ));
-        }
-
-        // Read the response
-        let mut response_buf = vec![0u8; result_len as usize];
-        let bytes_read =
-            unsafe { host_http_read_result(response_buf.as_mut_ptr() as i32, result_len) };
-
-        if bytes_read <= 0 {
-            return Err(OAuth2Error::IntrospectionFailed(
-                "failed to read response".to_string(),
-            ));
-        }
-
-        // Parse the HTTP response
-        let http_response: HttpResponse =
-            serde_json::from_slice(&response_buf[..(bytes_read as usize).min(response_buf.len())])
-                .map_err(|e| {
-                    OAuth2Error::IntrospectionFailed(format!("invalid response format: {}", e))
-                })?;
 
         // Check HTTP status
         if http_response.status != 200 {
@@ -370,7 +318,8 @@ impl OAuth2Auth {
         }
 
         // Read response body from side-channel
-        let body = read_http_response_body()
+        let body = http_response
+            .body
             .ok_or_else(|| OAuth2Error::IntrospectionFailed("empty response body".to_string()))?;
 
         serde_json::from_slice(&body).map_err(|e| {
@@ -478,28 +427,6 @@ fn url_encode(s: &str) -> String {
         }
     }
     result
-}
-
-// Host function declarations (WASM only)
-#[cfg(target_arch = "wasm32")]
-#[link(wasm_import_module = "barbacane")]
-extern "C" {
-    /// Make an HTTP request. Returns the response length, or -1 on error.
-    fn host_http_call(req_ptr: i32, req_len: i32) -> i32;
-
-    /// Read the HTTP response into the provided buffer. Returns bytes read.
-    fn host_http_read_result(buf_ptr: i32, buf_len: i32) -> i32;
-}
-
-// Mock host functions for native tests (not called in pure logic tests)
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_call(_req_ptr: i32, _req_len: i32) -> i32 {
-    -1
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_read_result(_buf_ptr: i32, _buf_len: i32) -> i32 {
-    0
 }
 
 #[cfg(test)]

--- a/plugins/oidc-auth/src/lib.rs
+++ b/plugins/oidc-auth/src/lib.rs
@@ -4,6 +4,7 @@
 //! JWKS key rotation, and cryptographic signature verification via the
 //! `host_verify_signature` host function.
 
+use barbacane_plugin_sdk::http::{call, HttpError, HttpRequest};
 use barbacane_plugin_sdk::prelude::*;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::{Deserialize, Serialize};
@@ -178,26 +179,6 @@ fn key_is_compatible(key: &Jwk, expected_kty: &str, alg: &str) -> bool {
 struct DiscoveryResponse {
     issuer: String,
     jwks_uri: String,
-}
-
-/// HTTP request format for host_http_call.
-///
-/// Body travels via side-channel (`set_http_request_body`), not in JSON.
-#[derive(Serialize)]
-struct HttpRequest {
-    method: String,
-    url: String,
-    headers: BTreeMap<String, String>,
-    timeout_ms: Option<u64>,
-}
-
-/// HTTP response metadata from host_http_call.
-/// Body is read separately via `read_http_response_body()`.
-#[derive(Deserialize)]
-struct HttpResponse {
-    status: u16,
-    #[allow(dead_code)]
-    headers: BTreeMap<String, String>,
 }
 
 /// Signature verification request for host_verify_signature.
@@ -787,44 +768,20 @@ impl OidcAuth {
         }
     }
 
-    /// Make an HTTP GET request via host_http_call.
+    /// Make an HTTP GET request via the SDK HTTP helper.
     /// Returns (status, body) where body is read from the side-channel.
     fn http_get(&self, url: &str) -> Result<(u16, Option<Vec<u8>>), String> {
-        let mut headers = BTreeMap::new();
-        headers.insert("accept".to_string(), "application/json".to_string());
+        let http_request = HttpRequest::new("GET", url.to_string())
+            .header("accept", "application/json")
+            .timeout_ms((self.timeout * 1000.0) as u64);
 
-        let http_request = HttpRequest {
-            method: "GET".to_string(),
-            url: url.to_string(),
-            headers,
-            timeout_ms: Some((self.timeout * 1000.0) as u64),
-        };
+        let response = call(&http_request, None).map_err(|e| match e {
+            HttpError::Unreachable | HttpError::Unsupported => "connection failed".to_string(),
+            HttpError::Empty | HttpError::ReadFailed => "failed to read response".to_string(),
+            HttpError::InvalidResponse => "invalid response format".to_string(),
+        })?;
 
-        let request_json = serde_json::to_vec(&http_request)
-            .map_err(|e| format!("request serialization: {}", e))?;
-
-        let result_len =
-            unsafe { host_http_call(request_json.as_ptr() as i32, request_json.len() as i32) };
-
-        if result_len < 0 {
-            return Err("connection failed".to_string());
-        }
-
-        let mut response_buf = vec![0u8; result_len as usize];
-        let bytes_read =
-            unsafe { host_http_read_result(response_buf.as_mut_ptr() as i32, result_len) };
-
-        if bytes_read <= 0 {
-            return Err("failed to read response".to_string());
-        }
-
-        let http_response: HttpResponse =
-            serde_json::from_slice(&response_buf[..(bytes_read as usize).min(response_buf.len())])
-                .map_err(|e| format!("invalid response format: {}", e))?;
-
-        let body = read_http_response_body();
-
-        Ok((http_response.status, body))
+        Ok((response.status, response.body))
     }
 
     /// Build the discovery URL from the issuer.
@@ -874,20 +831,8 @@ impl OidcAuth {
 #[cfg(target_arch = "wasm32")]
 #[link(wasm_import_module = "barbacane")]
 extern "C" {
-    fn host_http_call(req_ptr: i32, req_len: i32) -> i32;
-    fn host_http_read_result(buf_ptr: i32, buf_len: i32) -> i32;
     fn host_verify_signature(req_ptr: i32, req_len: i32) -> i32;
     fn host_get_unix_timestamp() -> u64;
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_call(_req_ptr: i32, _req_len: i32) -> i32 {
-    -1
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_read_result(_buf_ptr: i32, _buf_len: i32) -> i32 {
-    0
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/plugins/opa-authz/src/lib.rs
+++ b/plugins/opa-authz/src/lib.rs
@@ -4,6 +4,7 @@
 //! Typically placed after an authentication middleware (jwt-auth, oauth2-auth, etc.)
 //! in the middleware chain so that auth claims are available as OPA input.
 
+use barbacane_plugin_sdk::http::{call, HttpError, HttpRequest};
 use barbacane_plugin_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -42,27 +43,6 @@ fn default_true() -> bool {
 
 fn default_deny_message() -> String {
     "Authorization denied by policy".to_string()
-}
-
-// ---------------------------------------------------------------------------
-// HTTP types for host_http_call
-// ---------------------------------------------------------------------------
-
-/// Body travels via side-channel (`set_http_request_body`), not in JSON.
-#[derive(Serialize)]
-struct HttpRequest {
-    method: String,
-    url: String,
-    headers: BTreeMap<String, String>,
-    timeout_ms: Option<u64>,
-}
-
-/// Body is read separately via `read_http_response_body()`.
-#[derive(Deserialize)]
-struct HttpResponse {
-    status: u16,
-    #[allow(dead_code)]
-    headers: BTreeMap<String, String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -167,53 +147,33 @@ impl OpaAuthz {
 
     /// POST to the OPA endpoint and return the raw response body.
     fn call_opa(&self, request_json: &str) -> Result<Vec<u8>, OpaError> {
-        let mut headers = BTreeMap::new();
-        headers.insert("content-type".to_string(), "application/json".to_string());
-        headers.insert("accept".to_string(), "application/json".to_string());
+        let http_request = HttpRequest::new("POST", self.opa_url.clone())
+            .header("content-type", "application/json")
+            .header("accept", "application/json")
+            .timeout_ms((self.timeout * 1000.0) as u64);
 
-        // Send request body via side-channel
-        set_http_request_body(request_json.as_bytes());
+        // Request body travels via the side-channel inside `call`.
+        let response = call(&http_request, Some(request_json.as_bytes())).map_err(|e| match e {
+            HttpError::Unreachable | HttpError::Unsupported => {
+                OpaError::ServiceError("OPA service unreachable".to_string())
+            }
+            HttpError::Empty | HttpError::ReadFailed => {
+                OpaError::ServiceError("failed to read OPA response".to_string())
+            }
+            HttpError::InvalidResponse => {
+                OpaError::ServiceError("invalid response format".to_string())
+            }
+        })?;
 
-        let http_request = HttpRequest {
-            method: "POST".to_string(),
-            url: self.opa_url.clone(),
-            headers,
-            timeout_ms: Some((self.timeout * 1000.0) as u64),
-        };
-
-        let serialized = serde_json::to_vec(&http_request)
-            .map_err(|e| OpaError::ServiceError(format!("request serialization: {}", e)))?;
-
-        let result_len =
-            unsafe { host_http_call(serialized.as_ptr() as i32, serialized.len() as i32) };
-
-        if result_len < 0 {
-            return Err(OpaError::ServiceError(
-                "OPA service unreachable".to_string(),
-            ));
-        }
-
-        let mut buf = vec![0u8; result_len as usize];
-        let bytes_read = unsafe { host_http_read_result(buf.as_mut_ptr() as i32, result_len) };
-
-        if bytes_read <= 0 {
-            return Err(OpaError::ServiceError(
-                "failed to read OPA response".to_string(),
-            ));
-        }
-
-        let http_response: HttpResponse = serde_json::from_slice(&buf[..bytes_read as usize])
-            .map_err(|e| OpaError::ServiceError(format!("invalid response format: {}", e)))?;
-
-        if http_response.status != 200 {
+        if response.status != 200 {
             return Err(OpaError::ServiceError(format!(
                 "OPA returned status {}",
-                http_response.status
+                response.status
             )));
         }
 
-        // Read response body from side-channel
-        read_http_response_body()
+        response
+            .body
             .ok_or_else(|| OpaError::ServiceError("empty OPA response body".to_string()))
     }
 
@@ -261,27 +221,6 @@ impl OpaAuthz {
         .detail(detail)
         .into_response()
     }
-}
-
-// ---------------------------------------------------------------------------
-// Host function declarations
-// ---------------------------------------------------------------------------
-
-#[cfg(target_arch = "wasm32")]
-#[link(wasm_import_module = "barbacane")]
-extern "C" {
-    fn host_http_call(req_ptr: i32, req_len: i32) -> i32;
-    fn host_http_read_result(buf_ptr: i32, buf_len: i32) -> i32;
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_call(_req_ptr: i32, _req_len: i32) -> i32 {
-    -1
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_read_result(_buf_ptr: i32, _buf_len: i32) -> i32 {
-    0
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/s3/src/lib.rs
+++ b/plugins/s3/src/lib.rs
@@ -12,9 +12,10 @@
 //! The plugin SDK's `Response` type uses `Option<Vec<u8>>`, so binary
 //! objects (images, PDFs, etc.) are passed through without data loss.
 
+use barbacane_plugin_sdk::http::{self, HttpError, HttpRequest, HttpResponse};
 use barbacane_plugin_sdk::prelude::*;
 use barbacane_sigv4 as sigv4;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::BTreeMap;
 
 /// S3 dispatcher configuration.
@@ -85,25 +86,6 @@ fn default_key_param() -> String {
 
 fn default_timeout() -> f64 {
     30.0
-}
-
-/// HTTP request format for `host_http_call`.
-///
-/// Body travels via side-channel (`set_http_request_body`), not in JSON.
-#[derive(Serialize)]
-struct HttpRequest {
-    method: String,
-    url: String,
-    headers: BTreeMap<String, String>,
-    timeout_ms: Option<u64>,
-}
-
-/// HTTP response metadata from `host_http_call`.
-/// Body is read separately via `read_http_response_body()`.
-#[derive(Deserialize)]
-struct HttpResponse {
-    status: u16,
-    headers: BTreeMap<String, String>,
 }
 
 impl S3Dispatcher {
@@ -239,55 +221,42 @@ impl S3Dispatcher {
         body: Option<&[u8]>,
         headers: &BTreeMap<String, String>,
     ) -> Result<(HttpResponse, Option<Vec<u8>>), Response> {
-        if let Some(b) = body {
-            set_http_request_body(b);
-        }
-
         let unix_secs = current_timestamp();
         let http_request =
             self.build_s3_request(bucket, key, method, query, body, headers, unix_secs);
 
-        let request_json = serde_json::to_vec(&http_request).map_err(|e| {
-            self.error_response(
-                500,
-                "Internal Error",
-                "failed to serialize request",
-                &e.to_string(),
-            )
-        })?;
+        // Perform the outbound call via the shared SDK helper. The request body
+        // is sent via the side-channel by `http::call`; the response body is
+        // attached back onto the returned `HttpResponse`.
+        let mut http_response = match http::call(&http_request, body) {
+            Ok(resp) => resp,
+            Err(HttpError::Unreachable) | Err(HttpError::Unsupported) => {
+                return Err(self.error_response(
+                    502,
+                    "Bad Gateway",
+                    "S3 connection failed",
+                    "host_http_call returned error",
+                ));
+            }
+            Err(HttpError::Empty) | Err(HttpError::ReadFailed) => {
+                return Err(self.error_response(
+                    502,
+                    "Bad Gateway",
+                    "S3 connection failed",
+                    "failed to read response",
+                ));
+            }
+            Err(HttpError::InvalidResponse) => {
+                return Err(self.error_response(
+                    502,
+                    "Bad Gateway",
+                    "invalid S3 response",
+                    "failed to parse response",
+                ));
+            }
+        };
 
-        let result_len =
-            unsafe { host_http_call(request_json.as_ptr() as i32, request_json.len() as i32) };
-
-        if result_len < 0 {
-            return Err(self.error_response(
-                502,
-                "Bad Gateway",
-                "S3 connection failed",
-                "host_http_call returned error",
-            ));
-        }
-
-        let mut response_buf = vec![0u8; result_len as usize];
-        let bytes_read =
-            unsafe { host_http_read_result(response_buf.as_mut_ptr() as i32, result_len) };
-
-        if bytes_read <= 0 {
-            return Err(self.error_response(
-                502,
-                "Bad Gateway",
-                "S3 connection failed",
-                "failed to read response",
-            ));
-        }
-
-        let http_response: HttpResponse =
-            serde_json::from_slice(&response_buf[..(bytes_read as usize).min(response_buf.len())])
-                .map_err(|e| {
-                    self.error_response(502, "Bad Gateway", "invalid S3 response", &e.to_string())
-                })?;
-
-        let response_body = read_http_response_body();
+        let response_body = http_response.body.take();
         Ok((http_response, response_body))
     }
 
@@ -390,29 +359,6 @@ impl S3Dispatcher {
             .detail(full_detail)
             .into_response()
     }
-}
-
-// ── Host function declarations ─────────────────────────────────────────────
-
-#[cfg(target_arch = "wasm32")]
-#[link(wasm_import_module = "barbacane")]
-extern "C" {
-    /// Make an HTTP request. Returns the response length, or -1 on error.
-    fn host_http_call(req_ptr: i32, req_len: i32) -> i32;
-
-    /// Read the HTTP response into the provided buffer. Returns bytes read.
-    fn host_http_read_result(buf_ptr: i32, buf_len: i32) -> i32;
-}
-
-// Native stubs for testing (non-WASM targets)
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_call(_req_ptr: i32, _req_len: i32) -> i32 {
-    -1
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn host_http_read_result(_buf_ptr: i32, _buf_len: i32) -> i32 {
-    0
 }
 
 // ── Unix timestamp ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Part 3, batch C of #90 — migrate the **8 plain-`http_call` plugins** onto `barbacane_plugin_sdk::http` (added in #119). Net **−402 lines**.

Removes each plugin's local `HttpRequest`/`HttpResponse` structs, `host_http_call`/`host_http_read_result` externs (+ native stubs), and manual call/read-result orchestration.

**Plugins:** http-upstream (core proxy dispatcher), lambda, s3, opa-authz, oidc-auth, oauth2-auth, http-log, fire-and-forget.

## Preserved exactly
- request method/url/headers/body (same side-channel body protocol the SDK matches), timeouts (seconds→ms unchanged), and error mapping (each `HttpError` variant → the plugin's existing status/message).
- **SigV4 signing** (lambda/s3), **JWT/introspection** (oidc/oauth2), and non-HTTP externs (`host_verify_signature`, `host_get_unix_timestamp`) untouched.
- fire-and-forget/http-log keep best-effort semantics + their native test-recording host shims.

## Excluded
**ai-proxy** — also uses `host_http_stream` (streaming), which the SDK helper doesn't wrap; it retains its own http module.

## Benign divergences (non-success paths only)
- parse/serialize error *detail text* is now a fixed string (`HttpError` carries no message); status/type/title unchanged.
- an unreachable "serialize request → 500" branch removed.
- empty-body requests now send an empty side-channel body (protocol-equivalent).

## Validation
All 8 plugins' tests pass locally, 0 warnings (http-upstream 14, lambda 13, s3 24, opa-authz 21, oidc 58, oauth2 40, http-log 12, fire-and-forget 12); http-upstream + oauth2-auth verified building to `wasm32`. Integration Tests exercise http-upstream end-to-end as the runtime gate.

Last #90 batch after this: `jwt` helpers (4 auth plugins).