### PR TITLE
refactor(plugins): adopt SDK jwt helpers in auth plugins (#90 part 3d)

### DIFF
--- a/crates/barbacane-plugin-sdk/src/jwt.rs
+++ b/crates/barbacane-plugin-sdk/src/jwt.rs
@@ -9,10 +9,10 @@
 //! decode; callers still verify before trusting claims.
 
 use base64::Engine;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// The JWT `aud` claim: a single audience or a list (RFC 7519 §4.1.3).
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Audience {
     Single(String),

--- a/plugins/basic-auth/Cargo.lock
+++ b/plugins/basic-auth/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "barbacane-plugin-macros",
  "base64",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/plugins/jwt-auth/src/lib.rs
+++ b/plugins/jwt-auth/src/lib.rs
@@ -3,8 +3,8 @@
 //! Validates Bearer tokens in the Authorization header and rejects
 //! unauthenticated requests with 401 Unauthorized.
 
+use barbacane_plugin_sdk::jwt::{self, Audience};
 use barbacane_plugin_sdk::prelude::*;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -134,23 +134,6 @@ struct JwtClaims {
     /// All other claims (roles, groups, permissions, etc.)
     #[serde(flatten)]
     extra: BTreeMap<String, serde_json::Value>,
-}
-
-/// Audience can be a single string or array of strings.
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(untagged)]
-enum Audience {
-    Single(String),
-    Multiple(Vec<String>),
-}
-
-impl Audience {
-    fn contains(&self, value: &str) -> bool {
-        match self {
-            Audience::Single(s) => s == value,
-            Audience::Multiple(v) => v.iter().any(|s| s == value),
-        }
-    }
 }
 
 /// Parsed JWT token.
@@ -304,29 +287,19 @@ impl JwtAuth {
             .or_else(|| req.headers.get("Authorization"))
             .ok_or(JwtError::MissingAuthHeader)?;
 
-        if !auth_header.starts_with("Bearer ") && !auth_header.starts_with("bearer ") {
-            return Err(JwtError::InvalidAuthHeader);
-        }
-
-        Ok(auth_header[7..].trim().to_string())
+        jwt::bearer_token(auth_header)
+            .map(|token| token.to_string())
+            .ok_or(JwtError::InvalidAuthHeader)
     }
 
     /// Parse a JWT token into its components.
     fn parse_jwt(&self, token: &str) -> Result<ParsedJwt, JwtError> {
-        let parts: Vec<&str> = token.split('.').collect();
-        if parts.len() != 3 {
-            return Err(JwtError::MalformedToken);
-        }
+        let (header_seg, claims_seg, signature_seg) =
+            jwt::split(token).ok_or(JwtError::MalformedToken)?;
 
-        let header_bytes = URL_SAFE_NO_PAD
-            .decode(parts[0])
-            .map_err(|_| JwtError::InvalidBase64)?;
-        let claims_bytes = URL_SAFE_NO_PAD
-            .decode(parts[1])
-            .map_err(|_| JwtError::InvalidBase64)?;
-        let signature = URL_SAFE_NO_PAD
-            .decode(parts[2])
-            .map_err(|_| JwtError::InvalidBase64)?;
+        let header_bytes = jwt::decode_segment(header_seg).map_err(|_| JwtError::InvalidBase64)?;
+        let claims_bytes = jwt::decode_segment(claims_seg).map_err(|_| JwtError::InvalidBase64)?;
+        let signature = jwt::decode_segment(signature_seg).map_err(|_| JwtError::InvalidBase64)?;
 
         let header: JwtHeader =
             serde_json::from_slice(&header_bytes).map_err(|_| JwtError::InvalidJson)?;
@@ -336,7 +309,7 @@ impl JwtAuth {
         Ok(ParsedJwt {
             header,
             claims,
-            signing_input: format!("{}.{}", parts[0], parts[1]),
+            signing_input: format!("{}.{}", header_seg, claims_seg),
             signature,
         })
     }

--- a/plugins/oauth2-auth/src/lib.rs
+++ b/plugins/oauth2-auth/src/lib.rs
@@ -274,11 +274,9 @@ impl OAuth2Auth {
             .or_else(|| req.headers.get("Authorization"))
             .ok_or(OAuth2Error::MissingToken)?;
 
-        if !auth_header.starts_with("Bearer ") && !auth_header.starts_with("bearer ") {
-            return Err(OAuth2Error::InvalidAuthHeader);
-        }
-
-        Ok(auth_header[7..].trim().to_string())
+        barbacane_plugin_sdk::jwt::bearer_token(auth_header)
+            .map(|token| token.to_string())
+            .ok_or(OAuth2Error::InvalidAuthHeader)
     }
 
     /// Call the introspection endpoint to validate the token.

--- a/plugins/oidc-auth/src/lib.rs
+++ b/plugins/oidc-auth/src/lib.rs
@@ -5,8 +5,8 @@
 //! `host_verify_signature` host function.
 
 use barbacane_plugin_sdk::http::{call, HttpError, HttpRequest};
+use barbacane_plugin_sdk::jwt::{self, Audience};
 use barbacane_plugin_sdk::prelude::*;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -225,23 +225,6 @@ struct JwtClaims {
     extra: BTreeMap<String, serde_json::Value>,
 }
 
-/// Audience can be a single string or array of strings.
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(untagged)]
-enum Audience {
-    Single(String),
-    Multiple(Vec<String>),
-}
-
-impl Audience {
-    fn contains(&self, value: &str) -> bool {
-        match self {
-            Audience::Single(s) => s == value,
-            Audience::Multiple(v) => v.iter().any(|s| s == value),
-        }
-    }
-}
-
 /// Parsed JWT token.
 struct ParsedJwt {
     header: JwtHeader,
@@ -458,20 +441,15 @@ impl OidcAuth {
 
     /// Parse a JWT token into its components.
     fn parse_jwt(&self, token: &str) -> Result<ParsedJwt, OidcError> {
-        let parts: Vec<&str> = token.split('.').collect();
-        if parts.len() != 3 {
-            return Err(OidcError::MalformedToken);
-        }
+        let (header_part, claims_part, signature_part) =
+            jwt::split(token).ok_or(OidcError::MalformedToken)?;
 
-        let header_bytes = URL_SAFE_NO_PAD
-            .decode(parts[0])
-            .map_err(|_| OidcError::InvalidBase64)?;
-        let claims_bytes = URL_SAFE_NO_PAD
-            .decode(parts[1])
-            .map_err(|_| OidcError::InvalidBase64)?;
-        let signature = URL_SAFE_NO_PAD
-            .decode(parts[2])
-            .map_err(|_| OidcError::InvalidBase64)?;
+        let header_bytes =
+            jwt::decode_segment(header_part).map_err(|_| OidcError::InvalidBase64)?;
+        let claims_bytes =
+            jwt::decode_segment(claims_part).map_err(|_| OidcError::InvalidBase64)?;
+        let signature =
+            jwt::decode_segment(signature_part).map_err(|_| OidcError::InvalidBase64)?;
 
         let header: JwtHeader =
             serde_json::from_slice(&header_bytes).map_err(|_| OidcError::InvalidJson)?;
@@ -481,7 +459,7 @@ impl OidcAuth {
         Ok(ParsedJwt {
             header,
             claims,
-            signing_input: format!("{}.{}", parts[0], parts[1]),
+            signing_input: format!("{}.{}", header_part, claims_part),
             signature,
         })
     }


### PR DESCRIPTION
**Final batch of #90** — dedup the JWT/Audience/Bearer plumbing across the auth plugins onto `barbacane_plugin_sdk::jwt` (added in #119).

## Changes
- **jwt-auth**: local `Audience` enum → `jwt::Audience`; `token.split('.')` + 3× `URL_SAFE_NO_PAD.decode` → `jwt::split` + `jwt::decode_segment`; Bearer → `jwt::bearer_token`. Signing-input / signature bytes handed to `host_verify_signature` are **byte-identical**; signature verification untouched.
- **oidc-auth**: same split/decode migration; local `Audience` → `jwt::Audience`. **Bearer left local** — it has an `access_token` query-param fallback and an empty-`"Bearer "` error-code edge the SDK helper would change. Discovery/JWKS untouched.
- **oauth2-auth**: Bearer → `jwt::bearer_token` (all 4 bearer tests reasoned through). **Audience left local** (stored as `serde_json::Value`, no reusable enum); `base64_encode` (standard base64 for Basic auth) and introspection untouched.
- **basic-auth**: unchanged (standard-base64 Basic creds — not a jwt-helper user).

## SDK change
Added `Serialize` to `jwt::Audience` — the auth plugins serialize claims into the `x-auth-claims` header/groups, so the shared enum needs it. Additive; untagged output is byte-identical to the old local enums (SDK tests still pass).

## Behavior notes (untested edges)
Where Bearer was migrated (jwt-auth, oauth2-auth), an empty `"Bearer "` now yields the "invalid auth header" error instead of an empty token that later failed downstream — a stricter, still-401 outcome, not covered by any test. Uppercase schemes (`BEARER`) are now accepted (RFC-correct). No existing assertion flips.

## Validation
All auth plugins' tests pass (jwt-auth 35, oidc-auth 58, oauth2-auth 40, basic-auth 18 unchanged), SDK 35; the 3 migrated plugins build to `wasm32`. Workspace clippy + fmt clean. `plugin-tests` CI is the gate.

This completes **#90** (macro fix + SDK helpers + all plugin migrations).