### PR TITLE
release: prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-10
+
+Headline: a comprehensive security-hardening pass (adversarial review + full remediation) landed on top of the earlier sweep, plus pre-release housekeeping — plugin SDK consolidation, an MSRV/toolchain floor, supply-chain CI gates, and an OpenTelemetry stack upgrade.
+
+> **Upgrade notes (breaking):**
+> - **MSRV is now Rust 1.85+** at the source level; the dependency floor (wasmtime 43 / cranelift 0.130) requires **rustc 1.91**. Build with 1.91 or newer.
+> - **`.bca` artifact hash format changed.** The signed hash now covers the capability-enforcement surface (`capabilities_enforced`, per-plugin `host_functions`/`body_access`, MCP config), so **existing *signed* artifacts must be recompiled** (`BARBACANE_SIGNING_KEY`); unsigned artifacts are unaffected beyond the hash value.
+
 ### Added
 
 - **security**: control-plane admin authentication (`BARBACANE_CONTROL_ADMIN_TOKEN`), CORS allowlist (`BARBACANE_CONTROL_ALLOWED_ORIGINS`).
@@ -43,6 +51,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security (control plane)**: request-body size limits — 1 MiB default for JSON endpoints, 32 MiB for spec/plugin uploads — bound in-memory buffering; database errors are routed through the generic error mapper (no schema disclosure); upload filenames are sanitized to a safe basename (defeating path traversal into the compile temp dir and CRLF/quote injection in `Content-Disposition`); and concurrent WebSocket sessions are capped so unauthenticated sockets can't pile up during the registration window.
 - **security (data plane)**: a single canonical, UTF-8-correct percent-decoder is applied to query and path parameters before validation and dispatch (the previous per-byte decode corrupted multi-byte sequences); request header limits are enforced on the raw header map so duplicate header names can't undercount the header limit or skip per-value size checks; and the unauthenticated admin port (`/health`, `/metrics`, `/provenance`) logs a startup warning when bound to a non-loopback address.
 - **deps**: bump `anyhow` to 1.0.103 (RUSTSEC-2026-0190).
+- **security**: the signed `.bca` hash now binds the capability-enforcement surface (`capabilities_enforced`, per-plugin `host_functions`/`body_access`, MCP config), so a tampered-but-still-signature-verifying artifact can no longer silently disable the WASM sandbox.
+- **security**: MCP tool-call path parameters are validated and percent-encoded (rejecting `/`/`..` traversal and prefix-authz confusion that bypassed the router), and unauthenticated MCP `initialize` sessions are capped with the attacker-controlled `clientInfo` no longer retained (memory-exhaustion DoS).
+- **security**: per-plugin isolation of shared host state — response-cache keys and rate-limiter partitions are namespaced by the calling plugin (no cross-plugin cache poisoning/DoS), and plugin metrics gain name/label length caps, a per-plugin cardinality budget, and non-finite-value rejection (host-heap exhaustion).
+- **security**: WS / NATS / Kafka egress now pin the SSRF-vetted IP at connect time (DNS-rebinding safe), matching the HTTP client; the Kafka bootstrap connection is pinned (advertised-broker filtering is tracked as a follow-up, blocked on the client library).
+- **security**: WASI `random_get` is backed by the host CSPRNG — plugin-side `getrandom` / `uuid` / crypto nonces are no longer predictable, and HashDoS via a fixed hasher seed is closed. Plugin-supplied response headers are validated before insertion, so a malicious/buggy plugin can no longer panic the connection task (per-route DoS).
+- **security (hygiene)**: duplicate declared query parameters are rejected (HTTP parameter pollution); offline `data_plane` rows are reaped past a retention window (unbounded-row DoS); the E1070 plaintext-secret scan now covers version-pinned plugin references; remote plugin downloads are size-capped.
+
+### Changed
+
+- **plugin-sdk**: shared building blocks (`errors::ProblemDetails`, `log`, `http`, `jwt`) added and adopted across the plugin fleet, removing over 1,000 lines of duplicated error/logging/HTTP/JWT plumbing. The `#[barbacane_middleware]` / `#[barbacane_dispatcher]` macros now hold plugin state in a `thread_local` `RefCell` instead of `static mut` (sound under Rust 2024's `static_mut_refs`).
+- **build**: declared MSRV (`rust-version = 1.91`) enforced by a CI job; clippy now runs `--all-targets` (tests/benches included).
+- **ci/supply-chain**: third-party GitHub Actions are SHA-pinned (incl. `trivy` off `@master`), jobs run with least-privilege `permissions`, the `/bench` comment trigger is gated on author association, and the full `cargo deny check` (advisories + licenses + bans + sources) is a CI gate with a weekly scheduled run.
+- **deps**: OpenTelemetry stack upgraded to 0.32 (`tracing-opentelemetry` 0.33); workspace `tokio` features narrowed from `full` to the set actually used. The OTel upgrade also eliminated the duplicate axum 0.7 / tower 0.4 major versions previously pulled in transitively.
 
 ## [0.7.0] - 2026-05-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "barbacane-compiler",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-compiler"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-control"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "quote",
  "syn",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-sigv4"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "hex",
  "hmac",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-telemetry"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-test"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "barbacane-compiler",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 # Minimum supported Rust version, set by the dependency floor: wasmtime 43 and
 # cranelift 0.130 require rustc 1.91. Enforced by the `msrv` CI job.
@@ -155,15 +155,15 @@ assert_cmd = "2"
 predicates = "3"
 
 # Workspace crates (version required for crates.io publishing)
-barbacane-sigv4 = { path = "crates/barbacane-sigv4", version = "0.7.0" }
-barbacane-compiler = { path = "crates/barbacane-compiler", version = "0.7.0" }
-barbacane-plugin-sdk = { path = "crates/barbacane-plugin-sdk", version = "0.7.0" }
-barbacane-plugin-macros = { path = "crates/barbacane-plugin-macros", version = "0.7.0" }
-barbacane-wasm = { path = "crates/barbacane-wasm", version = "0.7.0" }
-barbacane-telemetry = { path = "crates/barbacane-telemetry", version = "0.7.0" }
-barbacane-test = { path = "crates/barbacane-test", version = "0.7.0" }
-barbacane = { path = "crates/barbacane", version = "0.7.0" }
-barbacane-control = { path = "crates/barbacane-control", version = "0.7.0" }
+barbacane-sigv4 = { path = "crates/barbacane-sigv4", version = "0.8.0" }
+barbacane-compiler = { path = "crates/barbacane-compiler", version = "0.8.0" }
+barbacane-plugin-sdk = { path = "crates/barbacane-plugin-sdk", version = "0.8.0" }
+barbacane-plugin-macros = { path = "crates/barbacane-plugin-macros", version = "0.8.0" }
+barbacane-wasm = { path = "crates/barbacane-wasm", version = "0.8.0" }
+barbacane-telemetry = { path = "crates/barbacane-telemetry", version = "0.8.0" }
+barbacane-test = { path = "crates/barbacane-test", version = "0.8.0" }
+barbacane = { path = "crates/barbacane", version = "0.8.0" }
+barbacane-control = { path = "crates/barbacane-control", version = "0.8.0" }
 
 [profile.dev]
 opt-level = 0


### PR DESCRIPTION
Release-prep for **v0.8.0** (last release 0.7.0). No tagging/publishing here — the release workflow runs when the `v0.8.0` tag is pushed after this merges.

## Changes
- Bump `[workspace.package] version` and all path-dep pins 0.7.0 → **0.8.0**; update `Cargo.lock`.
- Finalize `CHANGELOG.md`: `[Unreleased]` → `[0.8.0] - 2026-07-10`, with this cycle's entries (security-review remediation, plugin SDK consolidation + `static_mut` macro fix, MSRV/toolchain, supply-chain CI gates, OpenTelemetry 0.32 bump) and **upgrade notes**.

## ⚠️ Upgrade notes (breaking, pre-1.0)
- **MSRV**: build requires **rustc 1.91+** (dependency floor: wasmtime 43 / cranelift 0.130).
- **`.bca` artifact hash format changed**: the signed hash now binds the capability-enforcement surface, so **existing *signed* artifacts must be recompiled**. Unsigned artifacts only see a different hash value.

## Scope of 0.8.0
Bundles everything since 0.7.0: the full security-hardening sweep + the comprehensive adversarial review & remediation (15 findings) + pre-release housekeeping. The only deferred item is **#87** (SBOM + cosign/SLSA image signing), a post-release follow-up.

## Release gates (verified locally)
- `Cargo.toml` version `0.8.0` == tag `v0.8.0` (validate-version) ✅
- `CHANGELOG.md` has `## [0.8.0]` (validate-changelog) ✅
- workspace builds at 0.8.0, fmt clean.
