### PR TITLE
docs: pre-0.8.0 accuracy pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Headline: a comprehensive security-hardening pass (adversarial review + full rem
 
 > **Upgrade notes (breaking):**
 > - **MSRV is now Rust 1.85+** at the source level; the dependency floor (wasmtime 43 / cranelift 0.130) requires **rustc 1.91**. Build with 1.91 or newer.
-> - **`.bca` artifact hash format changed.** The signed hash now covers the capability-enforcement surface (`capabilities_enforced`, per-plugin `host_functions`/`body_access`, MCP config), so **existing *signed* artifacts must be recompiled** (`BARBACANE_SIGNING_KEY`); unsigned artifacts are unaffected beyond the hash value.
+> - **`.bca` artifact hash format changed → all pre-0.8 artifacts must be recompiled.** `artifact_hash` now also binds the capability-enforcement surface (`capabilities_enforced`, per-plugin `host_functions`/`body_access`, MCP config). The data plane recomputes and verifies `artifact_hash` on load **unconditionally** (independent of signing), so a `.bca` built before 0.8 fails with `artifact integrity check failed`. Recompile every artifact with 0.8 (`barbacane compile`); re-sign signed artifacts (`BARBACANE_SIGNING_KEY`). The artifact format version is now **4**.
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Be respectful. We're all here to build something useful.
 ### Pull Request Process
 
 1. PRs require at least one approving review
-2. All CI checks must pass (fmt, clippy, tests, benchmarks)
+2. All CI checks must pass (fmt, clippy, tests, benchmarks, cargo deny check)
 3. Commits should be signed off (see below)
 4. Keep PRs focused — one logical change per PR
 
@@ -35,7 +35,7 @@ Be respectful. We're all here to build something useful.
 
 ### Prerequisites
 
-- Rust stable (install via [rustup](https://rustup.rs/))
+- Rust 1.91+ (the project MSRV, enforced by CI)
 - PostgreSQL (for control plane tests)
 
 ### Building
@@ -59,7 +59,7 @@ We use standard Rust formatting and lints:
 cargo fmt
 
 # Run lints
-cargo clippy -- -D warnings
+cargo clippy --all-targets -- -D warnings
 ```
 
 **Guidelines:**
@@ -136,13 +136,15 @@ Barbacane/
 ├── adr/                    # Architecture Decision Records
 ├── specs/                  # Technical specifications
 ├── crates/
-│   ├── barbacane/          # Data plane binary
-│   ├── barbacane-control/  # Control plane CLI
-│   ├── barbacane-spec-parser/
-│   ├── barbacane-compiler/
-│   ├── barbacane-router/
-│   ├── barbacane-plugin-sdk/
-│   └── barbacane-test/
+│   ├── barbacane/            # Data-plane binary + CLI: router, validator, TLS, WS proxy
+│   ├── barbacane-control/    # Control-plane binary
+│   ├── barbacane-compiler/   # Spec compilation + parser + .bca format
+│   ├── barbacane-wasm/       # WASM runtime
+│   ├── barbacane-telemetry/  # OTel + Prometheus
+│   ├── barbacane-plugin-sdk/ # Plugin SDK
+│   ├── barbacane-plugin-macros/ # Proc macros
+│   ├── barbacane-sigv4/      # AWS SigV4
+│   └── barbacane-test/       # Integration tests
 └── tests/fixtures/         # Test spec files
 ```
 
@@ -153,4 +155,4 @@ Barbacane/
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the Apache License 2.0.
+By contributing, you agree that your contributions will be licensed under the GNU AGPLv3.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -63,7 +63,7 @@ Large organizations moving from legacy gateways who want:
 
 ## Business Model
 
-Barbacane is fully open source under the Apache 2.0 license.
+Barbacane is open source under the GNU AGPLv3, with a commercial license available for organizations that can't comply with AGPLv3.
 
 ### How We Make Money
 
@@ -81,7 +81,7 @@ Everything in this repository:
 - The plugin SDK
 - Documentation and specifications
 
-There is no "enterprise edition" with gated features. The open source version is the complete product.
+There is no "enterprise edition" with gated features. The full gateway is AGPLv3; the commercial license is an alternative licensing option for AGPL-incompatible use, not a separate feature-gated edition. The open source version is the complete product.
 
 ## Roadmap
 

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -45,72 +45,55 @@ The project is organized as a Cargo workspace with specialized crates:
 
 ```
 crates/
-├── barbacane/              # Main CLI (compile, validate, serve)
-├── barbacane-control/      # Control plane CLI (spec upload, plugin register)
-├── barbacane-compiler/     # Spec compilation & artifact format
-├── barbacane-spec-parser/  # OpenAPI/AsyncAPI parsing
-├── barbacane-router/       # Prefix trie request routing
-├── barbacane-validator/    # Request validation
-├── barbacane-wasm/         # WASM plugin runtime (wasmtime)
-├── barbacane-plugin-sdk/   # WASM plugin development kit
-├── barbacane-plugin-macros/# Proc macros for plugin development
-└── barbacane-test/         # Integration test harness
+├── barbacane/              # Data-plane binary + CLI — router (prefix trie), validator, TLS, WebSocket proxy; serve/compile/validate/dev
+├── barbacane-control/      # Control-plane binary — REST API, PostgreSQL, spec/artifact management
+├── barbacane-compiler/     # Spec compilation & .bca artifact format (includes the OpenAPI/AsyncAPI spec parser)
+├── barbacane-wasm/         # WASM plugin runtime (wasmtime), host functions, sandboxing
+├── barbacane-telemetry/    # OpenTelemetry tracing + Prometheus metrics
+├── barbacane-plugin-sdk/   # WASM plugin SDK (Request/Response/Action + log/http/errors/jwt helpers)
+├── barbacane-plugin-macros/# Proc macros (#[barbacane_middleware] / #[barbacane_dispatcher])
+├── barbacane-sigv4/        # AWS SigV4 request signing (used by the s3 / lambda dispatchers)
+└── barbacane-test/         # Integration test harness (incl. the adversarial security suite)
 ```
+
+Routing, request validation, and spec parsing are modules within `barbacane` /
+`barbacane-compiler`, not separate crates.
 
 ### Crate Dependencies
 
 ```
-barbacane (CLI / data plane)
-    ├── barbacane-compiler
-    │   ├── barbacane-spec-parser
-    │   └── barbacane-router
-    ├── barbacane-validator
-    ├── barbacane-router
-    └── barbacane-wasm
-        └── barbacane-plugin-sdk
+barbacane (CLI / data plane)      — router + validator modules live here
+    ├── barbacane-compiler        — includes the spec parser
+    ├── barbacane-wasm
+    │   └── barbacane-plugin-sdk
+    │       └── barbacane-plugin-macros
+    └── barbacane-telemetry
 
-barbacane-plugin-sdk
-    └── barbacane-plugin-macros
+barbacane-control
+    ├── barbacane-compiler
+    └── barbacane-telemetry
 
 barbacane-test
-    └── barbacane-compiler
+    └── barbacane-compiler (+ builds fixture plugins)
 ```
 
 ## Crate Details
 
-### barbacane-spec-parser
+### barbacane-compiler
 
-Parses OpenAPI and AsyncAPI specifications and extracts Barbacane extensions.
+Parses OpenAPI/AsyncAPI specs (spec-parser module) and compiles them into
+deployable `.bca` artifacts.
 
-**Key types:**
+**Key spec types:**
 - `ApiSpec` - Parsed specification with operations and metadata
 - `Operation` - Single API operation with dispatch/middleware config
-- `DispatchConfig` - Dispatcher name and configuration
-- `MiddlewareConfig` - Middleware name and configuration
-- `Channel` - AsyncAPI channel with publish/subscribe operations
+- `DispatchConfig` / `MiddlewareConfig` - Dispatcher / middleware name + config
 
-**Supported formats:**
-- OpenAPI 3.0.x
-- OpenAPI 3.1.x
-- OpenAPI 3.2.x (draft)
-- AsyncAPI 3.x (with Kafka and NATS dispatchers)
+**Supported formats:** OpenAPI 3.0.x / 3.1.x / 3.2.x (draft), AsyncAPI 3.x (Kafka/NATS).
 
-### barbacane-router
-
-Prefix trie implementation for fast HTTP request routing.
-
-**Key types:**
-- `Router` - The routing trie
-- `RouteEntry` - Points to compiled operation index
-- `RouteMatch` - Found / MethodNotAllowed / NotFound
-
-**Features:**
-- O(path length) lookup
-- Static routes take precedence over parameters
-- Path parameter extraction
-- Path normalization (trailing slashes, double slashes)
-
-### barbacane-compiler
+**Routing** is a prefix-trie module in `barbacane` (`router/trie.rs`): O(path-length)
+lookup, static routes take precedence over parameters, path-parameter extraction,
+and path normalization.
 
 Compiles parsed specs into deployable artifacts.
 
@@ -174,21 +157,22 @@ WASM plugin runtime built on wasmtime.
 - `PluginInstance` - Single WASM instance with host function bindings
 - `MiddlewareChain` - Ordered middleware execution
 
-**Host functions:**
-- `host_set_output` - Plugin writes result to host buffer
-- `host_log` - Structured logging with trace context
-- `host_context_get/set` - Per-request key-value store
-- `host_clock_now` - Monotonic time in milliseconds
-- `host_http_call` - Make outbound HTTP requests
-- `host_http_read_result` - Read HTTP response data
-- `host_get_secret` - Get a resolved secret by reference
-- `host_secret_read_result` - Read secret value into plugin memory
-- `host_kafka_publish` - Publish messages to Kafka topics
-- `host_nats_publish` - Publish messages to NATS subjects
-- `host_rate_limit_check` - Check rate limits
-- `host_cache_read/write` - Read/write response cache
-- `host_metric_counter_inc` - Increment Prometheus counter
-- `host_metric_histogram_observe` - Record histogram observation
+**Host functions** (grouped; `*_read_result` variants copy a staged value into plugin memory):
+- Output: `host_set_output` - plugin writes its result to the host buffer
+- Logging: `host_log` - structured logging with trace context
+- Context: `host_context_get`/`host_context_set`/`host_context_read_result` - per-request key-value store
+- Clock: `host_clock_now`/`host_get_unix_timestamp`/`host_time_now` - time access
+- Secrets: `host_get_secret`/`host_secret_read_result` - resolved secret by reference
+- HTTP: `host_http_call`/`host_http_read_result`/`host_http_stream`/`host_http_request_body_set`/`host_http_response_body_len`/`host_http_response_body_read` - outbound HTTP requests
+- Cache: `host_cache_get`/`host_cache_set`/`host_cache_read_result` - response cache
+- Rate limiting: `host_rate_limit_check`/`host_rate_limit_read_result`
+- Brokers: `host_kafka_publish`/`host_nats_publish`/`host_broker_read_result`
+- Metrics: `host_metric_counter_inc`/`host_metric_histogram_observe`
+- Spans: `host_span_start`/`host_span_end`/`host_span_set_attribute`
+- UUID: `host_uuid_generate`/`host_uuid_read_result`
+- Crypto: `host_verify_signature` - signature verification (e.g. RS256/384/512)
+- WebSocket: `host_ws_upgrade`
+- Body access: `host_body_get`/`host_body_set`/`host_body_len`/`host_body_clear`
 
 **Resource limits:**
 - 16 MB linear memory
@@ -204,6 +188,12 @@ SDK for developing WASM plugins (dispatchers and middlewares).
 - `#[barbacane_middleware]` macro - generates WASM exports for middlewares
 - `#[barbacane_dispatcher]` macro - generates WASM exports for dispatchers
 - Host function FFI bindings
+- Helper modules (0.8+):
+  - `log` - host logging
+  - `http` - outbound HTTP via `host_http_call`
+  - `errors::ProblemDetails` - RFC 9457 problem+json builder
+  - `jwt` - `Audience` / `Bearer` / base64url / claims parsing
+  - `body` - request/response body side-channel
 
 ### barbacane-plugin-macros
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -4,7 +4,7 @@ This guide helps you set up a development environment for contributing to Barbac
 
 ## Prerequisites
 
-- **Rust 1.75+** - Install via [rustup](https://rustup.rs/)
+- **Rust 1.91+** - Install via [rustup](https://rustup.rs/). This is the project MSRV (enforced by CI); the dependency floor (wasmtime/cranelift) requires it.
 - **Git** - For version control
 - **Node.js 20+** - For the UI (if working on the web interface)
 - **PostgreSQL 14+** - For the control plane (or use Docker)
@@ -102,13 +102,13 @@ cargo build --workspace --release
 cargo test --workspace
 
 # Run tests for a specific crate
-cargo test -p barbacane-router
+cargo test -p barbacane-compiler
 
 # Run tests with output
 cargo test --workspace -- --nocapture
 
-# Run a specific test
-cargo test -p barbacane-router trie::tests::static_takes_precedence
+# Run a specific test (routing trie lives in the barbacane crate)
+cargo test -p barbacane router::trie::tests::static_takes_precedence_over_param
 ```
 
 ### Run
@@ -146,50 +146,34 @@ barbacane/
 ├── README.md
 │
 ├── crates/
-│   ├── barbacane/          # Data plane CLI (compile, validate, serve)
+│   ├── barbacane/          # Data-plane binary + CLI (serve/compile/validate/dev)
 │   │   ├── Cargo.toml
 │   │   └── src/
-│   │       └── main.rs
+│   │       ├── main.rs
+│   │       ├── router/     # Prefix-trie routing (trie.rs)
+│   │       ├── validator.rs
+│   │       └── mcp/        # MCP server
 │   │
-│   ├── barbacane-control/  # Control plane server
+│   ├── barbacane-control/  # Control plane server (REST API, PostgreSQL)
 │   │   ├── Cargo.toml
-│   │   ├── openapi.yaml    # API specification
 │   │   └── src/
 │   │       ├── main.rs
 │   │       ├── server.rs
 │   │       └── db/
 │   │
-│   ├── barbacane-compiler/ # Compilation logic
+│   ├── barbacane-compiler/ # Spec compilation + parser + .bca format
 │   │   ├── Cargo.toml
 │   │   └── src/
 │   │       ├── lib.rs
 │   │       ├── artifact.rs
-│   │       └── error.rs
+│   │       └── spec_parser/   # OpenAPI/AsyncAPI parsing
 │   │
-│   ├── barbacane-spec-parser/  # OpenAPI/AsyncAPI parsing
-│   │   ├── Cargo.toml
-│   │   └── src/
-│   │       ├── lib.rs
-│   │       ├── openapi.rs
-│   │       ├── asyncapi.rs
-│   │       └── error.rs
-│   │
-│   ├── barbacane-router/   # Request routing
-│   │   ├── Cargo.toml
-│   │   └── src/
-│   │       ├── lib.rs
-│   │       └── trie.rs
-│   │
-│   ├── barbacane-plugin-sdk/  # Plugin development SDK
-│   │   ├── Cargo.toml
-│   │   └── src/
-│   │       └── lib.rs
-│   │
-│   └── barbacane-test/     # Test harness
-│       ├── Cargo.toml
-│       └── src/
-│           ├── lib.rs
-│           └── gateway.rs
+│   ├── barbacane-wasm/     # WASM plugin runtime (wasmtime), host functions
+│   ├── barbacane-telemetry/# OpenTelemetry tracing + Prometheus metrics
+│   ├── barbacane-plugin-sdk/  # Plugin SDK (types + log/http/errors/jwt helpers)
+│   ├── barbacane-plugin-macros/ # #[barbacane_middleware] / #[barbacane_dispatcher]
+│   ├── barbacane-sigv4/    # AWS SigV4 signing (s3 / lambda dispatchers)
+│   └── barbacane-test/     # Integration tests (+ adversarial security suite)
 │
 ├── plugins/                # Built-in WASM plugins
 │   ├── http-upstream/      # HTTP reverse proxy dispatcher
@@ -497,18 +481,16 @@ Criterion benchmarks are available for performance-critical components:
 # Run all benchmarks
 cargo bench --workspace
 
-# Run router benchmarks (trie lookup and insertion)
-cargo bench -p barbacane-router
-
-# Run validator benchmarks (schema validation)
-cargo bench -p barbacane-validator
+# Run router + validator benchmarks (both live in the barbacane crate)
+cargo bench -p barbacane --bench routing
+cargo bench -p barbacane --bench validation
 ```
 
-**Router benchmarks** (`crates/barbacane-router/benches/routing.rs`):
+**Router benchmarks** (`crates/barbacane/benches/routing.rs`):
 - `router_lookup` - Measures lookup performance for static paths, parameterized paths, and not-found cases
 - `router_insert` - Measures route insertion performance at various route counts (10-1000 routes)
 
-**Validator benchmarks** (`crates/barbacane-validator/benches/validation.rs`):
+**Validator benchmarks** (`crates/barbacane/benches/validation.rs`):
 - `validator_creation` - Measures schema compilation time
 - `path_param_validation` - Validates path parameters against schemas
 - `query_param_validation` - Validates query parameters

--- a/docs/contributing/plugins.md
+++ b/docs/contributing/plugins.md
@@ -214,6 +214,11 @@ pub enum Action {
 
 Plugins can call host functions to access gateway capabilities. Declare required capabilities in `plugin.toml`:
 
+The SDK wraps the most common host functions so you don't hand-roll the FFI:
+`barbacane_plugin_sdk::log`, `::http`, `::errors::ProblemDetails`, and `::jwt`.
+Each has a native (non-wasm) stub so your plugin still compiles and unit-tests
+off-target. You still declare the underlying capability in `plugin.toml`.
+
 ### Logging
 
 ```toml
@@ -222,58 +227,12 @@ host_functions = ["log"]
 ```
 
 ```rust
-use barbacane_plugin_sdk::host;
+use barbacane_plugin_sdk::log;
 
-host::log("info", "Processing request");
-host::log("error", "Something went wrong");
-```
-
-### Context (per-request key-value store)
-
-```toml
-[capabilities]
-host_functions = ["context_get", "context_set"]
-```
-
-```rust
-use barbacane_plugin_sdk::host;
-
-// Set a value for downstream middleware/dispatcher
-host::context_set("user_id", "12345");
-
-// Get a value set by upstream middleware
-if let Some(value) = host::context_get("auth_token") {
-    // use value
-}
-```
-
-### Clock
-
-```toml
-[capabilities]
-host_functions = ["clock_now"]
-```
-
-```rust
-use barbacane_plugin_sdk::host;
-
-let timestamp_ms = host::clock_now();
-```
-
-### Secrets
-
-```toml
-[capabilities]
-host_functions = ["get_secret"]
-```
-
-```rust
-use barbacane_plugin_sdk::host;
-
-// Secrets are resolved at gateway startup from env:// or file:// references
-if let Some(api_key) = host::get_secret("api_key") {
-    // use api_key
-}
+log::info("Processing request");
+log::warn("rate limit exceeded");
+log::error("something went wrong");
+// or an explicit level: log::log(log::LEVEL_DEBUG, "verbose detail");
 ```
 
 ### HTTP Calls (Dispatcher only)
@@ -284,29 +243,64 @@ host_functions = ["http_call"]
 ```
 
 ```rust
-use barbacane_plugin_sdk::prelude::*;
-use serde::Serialize;
+use barbacane_plugin_sdk::http;
 
-// HTTP request struct — body travels via side-channel, not in JSON.
-#[derive(Serialize)]
-struct HttpRequest {
-    method: String,
-    url: String,
-    headers: BTreeMap<String, String>,
-    timeout_ms: Option<u64>,
+let req = http::HttpRequest::new("GET", "https://api.example.com")
+    .header("accept", "application/json")
+    .timeout_ms(5000);
+
+// The optional request body is passed separately (sent via the side-channel):
+match http::call(&req, None) {
+    Ok(resp) => {
+        let _status = resp.status;
+        let _body = resp.body_str(); // Option<&str>
+    }
+    Err(e) => { /* http::HttpError: Unreachable / Empty / ReadFailed / ... */ }
 }
-
-// Optionally set request body via side-channel:
-// barbacane_plugin_sdk::body::set_http_request_body(b"request body");
-
-// Serialize and call:
-let req = HttpRequest { method: "GET".into(), url: "https://api.example.com".into(), headers: BTreeMap::new(), timeout_ms: Some(5000) };
-let json = serde_json::to_vec(&req).unwrap();
-unsafe { host_http_call(json.as_ptr() as i32, json.len() as i32); }
-
-// Read response body via side-channel:
-// let body = barbacane_plugin_sdk::body::read_http_response_body();
 ```
+
+### Error responses (RFC 9457 problem+json)
+
+Build consistent `application/problem+json` error responses with the shared builder:
+
+```rust
+use barbacane_plugin_sdk::errors::ProblemDetails;
+
+return Action::ShortCircuit(
+    ProblemDetails::new(403, "urn:barbacane:error:forbidden", "Forbidden")
+        .detail("Access denied")
+        .with("consumer", "alice") // optional extension members
+        .into_response(),
+);
+```
+
+### JWT parsing (auth plugins)
+
+```rust
+use barbacane_plugin_sdk::jwt;
+
+if let Some(token) = jwt::bearer_token(auth_header) {
+    // Decode claims for inspection — signature is verified separately
+    // (host `verify_signature` capability), not by this helper.
+    let claims: MyClaims = jwt::decode_claims_unverified(token)?;
+    if claims.aud.contains("my-api") { /* jwt::Audience: string or array */ }
+}
+```
+
+### Context, clock, secrets (host imports)
+
+These host functions do not (yet) have SDK wrappers — declare the capability and
+import the function directly. See any official plugin (e.g. `correlation-id` for
+context, `oidc-auth` for secrets) for the exact `extern "C"` binding pattern.
+
+```toml
+[capabilities]
+host_functions = ["context_get", "context_set", "clock_now", "get_secret"]
+```
+
+Secrets are resolved at gateway startup from `env://` / `file://` references, so
+`get_secret` returns the resolved value (never a plaintext literal baked into the
+artifact).
 
 ## Using Plugins in Specs
 

--- a/docs/contributing/security-testing.md
+++ b/docs/contributing/security-testing.md
@@ -82,9 +82,11 @@ A few tests are `#[ignore]`d with a precise blocker:
   *all* host functions). The load-time positive control additionally needs
   `barbacane-wasm` added as a dev-dependency of `barbacane-test` so
   `validate::validate_imports` can be called directly.
-- **Crypto (BARB-SEC-005)** — the "validly-signed JWT is accepted" case needs
-  real RS256 signature verification (`public_key_pem`) in the `jwt-auth` plugin
-  plus a matching private key in the fixture to sign with.
+- **Crypto (BARB-SEC-005)** — real signature verification now exists: `jwt-auth`
+  performs RS256/384/512 verification via the host `verify_signature` capability
+  against an inline `public_key_jwk`. The remaining gap for the "validly-signed
+  JWT is accepted" case is only a test fixture — a matching private key plus a
+  token signed with it to exercise the positive path.
 - **DoS slowloris (BARB-SEC-003)** — needs a configurable + observable
   read/header timeout to assert against without flaky wall-clock sleeps.
 - **Authz IDOR phase 2 (BARB-SEC-001)** — needs per-project credentials and

--- a/docs/guide/control-plane.md
+++ b/docs/guide/control-plane.md
@@ -192,7 +192,7 @@ Response:
 ```json
 {
   "status": "healthy",
-  "version": "0.1.0"
+  "version": "0.8.0"
 }
 ```
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -257,7 +257,7 @@ curl http://127.0.0.1:8080/health
 
 # Gateway health
 curl http://127.0.0.1:8080/__barbacane/health
-# {"status":"healthy","artifact_version":1,"compiler_version":"0.1.0","routes_count":3}
+# {"status":"healthy","artifact_version":1,"compiler_version":"0.8.0","routes_count":3}
 
 # View the API specs
 curl http://127.0.0.1:8080/__barbacane/specs

--- a/docs/guide/spec-configuration.md
+++ b/docs/guide/spec-configuration.md
@@ -226,9 +226,9 @@ info:
 
 # Global middlewares
 x-barbacane-middlewares:
-  - name: request-id
+  - name: correlation-id
     config:
-      header: X-Request-ID
+      header_name: X-Request-ID
   - name: cors
     config:
       allowed_origins: ["https://shop.example.com"]
@@ -273,9 +273,6 @@ paths:
         - name: jwt-auth
           config:
             required: true
-        - name: idempotency
-          config:
-            header: Idempotency-Key
       x-barbacane-dispatch:
         name: http-upstream
         config:

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,4 +113,4 @@ Barbacane supports AsyncAPI 3.x for event-driven APIs. AsyncAPI `send` operation
 
 ## License
 
-Apache 2.0 - See [LICENSE](../LICENSE)
+GNU AGPLv3 (with a commercial license option for AGPL-incompatible use) - See [LICENSE](../LICENSE)

--- a/docs/reference/artifact.md
+++ b/docs/reference/artifact.md
@@ -26,9 +26,9 @@ Metadata about the artifact.
 
 ```json
 {
-  "barbacane_artifact_version": 2,
-  "compiled_at": "2026-03-01T10:30:00Z",
-  "compiler_version": "0.2.1",
+  "barbacane_artifact_version": 4,
+  "compiled_at": "2026-07-10T10:30:00Z",
+  "compiler_version": "0.8.0",
   "source_specs": [
     {
       "file": "api.yaml",
@@ -37,20 +37,28 @@ Metadata about the artifact.
       "version": "3.1.0"
     }
   ],
-  "bundled_plugins": [
+  "plugins": [
     {
       "name": "rate-limit",
       "version": "1.0.0",
       "plugin_type": "middleware",
       "wasm_path": "plugins/rate-limit.wasm",
-      "sha256": "789abc..."
+      "sha256": "789abc...",
+      "capabilities": {
+        "body_access": false,
+        "host_functions": ["rate_limit"]
+      }
     }
   ],
   "routes_count": 12,
   "checksums": {
     "routes.json": "sha256:def456..."
   },
+  "capabilities_enforced": true,
+  "mcp": { "enabled": false },
   "artifact_hash": "sha256:a1b2c3d4e5f6...",
+  "signature": "…hex…",
+  "signing_public_key": "…hex…",
   "provenance": {
     "commit": "abc123def456",
     "source": "ci/github-actions"
@@ -62,17 +70,32 @@ Metadata about the artifact.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `barbacane_artifact_version` | integer | Format version (currently `2`) |
+| `barbacane_artifact_version` | integer | Format version (currently `4`) |
 | `compiled_at` | string | ISO 8601 timestamp of compilation |
 | `compiler_version` | string | Version of `barbacane` compiler |
 | `source_specs` | array | List of source specifications |
-| `bundled_plugins` | array | List of bundled WASM plugins (optional) |
+| `plugins` | array | List of bundled WASM plugins (optional) |
 | `routes_count` | integer | Number of compiled routes |
-| `checksums` | object | SHA-256 checksums for integrity |
-| `artifact_hash` | string | Combined SHA-256 fingerprint of all artifact inputs (hash-of-hashes) |
+| `checksums` | object | SHA-256 checksums for integrity (`routes.json` + each plugin WASM) |
+| `capabilities_enforced` | bool | Whether per-plugin `host_functions` are authoritative and enforced on load (WA-1) |
+| `mcp` | object | MCP server config (`enabled`, optional `server_name`/`server_version`) |
+| `artifact_hash` | string | Combined SHA-256 fingerprint (see below) |
+| `signature` | string? | Detached Ed25519 signature over `artifact_hash` (present when signed with `BARBACANE_SIGNING_KEY`) |
+| `signing_public_key` | string? | Hex public key the signature was produced with (informational) |
 | `provenance` | object | Build provenance metadata |
 | `provenance.commit` | string? | Git commit SHA (if provided via `--provenance-commit`) |
 | `provenance.source` | string? | Build source identifier (if provided via `--provenance-source`) |
+
+`artifact_hash` binds not just the spec/route/plugin-WASM checksums but also the
+**capability-enforcement surface** — `capabilities_enforced`, each plugin's
+declared `host_functions` / `body_access` / type / version, and the MCP config —
+so a tampered artifact cannot flip the sandbox off while still passing signature
+verification. The data plane recomputes and verifies `artifact_hash` on **every**
+load, independent of signing.
+
+> **Migration to 0.8:** the `artifact_hash` inputs changed in 0.8, so **any `.bca`
+> built before 0.8 fails to load** (`artifact integrity check failed`). Recompile
+> every artifact with 0.8 (`barbacane compile`); re-sign any signed artifacts.
 
 #### source_specs entry
 
@@ -83,7 +106,7 @@ Metadata about the artifact.
 | `type` | string | Spec type (`openapi` or `asyncapi`) |
 | `version` | string | Spec version (e.g., `3.1.0`) |
 
-#### bundled_plugins entry
+#### plugins entry
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -92,6 +115,7 @@ Metadata about the artifact.
 | `plugin_type` | string | Plugin type (`middleware` or `dispatcher`) |
 | `wasm_path` | string | Path to WASM file within artifact |
 | `sha256` | string | SHA-256 hash of WASM file |
+| `capabilities` | object | `{ body_access: bool, host_functions: [string] }` — declared in `plugin.toml`, enforced on load when `capabilities_enforced` is true |
 
 ### routes.json
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -567,8 +567,7 @@ See [API Lifecycle](#api-lifecycle) for configuration details.
 | Code | Meaning |
 |------|---------|
 | 0 | Clean shutdown |
-| 1 | Startup error (artifact not found, bind failed) |
-| 11 | Plugin hash mismatch (artifact tampering detected) |
+| 1 | Startup error (artifact not found, bind failed, integrity/signature/capability failure) |
 | 13 | Secret resolution failure (missing env var or file) |
 
 Exit code 13 occurs when a secret reference in your spec cannot be resolved:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -72,6 +72,8 @@ BARBACANE_TRUSTED_PUBKEY=<hex-public-key> \
   barbacane serve --artifact api.bca --listen 0.0.0.0:8080
 ```
 
-The signature covers the artifact's content hash, which binds every spec, route,
-and plugin WASM checksum, so any tampering with the artifact fails verification
-on load.
+The signature covers the artifact's content hash (`artifact_hash`), which binds
+every spec, route, and plugin WASM checksum **plus the capability-enforcement
+surface** (`capabilities_enforced`, each plugin's declared `host_functions` /
+`body_access`, and the MCP config), so any tampering with the artifact — including
+attempts to weaken the sandbox — fails verification on load.

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -316,9 +316,9 @@ info:
   version: "1.0.0"
 
 x-barbacane-middlewares:
-  - name: request-id
+  - name: correlation-id
     config:
-      header: X-Request-ID
+      header_name: x-correlation-id
   - name: rate-limit
     config:
       quota: 100
@@ -381,10 +381,10 @@ paths:
 
 ## Available Middlewares
 
-### auth-jwt
+### jwt-auth
 
 ```yaml
-- name: auth-jwt
+- name: jwt-auth
   config:
     required: true
     header: Authorization
@@ -436,22 +436,15 @@ Adds `X-Cache` header to responses:
 - `HIT`: Response served from cache
 - `MISS`: Response not in cache (will be cached if cacheable)
 
-### request-id
+### correlation-id
 
 ```yaml
-- name: request-id
+- name: correlation-id
   config:
-    header: X-Request-ID
-    generate_if_missing: true
-```
-
-### idempotency
-
-```yaml
-- name: idempotency
-  config:
-    header: Idempotency-Key
-    ttl: 86400
+    header_name: x-correlation-id   # Header carrying the correlation ID
+    generate_if_missing: true       # Generate one if the request has none
+    trust_incoming: true            # Propagate an incoming correlation ID
+    include_in_response: true       # Echo the correlation ID in the response
 ```
 
 ### acl


### PR DESCRIPTION
Pre-0.8.0 documentation accuracy pass — audited every doc against the 0.7→0.8 changes and the current code. Blocks the `v0.8.0` tag.

## Release-critical correction
- **Artifact story fixed** across `CHANGELOG.md`, `docs/reference/artifact.md`, `docs/reference/configuration.md`: `artifact_hash` now binds the capability-enforcement surface (+ MCP config); the format is **version 4**; and the hash is verified **unconditionally** on load. So **all pre-0.8 `.bca` artifacts (signed or not) must be recompiled** — my earlier CHANGELOG note wrongly said only signed ones. Also added the missing manifest fields (`mcp`, `capabilities_enforced`, `signature`, `signing_public_key`, per-plugin `capabilities`) and fixed the JSON key `plugins` (was `bundled_plugins`).

## Plugin authoring (0.8 SDK)
- `docs/contributing/plugins.md`: rewrote the "Host Functions" section to the real SDK surface added in 0.8 — `log`, `http`, `errors::ProblemDetails`, `jwt` — instead of a nonexistent `host` module and a hand-rolled `host_http_call`.

## Crate/structure accuracy
- `architecture.md`, `development.md`, `CONTRIBUTING.md`: `barbacane-spec-parser` / `-router` / `-validator` are no longer separate crates (folded into `barbacane` / `barbacane-compiler`). Fixed the crate lists/trees, the `cargo test`/`cargo bench -p …` commands that referenced defunct crates, the host-function list (e.g. real `host_cache_get/set`), and added the SDK helper modules.

## Correctness/consistency
- **MSRV**: `development.md` + `CONTRIBUTING.md` now say Rust **1.91** (were 1.75 / "stable").
- **License**: corrected the factually-wrong "Apache 2.0" claim → **AGPLv3 (+ commercial)** in `PRODUCT.md`, `docs/index.md`, `CONTRIBUTING.md` (matches `LICENSE` / `LICENSING.md` / Cargo.toml).
- **CI docs**: added `cargo deny check` and `clippy --all-targets` to the documented checks.
- **reference**: fixed middleware names (`auth-jwt`→`jwt-auth`, `request-id`→`correlation-id`), removed the nonexistent `idempotency` example + exit-code-11 row, refreshed `0.1.0` version placeholders, and updated `security-testing.md`'s jwt-auth blocker (real signature verification now ships).

Docs-only; no code changes.
