### PR TITLE
fix(release): correct changelog release-notes extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -573,12 +573,20 @@ jobs:
       - name: Extract release notes from changelog
         id: changelog
         run: |
-          # Extract the section for this version from CHANGELOG.md
+          # Extract the body of this version's CHANGELOG section (everything after
+          # the `## [VERSION]` header, up to the next `## [` section). A range like
+          # /^## \[VERSION\]/,/^## \[/ does NOT work: the header line also matches
+          # the end pattern, so the range collapses to a single line. Use a flag.
           VERSION=${{ steps.tag.outputs.version }}
-          awk "/^## \[$VERSION\]/,/^## \[/{if(/^## \[/ && !/^## \[$VERSION\]/)exit; print}" CHANGELOG.md > release-notes.md
-          # Remove the header line
-          tail -n +2 release-notes.md > release-notes-trimmed.md
-          mv release-notes-trimmed.md release-notes.md
+          awk -v ver="$VERSION" '
+            $0 ~ ("^## \\[" ver "\\]") { f = 1; next }
+            f && /^## \[/ { exit }
+            f { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error::No CHANGELOG entry found for $VERSION"
+            exit 1
+          fi
           echo "Release notes:"
           cat release-notes.md
 


### PR DESCRIPTION
The `release.yml` "Extract release notes from changelog" step shipped an **empty** GitHub release body (noticed on v0.8.0, whose notes I set manually after the fact).

**Cause:** the awk range `/^## [VERSION]/,/^## [/` collapses to a single line — the version header (`## [0.8.0]`) also matches the *end* pattern `/^## [/`, so the range captures only that header line, which the following `tail -n +2` then strips → empty file. This affected every release.

**Fix:** flag-based extraction that prints the section body (everything after `## [VERSION]` up to the next `## [`), plus a guard that fails the job if the extracted notes are empty (so a missing/renamed CHANGELOG entry can't silently ship empty notes again).

Verified locally against the 0.8.0 (57 lines) and 0.7.0 (49 lines) sections. Docs/CI only; takes effect on the next tagged release.