### PR TITLE
feat(ci): keyless image signing + CycloneDX SBOM attestation (#87)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,6 +303,19 @@ jobs:
             docker.io/barbacane/barbacane-standalone:$VERSION-amd64 \
             docker.io/barbacane/barbacane-standalone:$VERSION-arm64
 
+  # Keyless (Sigstore) signing + CycloneDX SBOM attestation of the release images.
+  sign-and-sbom:
+    name: Sign & SBOM
+    needs: [validate-version, create-manifests]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/sign-and-sbom.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit
+
   # Security scan the multi-arch images
   scan-containers:
     name: Scan Containers

--- a/.github/workflows/sign-and-sbom.yml
+++ b/.github/workflows/sign-and-sbom.yml
@@ -1,0 +1,94 @@
+name: Sign & SBOM
+
+# Keyless (Sigstore/Fulcio) signing + CycloneDX SBOM attestation for the release
+# container images. Identity is the GitHub Actions OIDC token — no long-lived
+# signing keys (#87, option A).
+#
+# Two entry points:
+#   - workflow_call: invoked by release.yml after the multi-arch manifests exist.
+#   - workflow_dispatch: run manually against an already-published version to
+#     (re)sign it or to dry-run the mechanism (e.g. against the current release).
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to sign (with or without a leading v)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to sign, e.g. 0.8.0 (with or without leading v)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write      # push signatures/attestations to GHCR
+  id-token: write       # OIDC token for keyless signing
+
+jobs:
+  sign:
+    name: Sign & SBOM (${{ matrix.image }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [barbacane, barbacane-control, barbacane-standalone]
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Sign images and attest SBOMs (keyless)
+        env:
+          IMAGE: ${{ matrix.image }}
+          OWNER: ${{ github.repository_owner }}
+          COSIGN_YES: "true"
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          VERSION="${VERSION#v}"   # tolerate a leading v
+
+          for ref in "ghcr.io/${OWNER}/${IMAGE}" "docker.io/barbacane/${IMAGE}"; do
+            # Sign the multi-arch index by DIGEST (never by a mutable tag).
+            digest="$(docker buildx imagetools inspect "${ref}:${VERSION}" --format '{{.Manifest.Digest}}')"
+            target="${ref}@${digest}"
+            echo "::group::${target}"
+
+            echo "cosign sign ${target}"
+            cosign sign "${target}"
+
+            echo "syft SBOM (CycloneDX) for ${target}"
+            syft "${target}" -o cyclonedx-json > "sbom-${IMAGE}.cdx.json"
+
+            echo "cosign attest CycloneDX SBOM to ${target}"
+            cosign attest --predicate "sbom-${IMAGE}.cdx.json" --type cyclonedx "${target}"
+            echo "::endgroup::"
+          done
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-${{ matrix.image }}
+          path: sbom-${{ matrix.image }}.cdx.json
+          retention-days: 30


### PR DESCRIPTION
Implements **#87 option A** — keyless (Sigstore/Fulcio, GitHub OIDC) image signing + CycloneDX SBOM attestation. No long-lived signing keys; identity is the Actions OIDC token.

## What it does
New reusable workflow `.github/workflows/sign-and-sbom.yml`. For each release image (`barbacane`, `barbacane-control`, `barbacane-standalone`) on **both** GHCR and Docker Hub it:
1. resolves the multi-arch **index digest** and `cosign sign`s it **by digest** (never a mutable tag),
2. generates a **CycloneDX SBOM** with syft and `cosign attest`s it to the image,
3. uploads the SBOM as a workflow artifact.

Wired into `release.yml` as a `sign-and-sbom` job after `create-manifests` (`id-token: write` + `packages: write`, `secrets: inherit`). All third-party actions SHA-pinned (`cosign-installer` v4.1.2, `sbom-action` v0.24.0).

## Two entry points
- **workflow_call** — runs automatically on the next tagged release.
- **workflow_dispatch(version)** — sign an already-published version on demand. This is how we validate: keyless signing can only run inside GitHub Actions (needs the OIDC token), so it can't be exercised on a PR.

## Dry-run plan (after merge)
Run against the live 0.8.0 — this both validates the mechanism and retroactively signs 0.8.0 (a real registry mutation, so I'll confirm before triggering):
```
gh workflow run sign-and-sbom.yml -f version=0.8.0
```

## Verifying a signature (for the docs / consumers)
```
cosign verify \
  --certificate-identity-regexp 'https://github.com/barbacane-dev/barbacane/.github/workflows/.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  ghcr.io/barbacane-dev/barbacane:0.8.0
cosign verify-attestation --type cyclonedx <same flags> <image>   # SBOM
```

## Not yet included (follow-up)
Full SLSA build provenance for the binaries (via `actions/attest-build-provenance`) — can add once this signing path is validated. Docs "Verifying releases" section to follow after the dry-run confirms the exact identity string.