### PR TITLE
release: v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-07-15
+
+Patch release: fixes a regression that made the `barbacane-standalone` image unable to serve specs under 0.8's capability enforcement.
+
+### Fixed
+
+- **plugins**: WASM plugins are now **self-describing**. The SDK macros (`#[barbacane_middleware]` / `#[barbacane_dispatcher]`) embed each plugin's `plugin.toml` into a custom wasm section (`barbacane_manifest`), and the compiler reads declared capabilities directly from the binary (falling back to a sibling/downloaded `plugin.toml` for plugins built before 0.8.1). The standalone image shipped plugins as bare `.wasm` files with no sidecar `plugin.toml`, so every bundled plugin was compiled with empty capabilities and the data plane rejected the first one to import a host function under `capabilities_enforced` (`plugin '<name>' violates its declared capabilities: plugin imports undeclared host function: ...`). As a result the standalone image could compile a spec but not serve it. Capability contracts now travel inside the `.wasm`, so no sidecar file has to accompany a plugin. A compile-time warning is emitted when a plugin resolves with no manifest from either source.
+
 ## [0.8.0] - 2026-07-10
 
 Headline: a comprehensive security-hardening pass (adversarial review + full remediation) landed on top of the earlier sweep, plus pre-release housekeeping — plugin SDK consolidation, an MSRV/toolchain floor, supply-chain CI gates, and an OpenTelemetry stack upgrade.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arc-swap",
  "barbacane-compiler",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-compiler"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-control"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-sigv4"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "hex",
  "hmac",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-telemetry"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-test"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "assert_cmd",
  "barbacane-compiler",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-wasm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 # Minimum supported Rust version, set by the dependency floor: wasmtime 43 and
 # cranelift 0.130 require rustc 1.91. Enforced by the `msrv` CI job.
@@ -155,15 +155,15 @@ assert_cmd = "2"
 predicates = "3"
 
 # Workspace crates (version required for crates.io publishing)
-barbacane-sigv4 = { path = "crates/barbacane-sigv4", version = "0.8.0" }
-barbacane-compiler = { path = "crates/barbacane-compiler", version = "0.8.0" }
-barbacane-plugin-sdk = { path = "crates/barbacane-plugin-sdk", version = "0.8.0" }
-barbacane-plugin-macros = { path = "crates/barbacane-plugin-macros", version = "0.8.0" }
-barbacane-wasm = { path = "crates/barbacane-wasm", version = "0.8.0" }
-barbacane-telemetry = { path = "crates/barbacane-telemetry", version = "0.8.0" }
-barbacane-test = { path = "crates/barbacane-test", version = "0.8.0" }
-barbacane = { path = "crates/barbacane", version = "0.8.0" }
-barbacane-control = { path = "crates/barbacane-control", version = "0.8.0" }
+barbacane-sigv4 = { path = "crates/barbacane-sigv4", version = "0.8.1" }
+barbacane-compiler = { path = "crates/barbacane-compiler", version = "0.8.1" }
+barbacane-plugin-sdk = { path = "crates/barbacane-plugin-sdk", version = "0.8.1" }
+barbacane-plugin-macros = { path = "crates/barbacane-plugin-macros", version = "0.8.1" }
+barbacane-wasm = { path = "crates/barbacane-wasm", version = "0.8.1" }
+barbacane-telemetry = { path = "crates/barbacane-telemetry", version = "0.8.1" }
+barbacane-test = { path = "crates/barbacane-test", version = "0.8.1" }
+barbacane = { path = "crates/barbacane", version = "0.8.1" }
+barbacane-control = { path = "crates/barbacane-control", version = "0.8.1" }
 
 [profile.dev]
 opt-level = 0


### PR DESCRIPTION
Patch release for the standalone-image plugin capability regression fixed in #130 (self-describing wasm). Bumps all crate versions 0.8.0 → 0.8.1 and adds the CHANGELOG entry. Tag `v0.8.1` after merge to trigger the release workflow (crates.io + multi-arch images + signing/SBOM).