### PR TITLE
chore: unblock clippy on Rust 1.98 (result_large_err)

### DIFF
--- a/crates/barbacane-control/src/main.rs
+++ b/crates/barbacane-control/src/main.rs
@@ -3,6 +3,18 @@
 //! Provides `serve` and `seed-plugins` subcommands for running the control plane server
 //! and seeding the plugin registry.
 
+// Handlers return `Result<_, ProblemDetails>`, and `ProblemDetails` is exactly
+// 128 bytes: the six fields RFC 9457 defines, five of them String, Option<String>
+// or Vec. There is nothing to trim, and it sits exactly on this lint's default
+// threshold.
+//
+// Boxing it would trade a 128-byte move on the success path for a heap
+// allocation on every error path, in an administrative API whose handlers run
+// at human frequency. That is a worse trade, not a better one, so the lint is
+// allowed here rather than satisfied. The data plane, where per-request cost
+// does matter, keeps it enabled.
+#![allow(clippy::result_large_err)]
+
 use std::net::SocketAddr;
 use std::path::Path;
 use std::process::ExitCode;

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -1843,6 +1843,10 @@ impl Gateway {
     ///   returns, body streams via `StreamBody`. on_response runs in a background task for
     ///   observability only (modifications are discarded since the response is already sent).
     #[allow(clippy::too_many_arguments)]
+    // The Err variant here *is* an HTTP response, which hyper sizes at 144
+    // bytes. Boxing a response to satisfy a size lint would add an allocation
+    // to the error path for no benefit, and the type is not ours to shrink.
+    #[allow(clippy::result_large_err)]
     async fn dispatch_wasm_plugin_inner(
         &self,
         plugin_name: &str,


### PR DESCRIPTION
CI resolves `dtolnay/rust-toolchain@stable` to 1.98, where `clippy::result_large_err` fires **47 times** and fails every PR. Nothing in the flagged code changed; the toolchain moved.

Found while triaging CI on #140, and it blocks that PR and every other one until this lands.

## What the 47 actually are

| Count | Err type | Size |
|---|---|---|
| 46 | `barbacane-control`'s `ProblemDetails` | exactly 128 bytes |
| 1 | `hyper::Response<Full<Bytes>>` in the data plane | 144 bytes |

`ProblemDetails` is exactly the lint's default threshold, and it is exactly the six fields RFC 9457 defines — five of them `String`, `Option<String>` or `Vec`, plus a `u16`. There is nothing in it to trim.

## Why allow rather than box

Boxing `ProblemDetails` trades a 128-byte move on the **success** path for a heap allocation on **every error** path, across 46 handlers in an administrative API whose handlers run at human frequency rather than per request. That is the worse trade, so the lint is allowed at the crate root with the reasoning written next to it rather than satisfied by 46 signature changes that make the code slower to clear a threshold it sits exactly on.

The 47th is in the data plane, where the `Err` variant *is* an HTTP response and hyper sizes it. Boxing a response to satisfy a size lint adds an allocation for no benefit, and the type is not ours to shrink. That one is allowed **on the single function**, not crate-wide, so the data plane keeps the lint everywhere it could still catch something real.

If you would rather take the boxing, say so and I will do it — it is mechanical, just slower at runtime and a much larger diff.

## What this does not do

**No `rust-toolchain.toml`.** Pinning would fix the symptom by freezing the toolchain and defer every future lint to whenever someone remembers to bump it. On a security-sensitive codebase that is how you end up several versions behind.

**Does not touch the advisories failure.** RUSTSEC-2026-0258 (hyper), 0268 and 0269 (wasmtime) also fail on `main`, and the scheduled supply-chain audit has been failing since 2026-08-31. Separate problem, separate PR, same shape as #137.

## Verification

`cargo fmt --check` and tests pass across `barbacane`, `barbacane-compiler` and `barbacane-control`. The lint only fires on 1.98, so CI is the check that matters here; locally on 1.96 the same clippy invocation passes both before and after, which verifies the attributes are well-formed rather than that they work.

Refs #140