### PR TITLE
test: WAF integration suite, and coverage tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,10 @@ jobs:
         run: make plugins
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        # Third-party actions are pinned to a commit, as elsewhere in this repo.
+        uses: taiki-e/install-action@d438492cf8a250514fa2d34b30bc3c0dc37c65ff # v2
+        with:
+          tool: cargo-llvm-cov
 
       # The floor is enforced here rather than in a step of its own: the report
       # needs the environment `show-env` sets up inside the script.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,37 +400,26 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      # The floor is enforced here rather than in a step of its own: the report
+      # needs the environment `show-env` sets up inside the script.
+      # Raise the floor when the real number rises. Never lower it to turn a
+      # red build green.
       - name: Measure coverage
-        run: |
-          targets=$(ls crates/barbacane-test/tests/*.rs \
-            | xargs -n1 basename | sed 's/\.rs$//' \
-            | grep -vx security \
-            | sed 's/^/--test /' | tr '\n' ' ')
-          echo "Integration targets: $targets"
-          cargo llvm-cov clean --workspace
-          cargo llvm-cov --no-report --workspace --lib --bins --exclude barbacane-test
-          cargo llvm-cov --no-report -p barbacane-test --lib $targets -- --test-threads=2
-          cargo llvm-cov report --lcov --output-path lcov.info
-          cargo llvm-cov report --summary-only | tee coverage.txt
+        run: ./scripts/coverage.sh --lcov lcov.info --summary coverage.txt --floor 0
 
       - name: Publish summary
+        if: always()
         run: |
           {
             echo '### Coverage'
             echo
             echo '```'
-            cat coverage.txt
+            cat coverage.txt || echo '(no summary produced)'
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Enforce the coverage floor
-        run: cargo llvm-cov report --fail-under-lines "${COVERAGE_FLOOR}"
-        env:
-          # Raise this when the real number rises. Never lower it to turn a red
-          # build green.
-          COVERAGE_FLOOR: 0
-
       - name: Upload lcov
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,88 @@ jobs:
           # the binaries that would run after it; we want the full picture.
           cargo test -p barbacane-test --lib $targets --no-fail-fast -- --test-threads=2
 
+  # Line coverage over the unit tests plus the integration suite. The
+  # integration suite drives the gateway as a child process, and the harness
+  # resolves the binary through CARGO_TARGET_DIR, so the instrumented gateway is
+  # the one that runs and the request pipeline is measured rather than skipped.
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: [changes, unit-tests]
+    if: needs.changes.outputs.code == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: llvm-tools-preview
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-coverage-
+            ${{ runner.os }}-cargo-
+
+      - name: Cache WASM plugins
+        uses: actions/cache@v5
+        id: plugin-cache
+        with:
+          path: |
+            plugins/*/*.wasm
+            plugins/*/target
+          key: ${{ runner.os }}-plugins-${{ hashFiles('plugins/**/Cargo.toml', 'plugins/**/Cargo.lock', 'plugins/**/*.rs', 'crates/barbacane-plugin-sdk/**') }}
+
+      - name: Build WASM plugins
+        if: steps.plugin-cache.outputs.cache-hit != 'true'
+        run: make plugins
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Measure coverage
+        run: |
+          targets=$(ls crates/barbacane-test/tests/*.rs \
+            | xargs -n1 basename | sed 's/\.rs$//' \
+            | grep -vx security \
+            | sed 's/^/--test /' | tr '\n' ' ')
+          echo "Integration targets: $targets"
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --no-report --workspace --lib --bins --exclude barbacane-test
+          cargo llvm-cov --no-report -p barbacane-test --lib $targets -- --test-threads=2
+          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov report --summary-only | tee coverage.txt
+
+      - name: Publish summary
+        run: |
+          {
+            echo '### Coverage'
+            echo
+            echo '```'
+            cat coverage.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce the coverage floor
+        run: cargo llvm-cov report --fail-under-lines "${COVERAGE_FLOOR}"
+        env:
+          # Raise this when the real number rises. Never lower it to turn a red
+          # build green.
+          COVERAGE_FLOOR: 0
+
+      - name: Upload lcov
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-lcov
+          path: lcov.info
+          retention-days: 7
   # Adversarial security suite (crates/barbacane-test/tests/security/). Runs the
   # gateway (and, for authz, the control plane) end-to-end, so it needs the
   # built binaries, the WASM plugins, and a PostgreSQL instance.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
       # Raise the floor when the real number rises. Never lower it to turn a
       # red build green.
       - name: Measure coverage
-        run: ./scripts/coverage.sh --lcov lcov.info --summary coverage.txt --floor 0
+        run: ./scripts/coverage.sh --lcov lcov.info --summary coverage.txt --floor 60
 
       - name: Publish summary
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ target/
 
 # Coverage
 coverage/
+lcov.info
+coverage.txt
 *.profraw
 *.profdata
 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,8 @@ clean:
 # Test & Lint
 # -----------------------------------------------------------------------------
 
-.PHONY: test test-verbose test-one check clippy fmt fmt-check security-test security-test-build fuzz-build
+.PHONY: test test-verbose test-one check clippy fmt fmt-check security-test security-test-build fuzz-build \
+	coverage coverage-html coverage-lcov coverage-open
 
 test:
 	cargo test --workspace
@@ -101,6 +102,45 @@ security-test: plugins
 # Compile-only check of the security suite (does not require running services).
 security-test-build:
 	cargo test -p barbacane-test --test security --no-run
+
+# Coverage (cargo-llvm-cov, source-based LLVM instrumentation).
+#
+# Install once with:
+#   cargo install cargo-llvm-cov
+#   rustup component add llvm-tools-preview
+#
+# COVERAGE_FLOOR is the line-coverage percentage CI enforces. Raise it when the
+# real number rises; never lower it to make a red build green.
+COVERAGE_FLOOR ?= 55
+
+# Integration targets are discovered so a new suite is measured automatically.
+# `security` is excluded because it needs PostgreSQL and the control plane.
+INTEGRATION_TARGETS = $(shell ls crates/barbacane-test/tests/*.rs \
+	| xargs -n1 basename | sed 's/\.rs$$//' \
+	| grep -vx security \
+	| sed 's/^/--test /' | tr '\n' ' ')
+
+# Unit and binary tests only. Fast, needs no services.
+coverage:
+	cargo llvm-cov --workspace --lib --bins --exclude barbacane-test --summary-only
+
+# Adds the integration suite, which drives the gateway as a child process. The
+# harness resolves the binary through CARGO_TARGET_DIR, so the process that runs
+# is the instrumented one and its coverage lands in the same report.
+coverage-integration: plugins
+	cargo llvm-cov clean --workspace
+	cargo llvm-cov --no-report --workspace --lib --bins --exclude barbacane-test
+	cargo llvm-cov --no-report -p barbacane-test --lib $(INTEGRATION_TARGETS) -- --test-threads=2
+	cargo llvm-cov report --summary-only
+	cargo llvm-cov report --fail-under-lines $(COVERAGE_FLOOR)
+
+coverage-html:
+	cargo llvm-cov --workspace --lib --bins --exclude barbacane-test --html
+	@echo "Report: target/llvm-cov/html/index.html"
+
+coverage-lcov:
+	cargo llvm-cov --workspace --lib --bins --exclude barbacane-test --lcov --output-path lcov.info
+	@echo "Wrote lcov.info"
 
 # Build (not run) the standalone cargo-fuzz targets on stable, to catch bit-rot.
 # Actually fuzzing needs nightly + cargo-fuzz: `cd fuzz && cargo +nightly fuzz run <target>`.
@@ -209,6 +249,10 @@ help:
 	@echo "  make test-verbose   Run tests with output"
 	@echo "  make security-test  Run the adversarial security suite (RED until fixed)"
 	@echo "  make fuzz-build     Build the cargo-fuzz targets (run with +nightly)"
+	@echo "  make coverage       Line coverage of the unit tests"
+	@echo "  make coverage-integration  Coverage including the integration suite"
+	@echo "  make coverage-html  Coverage as a browsable HTML report"
+	@echo "  make coverage-lcov  Coverage as lcov.info (for editors and CI)"
 	@echo "  make test-one TEST=name"
 	@echo "  make check          Run fmt-check + clippy"
 	@echo "  make clippy         Run clippy lints"

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ security-test-build:
 #
 # COVERAGE_FLOOR is the line-coverage percentage CI enforces. Raise it when the
 # real number rises; never lower it to make a red build green.
-COVERAGE_FLOOR ?= 0
+COVERAGE_FLOOR ?= 60
 
 # Unit and binary tests only. Fast, needs no services.
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ clean:
 # -----------------------------------------------------------------------------
 
 .PHONY: test test-verbose test-one check clippy fmt fmt-check security-test security-test-build fuzz-build \
-	coverage coverage-html coverage-lcov coverage-open
+	coverage coverage-integration coverage-html coverage-lcov
 
 test:
 	cargo test --workspace
@@ -111,35 +111,21 @@ security-test-build:
 #
 # COVERAGE_FLOOR is the line-coverage percentage CI enforces. Raise it when the
 # real number rises; never lower it to make a red build green.
-COVERAGE_FLOOR ?= 55
-
-# Integration targets are discovered so a new suite is measured automatically.
-# `security` is excluded because it needs PostgreSQL and the control plane.
-INTEGRATION_TARGETS = $(shell ls crates/barbacane-test/tests/*.rs \
-	| xargs -n1 basename | sed 's/\.rs$$//' \
-	| grep -vx security \
-	| sed 's/^/--test /' | tr '\n' ' ')
+COVERAGE_FLOOR ?= 0
 
 # Unit and binary tests only. Fast, needs no services.
 coverage:
-	cargo llvm-cov --workspace --lib --bins --exclude barbacane-test --summary-only
+	./scripts/coverage.sh --unit
 
-# Adds the integration suite, which drives the gateway as a child process. The
-# harness resolves the binary through CARGO_TARGET_DIR, so the process that runs
-# is the instrumented one and its coverage lands in the same report.
+# Adds the integration suite, which drives the gateway as a child process.
 coverage-integration: plugins
-	cargo llvm-cov clean --workspace
-	cargo llvm-cov --no-report --workspace --lib --bins --exclude barbacane-test
-	cargo llvm-cov --no-report -p barbacane-test --lib $(INTEGRATION_TARGETS) -- --test-threads=2
-	cargo llvm-cov report --summary-only
-	cargo llvm-cov report --fail-under-lines $(COVERAGE_FLOOR)
+	./scripts/coverage.sh --floor $(COVERAGE_FLOOR)
 
 coverage-html:
-	cargo llvm-cov --workspace --lib --bins --exclude barbacane-test --html
-	@echo "Report: target/llvm-cov/html/index.html"
+	./scripts/coverage.sh --unit --html
 
 coverage-lcov:
-	cargo llvm-cov --workspace --lib --bins --exclude barbacane-test --lcov --output-path lcov.info
+	./scripts/coverage.sh --unit --lcov lcov.info
 	@echo "Wrote lcov.info"
 
 # Build (not run) the standalone cargo-fuzz targets on stable, to catch bit-rot.

--- a/crates/barbacane-test/build.rs
+++ b/crates/barbacane-test/build.rs
@@ -83,6 +83,17 @@ fn main() {
 fn build_fixture_plugin(plugin_dir: &Path, wasm_path: &Path, wasm_name: &str) {
     let status = Command::new("cargo")
         .current_dir(plugin_dir)
+        // The fixture plugins build for wasm32-unknown-unknown and must not
+        // inherit the outer build's flags or output paths. Coverage
+        // instrumentation in particular is unsupported on that target and makes
+        // this build fail. Each plugin crate keeps its own target directory.
+        .env_remove("RUSTFLAGS")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .env_remove("RUSTDOCFLAGS")
+        .env_remove("CARGO_ENCODED_RUSTDOCFLAGS")
+        .env_remove("CARGO_TARGET_DIR")
+        .env_remove("CARGO_BUILD_TARGET_DIR")
+        .env_remove("LLVM_PROFILE_FILE")
         .args(["build", "--target", "wasm32-unknown-unknown", "--release"])
         .status();
 

--- a/crates/barbacane-test/build.rs
+++ b/crates/barbacane-test/build.rs
@@ -95,22 +95,27 @@ fn build_fixture_plugin(plugin_dir: &Path, wasm_path: &Path, wasm_name: &str) {
         .env_remove("CARGO_BUILD_TARGET_DIR")
         .env_remove("LLVM_PROFILE_FILE")
         .args(["build", "--target", "wasm32-unknown-unknown", "--release"])
-        .status();
+        .output();
 
     match status {
-        Ok(s) if s.success() => {
+        Ok(o) if o.status.success() => {
             println!(
                 "cargo:warning=Built fixture plugin: {}",
                 wasm_path.display()
             );
         }
-        Ok(s) => {
+        Ok(o) => {
             println!(
                 "cargo:warning=Fixture plugin build failed (exit {}): {}. \
                  Streaming integration tests will be skipped.",
-                s.code().unwrap_or(-1),
+                o.status.code().unwrap_or(-1),
                 wasm_name
             );
+            // Cargo captures build-script output, so without relaying the
+            // child's diagnostics a failure here reports only an exit code.
+            for line in String::from_utf8_lossy(&o.stderr).lines() {
+                println!("cargo:warning=  {wasm_name}: {line}");
+            }
         }
         Err(e) => {
             println!(

--- a/crates/barbacane-test/src/gateway.rs
+++ b/crates/barbacane-test/src/gateway.rs
@@ -467,6 +467,25 @@ impl Drop for TestGateway {
 
 /// Find the barbacane binary in the target directory.
 fn find_barbacane_binary() -> Result<String, TestError> {
+    // An explicit path wins, then the active target directory. Both come before
+    // the fixed candidates so a build under a redirected CARGO_TARGET_DIR (which
+    // is how `cargo llvm-cov` instruments the gateway) runs the binary it just
+    // built rather than a stale one under ./target.
+    if let Ok(path) = std::env::var("BARBACANE_TEST_BINARY") {
+        if Path::new(&path).exists() {
+            return Ok(path);
+        }
+        return Err(TestError::BinaryNotFound(path));
+    }
+    if let Ok(dir) = std::env::var("CARGO_TARGET_DIR") {
+        for profile in ["debug", "release"] {
+            let path = format!("{dir}/{profile}/barbacane");
+            if Path::new(&path).exists() {
+                return Ok(path);
+            }
+        }
+    }
+
     // Try debug build first, then release
     let candidates = [
         "target/debug/barbacane",

--- a/crates/barbacane-test/tests/waf.rs
+++ b/crates/barbacane-test/tests/waf.rs
@@ -1,0 +1,418 @@
+//! Integration tests for the WAF pipeline stage.
+//!
+//! These cover the gateway wiring rather than detection quality: header and
+//! body collection, anomaly-score accumulation, the block response shape and
+//! the metrics. Rule-language conformance is measured by parapet's go-ftw
+//! suite, and the compile-time sealing and integrity checks are unit-tested in
+//! `barbacane-compiler`.
+//!
+//! The fixture rule set is `tests/fixtures/waf-rules` (see its README for the
+//! rules and their scores). The gateway boots with `--dev`, so the block
+//! response carries `rule_id` and the tests can assert which rule fired.
+//!
+//! Run with: `cargo test -p barbacane-test --test waf`
+
+use barbacane_test::TestGateway;
+use reqwest::header::{HeaderName, HeaderValue};
+
+fn fixture(name: &str) -> String {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("tests/fixtures")
+        .join(name)
+        .display()
+        .to_string()
+}
+
+/// The rule that makes the blocking decision on the accumulated score.
+const ANOMALY_RULE: u64 = 1_009_110;
+
+async fn blocking_gateway() -> TestGateway {
+    TestGateway::from_spec(&fixture("waf.yaml"))
+        .await
+        .expect("failed to start gateway")
+}
+
+/// Assert a request was blocked as an RFC 9457 problem document, and return the
+/// id of the rule that blocked it.
+async fn assert_blocked(resp: reqwest::Response, expected_status: u16) -> u64 {
+    assert_eq!(
+        resp.status().as_u16(),
+        expected_status,
+        "expected the WAF to block with {expected_status}"
+    );
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        content_type.contains("application/problem+json"),
+        "block response must be a problem document, got content-type {content_type:?}"
+    );
+    let body: serde_json::Value = resp.json().await.expect("problem document must be JSON");
+    assert_eq!(body["type"], "urn:barbacane:error:waf-blocked");
+    assert_eq!(body["status"], expected_status);
+    body["rule_id"]
+        .as_u64()
+        .expect("dev mode must report the blocking rule id")
+}
+
+async fn metrics(gateway: &TestGateway) -> String {
+    let resp = gateway.admin_get("/metrics").await.unwrap();
+    assert_eq!(resp.status(), 200);
+    resp.text().await.unwrap()
+}
+
+/// Find the value of a metric sample whose line contains every fragment given.
+fn sample(body: &str, family: &str, fragments: &[&str]) -> Option<f64> {
+    body.lines()
+        .filter(|l| l.starts_with(family))
+        .find(|l| fragments.iter().all(|f| l.contains(f)))
+        .and_then(|l| l.rsplit(' ').next())
+        .and_then(|v| v.parse().ok())
+}
+
+// ---------------------------------------------------------------------------
+// Attack classes reach the rules and are refused
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sql_injection_in_a_query_argument_is_blocked() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .get("/waf/search?q=1'%20or%20'1'%3D'1")
+        .await
+        .unwrap();
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+}
+
+#[tokio::test]
+async fn cross_site_scripting_in_a_query_argument_is_blocked() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .get("/waf/search?q=%3Cscript%3Ealert(1)%3C%2Fscript%3E")
+        .await
+        .unwrap();
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+}
+
+#[tokio::test]
+async fn path_traversal_in_a_query_argument_is_blocked() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .get("/waf/search?file=..%2F..%2F..%2Fetc%2Fpasswd")
+        .await
+        .unwrap();
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+}
+
+#[tokio::test]
+async fn command_injection_in_a_query_argument_is_blocked() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .get("/waf/search?q=x%3B%20cat%20%2Fetc%2Fpasswd")
+        .await
+        .unwrap();
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+}
+
+#[tokio::test]
+async fn an_attack_in_a_json_body_is_blocked() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .post("/waf/submit", r#"{"comment":"1' or '1'='1"}"#)
+        .await
+        .unwrap();
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+}
+
+/// Exercises `@pmFromFile`: the phrase list is sealed into the artifact at
+/// compile time and loaded from it at boot, with no filesystem access at
+/// request time.
+#[tokio::test]
+async fn a_scanner_user_agent_from_a_sealed_phrase_list_is_blocked() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .request_builder(reqwest::Method::GET, "/waf/search?q=hello")
+        .header("user-agent", "sqlmap/1.7")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+}
+
+#[tokio::test]
+async fn a_benign_request_passes_through() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway.get("/waf/search?q=hello%20world").await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "ok");
+}
+
+#[tokio::test]
+async fn a_benign_json_body_passes_through() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .post("/waf/submit", r#"{"comment":"looks fine to me"}"#)
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+// ---------------------------------------------------------------------------
+// Header collection
+// ---------------------------------------------------------------------------
+
+/// A header value is a byte string, not UTF-8. Dropping the ones that fail to
+/// decode leaves an uninspected channel into the application, so values are
+/// converted lossily and still reach the rules.
+#[tokio::test]
+async fn a_header_value_with_invalid_utf8_is_still_inspected() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .request_builder(reqwest::Method::GET, "/waf/search?q=hello")
+        .header(
+            HeaderName::from_static("user-agent"),
+            HeaderValue::from_bytes(b"nikto\xff").unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+}
+
+/// Two headers with the same name are two values. Collapsing them to one loses
+/// whichever the rules needed, so both are collected.
+///
+/// The first value matches rule 1001610 and the second does not, so a
+/// last-value-wins collapse would score zero and let the request through.
+#[tokio::test]
+async fn every_value_of_a_repeated_header_is_inspected() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .request_builder(reqwest::Method::GET, "/waf/search?debug=1")
+        .header("x-trace", "on")
+        .header("x-trace", "off")
+        .send()
+        .await
+        .unwrap();
+    // 1001610 (+3) on the first value, 1001600 (+3) on `debug=1`, threshold 5.
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+}
+
+// ---------------------------------------------------------------------------
+// Anomaly scoring
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_score_below_the_threshold_is_recorded_and_allowed() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway.get("/waf/search?debug=1").await.unwrap();
+    assert_eq!(resp.status(), 200, "3 points is under the threshold of 5");
+
+    let body = metrics(&gateway).await;
+    assert_eq!(
+        sample(
+            &body,
+            "barbacane_waf_matched_total",
+            &["rule_id=\"1001600\"", "path=\"/waf/search\""]
+        ),
+        Some(1.0),
+        "a rule that matched without blocking must still be counted"
+    );
+    assert!(
+        sample(
+            &body,
+            "barbacane_waf_blocked_total",
+            &["path=\"/waf/search\""]
+        )
+        .is_none(),
+        "nothing was blocked"
+    );
+}
+
+#[tokio::test]
+async fn scores_accumulate_across_rules_until_the_threshold() {
+    let gateway = blocking_gateway().await;
+
+    // 3 points on its own: allowed.
+    let resp = gateway.get("/waf/search?debug=1").await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // The same argument plus a second 3-point rule: 6 points, refused.
+    let resp = gateway
+        .request_builder(reqwest::Method::GET, "/waf/search?debug=1")
+        .header("x-trace", "on")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+}
+
+/// A rule can deny with its own status. The problem document's title is
+/// derived from that status rather than assumed to be "Forbidden".
+#[tokio::test]
+async fn a_rule_status_other_than_403_shapes_the_problem_response() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .request_builder(reqwest::Method::GET, "/waf/search?q=hello")
+        .header("x-waf-fixture-status", "406")
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    assert_eq!(status, 406);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["title"], "Not Acceptable");
+    assert_eq!(body["status"], 406);
+    assert_eq!(body["rule_id"].as_u64(), Some(1_001_700));
+}
+
+// ---------------------------------------------------------------------------
+// Detection-only mode
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn detection_only_records_matches_without_blocking() {
+    let gateway = TestGateway::from_spec(&fixture("waf-detection-only.yaml"))
+        .await
+        .expect("failed to start gateway");
+
+    let resp = gateway
+        .get("/waf/search?q=1'%20or%20'1'%3D'1")
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "detection-only mode must not interrupt the request"
+    );
+
+    let body = metrics(&gateway).await;
+    assert_eq!(
+        sample(
+            &body,
+            "barbacane_waf_matched_total",
+            &["rule_id=\"1001100\"", "path=\"/waf/search\""]
+        ),
+        Some(1.0),
+        "the SQL injection rule must be reported even though nothing was blocked"
+    );
+    assert!(
+        sample(
+            &body,
+            "barbacane_waf_blocked_total",
+            &["path=\"/waf/search\""]
+        )
+        .is_none(),
+        "barbacane_waf_blocked_total must stay at zero in detection-only mode"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Metrics surface
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn blocking_a_request_counts_the_rule_that_did_it() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .get("/waf/search?q=1'%20or%20'1'%3D'1")
+        .await
+        .unwrap();
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+
+    let body = metrics(&gateway).await;
+    assert_eq!(
+        sample(
+            &body,
+            "barbacane_waf_blocked_total",
+            &["rule_id=\"1009110\"", "path=\"/waf/search\""]
+        ),
+        Some(1.0)
+    );
+    assert_eq!(
+        sample(
+            &body,
+            "barbacane_waf_matched_total",
+            &["rule_id=\"1001100\"", "path=\"/waf/search\""]
+        ),
+        Some(1.0),
+        "the scoring rule that contributed must be counted, not only the blocking rule"
+    );
+}
+
+#[tokio::test]
+async fn an_allowed_request_is_counted_and_timed() {
+    let gateway = blocking_gateway().await;
+    assert_eq!(
+        gateway.get("/waf/search?q=hello").await.unwrap().status(),
+        200
+    );
+
+    let body = metrics(&gateway).await;
+    assert_eq!(
+        sample(
+            &body,
+            "barbacane_waf_allowed_total",
+            &["path=\"/waf/search\"", "method=\"GET\""]
+        ),
+        Some(1.0)
+    );
+    assert_eq!(
+        sample(
+            &body,
+            "barbacane_waf_duration_seconds_count",
+            &["path=\"/waf/search\""]
+        ),
+        Some(1.0),
+        "inspection latency must be observed for every inspected request"
+    );
+}
+
+#[tokio::test]
+async fn a_spec_without_the_waf_extension_exports_no_waf_samples() {
+    let gateway = TestGateway::from_spec(&fixture("mock.yaml"))
+        .await
+        .expect("failed to start gateway");
+    let _ = gateway.get("/mock/ok").await.unwrap();
+
+    let body = metrics(&gateway).await;
+    assert!(
+        sample(&body, "barbacane_waf_allowed_total", &["path="]).is_none(),
+        "no rule set is configured, so nothing should be inspected"
+    );
+    assert!(
+        sample(&body, "barbacane_waf_duration_seconds_count", &["path="]).is_none(),
+        "no rule set is configured, so nothing should be timed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Paranoia level
+// ---------------------------------------------------------------------------
+
+/// CRS gates whole rule files on `tx.blocking_paranoia_level`, and an unset
+/// variable reads as zero, so the level the spec declares has to reach the
+/// engine. The same rule set produces different verdicts at the two levels.
+#[tokio::test]
+async fn a_higher_paranoia_rule_does_not_fire_at_level_one() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway.get("/waf/search?q=paranoid").await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn a_higher_paranoia_rule_fires_at_level_two() {
+    let gateway = TestGateway::from_spec(&fixture("waf-paranoia-2.yaml"))
+        .await
+        .expect("failed to start gateway");
+    let resp = gateway.get("/waf/search?q=paranoid").await.unwrap();
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+}

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -1405,6 +1405,8 @@ impl Gateway {
                             message = %message,
                             "WAF blocked request"
                         );
+                        self.metrics
+                            .record_waf_blocked(&method_str, &route_path, rule_id);
                         self.metrics.record_validation_failure(
                             &method_str,
                             &route_path,

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -135,15 +135,21 @@ make coverage-integration
 make coverage-html
 ```
 
-`make coverage-integration` measures the gateway process too. The test harness
-resolves the binary through `CARGO_TARGET_DIR`, which `cargo llvm-cov`
-redirects, so the instrumented build is the one that runs. Set
-`BARBACANE_TEST_BINARY` to point the harness at a specific binary instead.
+`make coverage-integration` measures the gateway process too. `cargo llvm-cov
+show-env` puts the instrumented build under `CARGO_TARGET_DIR`, and the test
+harness resolves the gateway binary from there, so the process the tests drive
+is the instrumented one. Set `BARBACANE_TEST_BINARY` to point the harness at a
+specific binary instead.
 
-CI runs the same combined measurement in the **Coverage** job, publishes the
-summary to the run page, uploads `lcov.info` as an artifact, and fails if line
-coverage drops below `COVERAGE_FLOOR`. Raise that floor when the real number
-rises; do not lower it to turn a red build green.
+The targets wrap `scripts/coverage.sh`, which CI calls directly in the
+**Coverage** job, so local and CI runs measure the same thing. The job
+publishes the summary to the run page, uploads `lcov.info` as an artifact and
+fails if line coverage drops below the floor. Raise that floor when the real
+number rises; do not lower it to turn a red build green.
+
+```bash
+./scripts/coverage.sh --help
+```
 
 ### Run
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -53,6 +53,10 @@ Then open http://localhost:5173 in your browser.
 | `make compile` | Compile spec to artifact.bca |
 | `make seed-plugins` | Build plugins and seed registry |
 | `make clean` | Clean all build artifacts |
+| `make coverage` | Line coverage of the unit tests |
+| `make coverage-integration` | Coverage including the integration suite |
+| `make coverage-html` | Coverage as a browsable HTML report |
+| `make coverage-lcov` | Coverage as `lcov.info` |
 | **Development** | |
 | `make control-plane` | Start control plane server (port 9090) |
 | `make ui` | Start UI dev server (port 5173) |
@@ -110,6 +114,36 @@ cargo test --workspace -- --nocapture
 # Run a specific test (routing trie lives in the barbacane crate)
 cargo test -p barbacane router::trie::tests::static_takes_precedence_over_param
 ```
+
+### Coverage
+
+Coverage uses [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov),
+which instruments the build rather than sampling, so a line is covered only if
+it actually executed.
+
+```bash
+cargo install cargo-llvm-cov
+rustup component add llvm-tools-preview
+
+# Unit tests only: fast, needs no services
+make coverage
+
+# Adds the integration suite, which boots the gateway as a child process
+make coverage-integration
+
+# Browsable report at target/llvm-cov/html/index.html
+make coverage-html
+```
+
+`make coverage-integration` measures the gateway process too. The test harness
+resolves the binary through `CARGO_TARGET_DIR`, which `cargo llvm-cov`
+redirects, so the instrumented build is the one that runs. Set
+`BARBACANE_TEST_BINARY` to point the harness at a specific binary instead.
+
+CI runs the same combined measurement in the **Coverage** job, publishes the
+summary to the run page, uploads `lcov.info` as an artifact, and fails if line
+coverage drops below `COVERAGE_FLOOR`. Raise that floor when the real number
+rises; do not lower it to turn a red build green.
 
 ### Run
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -144,8 +144,8 @@ specific binary instead.
 The targets wrap `scripts/coverage.sh`, which CI calls directly in the
 **Coverage** job, so local and CI runs measure the same thing. The job
 publishes the summary to the run page, uploads `lcov.info` as an artifact and
-fails if line coverage drops below the floor. Raise that floor when the real
-number rises; do not lower it to turn a red build green.
+fails if line coverage drops below the floor, currently 60%. Raise that floor
+when the real number rises; do not lower it to turn a red build green.
 
 ```bash
 ./scripts/coverage.sh --help

--- a/docs/guide/waf.md
+++ b/docs/guide/waf.md
@@ -113,7 +113,7 @@ thing, and it is the single most common reason a WAF gets turned off again.
 
 ## Observing it
 
-Three metrics on the admin endpoint:
+Four metrics on the admin endpoint:
 
 | Metric | Meaning |
 |---|---|
@@ -121,6 +121,13 @@ Three metrics on the admin endpoint:
 | `barbacane_waf_blocked_total{method,path,rule_id}` | Requests actually interrupted, by the rule that did it. Zero in detection-only mode. |
 | `barbacane_waf_allowed_total{method,path}` | Requests inspected and allowed. With the above, the block rate. |
 | `barbacane_waf_duration_seconds{method,path}` | Time spent inspecting, so the WAF's share of latency is visible rather than inferred. |
+
+`barbacane_waf_matched_total` counts every rule that matched, including the
+control-flow rules CRS uses to gate paranoia levels. Those are `pass,nolog`
+rules whose only job is to skip a block of higher-paranoia rules, and they
+match on most requests, so they dominate the counter by volume. Filter them out
+when reading the tuning signal: the rule ids that matter are the ones that
+carry a score.
 
 A blocked request is logged at WARN with the rule id, the accumulated anomaly
 score and the rule's message, and answers `403` with an RFC 9457 body. The rule

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -61,6 +61,18 @@ done < <(
     | grep -vx security | sort
 )
 
+# The fixture plugins target wasm32-unknown-unknown, which cannot carry
+# coverage instrumentation, so they are built before the instrumented
+# environment exists. barbacane-test's build.rs skips any that are already
+# present.
+if [[ "$unit_only" -eq 0 ]]; then
+  for plugin in tests/fixture-plugins/*/; do
+    [[ -f "$plugin/Cargo.toml" ]] || continue
+    echo "Building fixture plugin: $(basename "$plugin")"
+    (cd "$plugin" && cargo build --target wasm32-unknown-unknown --release)
+  done
+fi
+
 # shellcheck disable=SC1090
 source <(cargo llvm-cov show-env --export-prefix)
 cargo llvm-cov clean --workspace

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Line coverage via cargo-llvm-cov (source-based LLVM instrumentation).
+#
+# Run from repo root: ./scripts/coverage.sh [--unit] [--html] [--lcov PATH]
+#                                           [--summary PATH] [--floor N]
+#
+# Options:
+#   --unit          Unit and bin tests only; skip the integration suite
+#   --html          Also write a browsable report to target/llvm-cov/html
+#   --lcov PATH     Also write lcov output to PATH
+#   --summary PATH  Copy the summary table to PATH as well as stdout
+#   --floor N       Fail if line coverage is below N percent
+#
+# The integration suite drives the gateway as a child process. `show-env` puts
+# the instrumented build under CARGO_TARGET_DIR and the test harness resolves
+# the binary from there, so the process that runs is the instrumented one and
+# the request pipeline is measured. Requires the WASM plugins (`make plugins`).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+unit_only=0
+want_html=0
+lcov_path=""
+summary_path=""
+floor=""
+
+usage() {
+ sed -n '2,17p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --unit) unit_only=1; shift ;;
+    --html) want_html=1; shift ;;
+    --lcov) lcov_path="$2"; shift 2 ;;
+    --summary) summary_path="$2"; shift 2 ;;
+    --floor) floor="$2"; shift 2 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! cargo llvm-cov --version >/dev/null 2>&1; then
+  echo "cargo-llvm-cov is not installed. Install it with:" >&2
+  echo "  cargo install cargo-llvm-cov" >&2
+  echo "  rustup component add llvm-tools-preview" >&2
+  exit 1
+fi
+
+# Integration targets are discovered so a new suite is measured automatically.
+# `security` is excluded: it needs PostgreSQL and the control-plane binary.
+suites=()
+targets=()
+while IFS= read -r suite; do
+  suites+=("$suite")
+  targets+=(--test "$suite")
+done < <(
+  find crates/barbacane-test/tests -maxdepth 1 -name '*.rs' -exec basename {} .rs \; \
+    | grep -vx security | sort
+)
+
+# shellcheck disable=SC1090
+source <(cargo llvm-cov show-env --export-prefix)
+cargo llvm-cov clean --workspace
+
+cargo test --workspace --lib --bins --exclude barbacane-test
+
+if [[ "$unit_only" -eq 0 ]]; then
+  # Build every binary instrumented before the suite runs. The CLI tests and
+  # the gateway harness both invoke `barbacane` as a subprocess, and
+  # `cargo test` alone builds bin targets only as test harnesses, leaving no
+  # such executable for them to find.
+  cargo build --workspace --all-targets
+
+  echo "Integration targets: ${suites[*]}"
+  cargo test -p barbacane-test --lib "${targets[@]}" --no-fail-fast -- --test-threads=2
+fi
+
+if [[ -n "$lcov_path" ]]; then
+  cargo llvm-cov report --lcov --output-path "$lcov_path"
+fi
+
+if [[ "$want_html" -eq 1 ]]; then
+  cargo llvm-cov report --html
+  echo "Report: target/llvm-cov/html/index.html"
+fi
+
+if [[ -n "$summary_path" ]]; then
+  cargo llvm-cov report --summary-only | tee "$summary_path"
+else
+  cargo llvm-cov report --summary-only
+fi
+
+if [[ -n "$floor" ]]; then
+  cargo llvm-cov report --fail-under-lines "$floor"
+fi

--- a/tests/fixtures/waf-detection-only.yaml
+++ b/tests/fixtures/waf-detection-only.yaml
@@ -1,0 +1,81 @@
+openapi: "3.0.3"
+info:
+  title: WAF Detection-Only Test API
+  version: "1.0.0"
+  description: API for testing the WAF pipeline stage in detection-only mode
+
+x-barbacane-waf:
+  ruleset: ./waf-rules
+  paranoia_level: 1
+  mode: detection-only
+  thresholds:
+    inbound: 5
+    outbound: 4
+
+paths:
+  /waf/search:
+    get:
+      summary: Free-form query parameters the rule set inspects
+      operationId: wafSearch
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: file
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: debug
+          in: query
+          required: false
+          schema:
+            type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"status": "ok"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+
+  /waf/submit:
+    post:
+      summary: JSON body the rule set inspects as phase 2 arguments
+      operationId: wafSubmit
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                comment:
+                  type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"status": "accepted"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string

--- a/tests/fixtures/waf-paranoia-2.yaml
+++ b/tests/fixtures/waf-paranoia-2.yaml
@@ -1,0 +1,81 @@
+openapi: "3.0.3"
+info:
+  title: WAF Paranoia Level 2 Test API
+  version: "1.0.0"
+  description: API for testing the WAF pipeline stage at paranoia level 2
+
+x-barbacane-waf:
+  ruleset: ./waf-rules
+  paranoia_level: 2
+  mode: blocking
+  thresholds:
+    inbound: 5
+    outbound: 4
+
+paths:
+  /waf/search:
+    get:
+      summary: Free-form query parameters the rule set inspects
+      operationId: wafSearch
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: file
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: debug
+          in: query
+          required: false
+          schema:
+            type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"status": "ok"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+
+  /waf/submit:
+    post:
+      summary: JSON body the rule set inspects as phase 2 arguments
+      operationId: wafSubmit
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                comment:
+                  type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"status": "accepted"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string

--- a/tests/fixtures/waf-rules/010-request-rules.conf
+++ b/tests/fixtures/waf-rules/010-request-rules.conf
@@ -1,0 +1,100 @@
+# Scoring rules. Each adds to tx.inbound_anomaly_score and passes; rule
+# 1009110 in 020-blocking.conf makes the blocking decision on the total.
+
+SecRule ARGS "@rx (?:\bor\b\s+\d+\s*=\s*\d+|union\s+select|'\s*or\s*'1'\s*=\s*'1|;\s*drop\s+table)" \
+    "id:1001100,\
+    phase:2,\
+    pass,\
+    t:none,t:urlDecodeUni,t:lowercase,\
+    msg:'SQL injection attempt',\
+    logdata:'Matched %{MATCHED_VAR_NAME}',\
+    tag:'fixture/sqli',\
+    setvar:'tx.blocking_inbound_anomaly_score=+5'"
+
+SecRule ARGS|REQUEST_HEADERS "@rx (?:<script|javascript:|onerror\s*=|<img[^>]+src)" \
+    "id:1001200,\
+    phase:2,\
+    pass,\
+    t:none,t:urlDecodeUni,t:htmlEntityDecode,t:lowercase,\
+    msg:'Cross-site scripting attempt',\
+    tag:'fixture/xss',\
+    setvar:'tx.blocking_inbound_anomaly_score=+5'"
+
+SecRule ARGS|REQUEST_URI "@rx (?:\.\./|/etc/passwd|/proc/self/environ)" \
+    "id:1001300,\
+    phase:2,\
+    pass,\
+    t:none,t:urlDecodeUni,t:lowercase,\
+    msg:'Path traversal attempt',\
+    tag:'fixture/lfi',\
+    setvar:'tx.blocking_inbound_anomaly_score=+5'"
+
+SecRule ARGS "@rx (?:[;|&]|\$\()\s*(?:cat|wget|curl|nc|bash|sh|id)\b" \
+    "id:1001400,\
+    phase:2,\
+    pass,\
+    t:none,t:urlDecodeUni,t:lowercase,\
+    msg:'Command injection attempt',\
+    tag:'fixture/rce',\
+    setvar:'tx.blocking_inbound_anomaly_score=+5'"
+
+# Reads a sealed @pmFromFile phrase list. The path is relative to this file and
+# the compiler seals the referenced .data file into the artifact.
+SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
+    "id:1001500,\
+    phase:1,\
+    pass,\
+    t:none,t:lowercase,\
+    msg:'Security scanner user agent',\
+    tag:'fixture/scanner',\
+    setvar:'tx.blocking_inbound_anomaly_score=+5'"
+
+# Below the threshold on its own. Two of these together cross it.
+SecRule ARGS:debug "@streq 1" \
+    "id:1001600,\
+    phase:2,\
+    pass,\
+    t:none,\
+    msg:'Debug argument present',\
+    tag:'fixture/notice',\
+    setvar:'tx.blocking_inbound_anomaly_score=+3'"
+
+SecRule REQUEST_HEADERS:X-Trace "@streq on" \
+    "id:1001610,\
+    phase:1,\
+    pass,\
+    t:none,t:lowercase,\
+    msg:'Trace header present',\
+    tag:'fixture/notice',\
+    setvar:'tx.blocking_inbound_anomaly_score=+3'"
+
+# Denies with a status other than 403, so the RFC 9457 title is derived from
+# the rule's status rather than assumed.
+SecRule REQUEST_HEADERS:X-Waf-Fixture-Status "@streq 406" \
+    "id:1001700,\
+    phase:1,\
+    deny,status:406,\
+    t:none,\
+    msg:'Fixture rule denying with a non-default status',\
+    tag:'fixture/status'"
+
+# Paranoia gate. CRS gates whole rule files this way, so the fixture proves the
+# level the spec declares reaches the engine. Everything between the skip and
+# the marker runs only at paranoia level 2 or above.
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@lt 2" \
+    "id:1001800,\
+    phase:2,\
+    pass,nolog,\
+    t:none,\
+    skipAfter:END-FIXTURE-PL2"
+
+SecRule ARGS "@rx paranoid" \
+    "id:1001810,\
+    phase:2,\
+    pass,\
+    t:none,t:lowercase,\
+    msg:'Paranoia level 2 rule',\
+    tag:'fixture/pl2',\
+    setvar:'tx.blocking_inbound_anomaly_score=+5'"
+
+SecMarker END-FIXTURE-PL2

--- a/tests/fixtures/waf-rules/020-blocking.conf
+++ b/tests/fixtures/waf-rules/020-blocking.conf
@@ -1,0 +1,11 @@
+# Mirrors the role of CRS 949110: the scoring rules above only accumulate, and
+# this is the rule that refuses the request once the total reaches the
+# inbound threshold the spec declares.
+
+SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
+    "id:1009110,\
+    phase:2,\
+    deny,status:403,\
+    t:none,\
+    msg:'Inbound Anomaly Score Exceeded (Total Score: %{TX.BLOCKING_INBOUND_ANOMALY_SCORE})',\
+    tag:'fixture/anomaly'"

--- a/tests/fixtures/waf-rules/README.md
+++ b/tests/fixtures/waf-rules/README.md
@@ -1,0 +1,31 @@
+# WAF integration test rule set
+
+A compact SecLang rule set in OWASP CRS idiom, used by
+`crates/barbacane-test/tests/waf.rs` to exercise the gateway's WAF stage:
+config parsing, compile-time sealing, `@pmFromFile` data loading, header and
+body collection, anomaly-score accumulation and the block response.
+
+It is not CRS and is not a detection benchmark. CRS conformance is measured by
+parapet's go-ftw suite. Rule ids live in the `10011xx`-`10018xx` range so they
+cannot be confused with real CRS rules, and the blocking rule `1009110`
+mirrors the role of CRS `949110`. Scores accumulate in
+`tx.blocking_inbound_anomaly_score`, as they do in CRS 4.
+
+Scores are tuned to the `inbound: 5` threshold the fixture specs declare:
+
+| Rule    | Class                    | Score |
+|---------|--------------------------|-------|
+| 1001100 | SQL injection            | 5     |
+| 1001200 | Cross-site scripting     | 5     |
+| 1001300 | Path traversal / LFI     | 5     |
+| 1001400 | Command injection        | 5     |
+| 1001500 | Scanner user agent       | 5     |
+| 1001600 | `debug` argument         | 3     |
+| 1001610 | `X-Trace` header         | 3     |
+| 1001810 | Paranoia level 2 only    | 5     |
+
+Rule `1001700` denies directly with `status:406` instead of scoring, and
+`1001800` skips to `END-FIXTURE-PL2` below paranoia level 2.
+
+The two 3-point rules are individually below the threshold, so either alone is
+recorded and allowed and both together block.

--- a/tests/fixtures/waf-rules/scanners-user-agents.data
+++ b/tests/fixtures/waf-rules/scanners-user-agents.data
@@ -1,0 +1,6 @@
+# Phrase list for rule 1001500. One phrase per line, # comments ignored.
+nikto
+sqlmap
+nmap scripting engine
+dirbuster
+masscan

--- a/tests/fixtures/waf.yaml
+++ b/tests/fixtures/waf.yaml
@@ -1,0 +1,81 @@
+openapi: "3.0.3"
+info:
+  title: WAF Test API
+  version: "1.0.0"
+  description: API for testing the WAF pipeline stage in blocking mode
+
+x-barbacane-waf:
+  ruleset: ./waf-rules
+  paranoia_level: 1
+  mode: blocking
+  thresholds:
+    inbound: 5
+    outbound: 4
+
+paths:
+  /waf/search:
+    get:
+      summary: Free-form query parameters the rule set inspects
+      operationId: wafSearch
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: file
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: debug
+          in: query
+          required: false
+          schema:
+            type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"status": "ok"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+
+  /waf/submit:
+    post:
+      summary: JSON body the rule set inspects as phase 2 arguments
+      operationId: wafSubmit
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                comment:
+                  type: string
+      x-barbacane-dispatch:
+        name: mock
+        config:
+          status: 200
+          body: '{"status": "accepted"}'
+          content_type: application/json
+      responses:
+        "200":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string


### PR DESCRIPTION
## Why

The WAF stage merged in #140 had 29 unit tests over the engine sealing and integrity paths and **zero** integration tests. Every comparable feature has a file in `crates/barbacane-test/tests/`; the WAF did not. The end-to-end verification behind that merge was a manual curl session that existed nowhere in CI.

That gap sat exactly where the feature's one real security defect had been: header collection dropped values that were not UTF-8 and collapsed repeated names, leaving an uninspected channel into the application. That code runs *before* the unit tests' entry point, so no unit test could have caught it and none can now.

Separately, the repo had no coverage tooling, so there was no number to quote for any of this.

## What

**A bug the tests found.** `barbacane_waf_blocked_total` was registered and documented but never incremented. The guide describes it as "requests actually interrupted, by the rule that did it" and tells operators it distinguishes detection-only from blocking. Both claims were false until the assertion on it had nothing to find.

**`crates/barbacane-test/tests/waf.rs`**, 16 tests over three fixture specs sharing one rule set:

| Area | Covered |
|---|---|
| Attack classes | SQLi, XSS, path traversal, command injection, scanner UA, in query args and in a JSON body |
| Benign traffic | Query and JSON body pass through untouched |
| Header collection | An invalid UTF-8 byte is still inspected; every value of a repeated header is inspected |
| Anomaly scoring | Scores accumulate to the threshold; a score below it is recorded and allowed |
| Block response | RFC 9457 shape, and `status:406` yields a title of "Not Acceptable" rather than "Forbidden" |
| Detection-only | Records matches, blocks nothing |
| Paranoia level | The same rule set refuses at level 2 what it allows at level 1 |
| Metrics | All four families carry the samples the guide promises; a spec without the extension produces none |

The repeated-header test is ordered so a last-value-wins collapse would score zero and let the request through, so it fails if that regression returns.

`tests/fixtures/waf-rules` is a compact rule set in CRS 4 idiom, not CRS: scoring rules accumulate into `tx.blocking_inbound_anomaly_score` and `1009110` mirrors the role of `949110`. It exercises `@pmFromFile`, so the sealed phrase list is loaded from the artifact at boot on a real request path. Rule ids are in a range that cannot collide with real CRS ids. Detection quality stays parapet's go-ftw suite's job (94.4%, ratcheted); these tests are about the wiring.

CI discovers integration targets rather than listing them, so no workflow change was needed for the suite.

**Coverage tooling.** `cargo-llvm-cov`, which instruments the build rather than sampling. `make coverage` (unit only), `make coverage-integration` (adds the integration suite), `make coverage-html`, `make coverage-lcov`, plus a **Coverage** CI job that runs the combined measurement, publishes the summary to the run page, uploads `lcov.info` and enforces a floor.

Including the integration suite required one harness change: it now resolves the gateway binary through `CARGO_TARGET_DIR` before the fixed `./target` candidates, because `cargo llvm-cov` redirects that variable. Without it the harness would run a stale uninstrumented binary from `./target` and report the whole request pipeline as untested.

## Verification

The fixture rule set was validated against parapet directly before wiring it up: all 14 payload cases produce the intended verdict and score, and the paranoia gate flips exactly one case between level 1 and level 2.

## The number

The first green Coverage run measured **61.17% line coverage** across the workspace (25,005 lines, 9,709 uncovered); regions 62.08%, functions 57.48%. The floor is set to **60**, just under the measurement, so ordinary variation does not fail a build and the ratchet starts from a measurement rather than a guess.

The per-file picture matters more than the total:

| File | Lines covered | % |
|---|---|---|
| `barbacane-compiler/src/artifact.rs` | 2844/3010 | 94.49% |
| `barbacane/src/waf.rs` | 179/215 | 83.26% |
| `barbacane-telemetry/src/metrics.rs` | 307/441 | 69.61% |
| `barbacane/src/main.rs` | 993/3624 | **27.40%** |

The sealing and integrity path is genuinely well covered. `waf.rs` sits at 83%, the uncovered remainder being mostly `inspect_response`, which is implemented and unit-tested but not yet wired into the pipeline. `main.rs` at 27% is the honest headline and is where the WAF glue lives: this suite lifted it, but 2,631 of its 3,624 lines are still unexercised. That is the file's general state rather than anything WAF-specific, and it is why the header bypass survived two review passes.

## Two CI fixes the Coverage job forced out

Neither is coverage-specific.

1. **`barbacane-test`'s `build.rs` swallowed its child's diagnostics.** It shells out to `cargo build --target wasm32-unknown-unknown` for the fixture plugins and reported only an exit code on failure, so a broken fixture build surfaced 25 minutes later as tests panicking on a missing `.wasm`. It now relays the child's stderr through `cargo:warning`.
2. **The nested fixture build inherited the outer build's flags and target directory.** Those crates target a different architecture and keep their own target directories, so inheriting `RUSTFLAGS`, `CARGO_TARGET_DIR` and friends was wrong regardless of what the outer build was doing.

The fixture plugins are now built before the instrumented environment exists, which is what actually made the job pass; clearing the environment alone did not. I did not establish the root cause of the wasm32 build's exit 101 under instrumentation, and the improved diagnostics exist so a recurrence names itself.

## Review note

Two CodeRabbit findings, both on the new CI job. The `taiki-e/install-action` pin is applied: it used a mutable per-tool tag, while every other third-party action in this repo is SHA-pinned and only first-party `actions/*` use version tags, so the finding matched the repo's own convention. `persist-credentials: false` is **not** applied: the finding is legitimate but no workflow here sets it on any job, so applying it to one job would be an inconsistency rather than a fix. Worth a separate pass across all workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated `waf_blocked` metric for requests rejected by the Web Application Firewall.
  - Added coverage reporting for unit and integration tests, including LCOV and HTML outputs, with configurable coverage thresholds.

- **Documentation**
  - Documented coverage commands and CI reporting workflows.
  - Clarified WAF metrics, including control-flow rule matches and recommended filtering for tuning.

- **Tests**
  - Expanded WAF integration coverage for blocking, detection-only mode, anomaly scoring, headers, metrics, and paranoia levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
