### PR TITLE
chore: harden the workflows and audit them in CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       ui: ${{ steps.filter.outputs.ui }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         with:
@@ -54,6 +56,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -70,6 +74,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -102,6 +108,26 @@ jobs:
           -A clippy::panic
 
   # Verify the workspace builds on the declared MSRV (workspace.package.rust-version).
+  # Static analysis of the workflows themselves. Runs on every push: a workflow
+  # change cannot be gated on a paths filter that lives in a workflow file.
+  # .github/zizmor.yml carries the action-pinning policy and the gate is
+  # medium and above, so informational findings stay visible without failing.
+  workflows:
+    name: Workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        run: pipx install zizmor==1.30.1
+
+      - name: Audit workflows
+        run: zizmor --config .github/zizmor.yml --min-severity=medium .github/workflows/
+
   msrv:
     name: MSRV
     runs-on: ubuntu-latest
@@ -109,6 +135,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install MSRV Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -139,6 +167,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
@@ -154,6 +184,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -204,6 +236,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -247,6 +281,8 @@ jobs:
       DATABASE_URL: postgres://barbacane:barbacane@localhost:5432/barbacane
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -273,6 +309,8 @@ jobs:
     if: needs.changes.outputs.plugins == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -309,6 +347,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -365,6 +405,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -454,6 +496,8 @@ jobs:
       DATABASE_URL: postgres://barbacane:barbacane@localhost:5432/barbacane
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -503,6 +547,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           # For issue_comment events, check out the PR head
           ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
 
@@ -607,6 +652,8 @@ jobs:
         working-directory: ui
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -635,6 +682,8 @@ jobs:
         working-directory: ui
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,10 +10,10 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
+# Only the deploy job needs the Pages and OIDC tokens; the build job runs
+# mdbook over repository content and needs nothing but the checkout.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -22,9 +22,13 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2
@@ -52,6 +56,9 @@ jobs:
           path: './book'
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: tag
@@ -44,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: tag
@@ -90,6 +94,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -148,6 +154,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: tag
@@ -314,7 +322,11 @@ jobs:
     uses: ./.github/workflows/sign-and-sbom.yml
     with:
       version: ${{ github.ref_name }}
-    secrets: inherit
+    # Only the registry credentials it declares. GITHUB_TOKEN is provided to
+    # called workflows automatically and does not need passing.
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   # Security scan the multi-arch images
   scan-containers:
@@ -327,6 +339,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: tag
@@ -392,6 +406,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -476,22 +492,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Cache cargo registry
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-plugins-${{ hashFiles('plugins/**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-plugins-
-
+      # No dependency cache. These plugins ship as release artifacts and are
+      # signed, so their only inputs are the checked-out sources and the
+      # lockfiles, not a cache another workflow can write to.
       - name: Build all plugins
         run: |
           mkdir -p dist/plugins
@@ -541,6 +552,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: tag

--- a/.github/workflows/sign-and-sbom.yml
+++ b/.github/workflows/sign-and-sbom.yml
@@ -16,6 +16,11 @@ on:
         description: "Version to sign (with or without a leading v)"
         required: true
         type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       version:
@@ -64,9 +69,10 @@ jobs:
           IMAGE: ${{ matrix.image }}
           OWNER: ${{ github.repository_owner }}
           COSIGN_YES: "true"
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          VERSION="${{ inputs.version }}"
+          VERSION="${INPUT_VERSION}"
           VERSION="${VERSION#v}"   # tolerate a leading v
 
           for ref in "ghcr.io/${OWNER}/${IMAGE}" "docker.io/barbacane/${IMAGE}"; do

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor configuration. See https://docs.zizmor.sh/configuration/
+
+rules:
+  unpinned-uses:
+    config:
+      # Third-party actions are pinned to a full commit; a tag they control is
+      # a tag they can move. Actions published by GitHub itself are pinned to a
+      # major version, so security fixes arrive without a commit bump.
+      policies:
+        actions/*: ref-pin
+        github/*: ref-pin
+        dtolnay/rust-toolchain: ref-pin
+        "*": hash-pin

--- a/docs/guide/waf.md
+++ b/docs/guide/waf.md
@@ -27,6 +27,12 @@ x-barbacane-waf:
   unsupported_rules: fail      # fail (default) | skip
 ```
 
+`thresholds.outbound` has no effect yet. The rule that reads it is a
+response-phase rule, and response phases are not evaluated (see
+[Current limitations](#current-limitations)). It is still covered by
+`artifact_hash`, so changing it changes the artifact without changing how any
+request is handled.
+
 `ruleset` is resolved relative to the spec. Point it at a directory containing
 the `.conf` files and, for CRS, the setup file:
 
@@ -83,7 +89,8 @@ CRS runs without them. Regex-based SQLi and XSS rules still fire, so a
 
 **Response-phase rules are not evaluated.** A CRS artifact carries around 152
 rules in phases 3 to 5, mostly outbound data-leakage detection, and they are
-present in the artifact but not run. Request-phase rules, around 439 of them,
+present in the artifact but not run. This is also why `thresholds.outbound` is
+inert: the rule that compares against it runs in phase 4. Request-phase rules, around 439 of them,
 are enforced. The gateway warns about this at startup. Outbound inspection is
 implemented in the engine but not yet wired into the response path, which has
 several exits and one unresolved question: a streamed response has already


### PR DESCRIPTION
## Why

CodeRabbit flagged a missing `persist-credentials: false` on the coverage job in #143. Looking into it, the more useful finding was that **this repo has no workflow linter** — no zizmor, no actionlint — which is why 25 checkout steps went unreviewed. So this adds the linter and fixes what it reports.

Running zizmor for the first time gave 170 findings. Most were a blanket policy disagreement; five were real.

## The linter

A **Workflows** job on every push (a workflow change cannot be gated on a paths filter that lives in a workflow file), running zizmor pinned to 1.30.1, gated at **medium severity and above**. Takes seconds.

`.github/zizmor.yml` records the pinning policy this repo already follows: hash-pin third-party actions, ref-pin the ones GitHub publishes. Without it zizmor reports 71 `unpinned-uses` findings against a deliberate convention, which would have made the job useless.

## What it found, and what I did

| Finding | Severity | Action |
|---|---|---|
| `persist-credentials` on 25 checkouts | — | Fixed |
| `docs.yml`: `pages: write` + `id-token: write` at workflow level | High ×2 | Fixed: moved to the `deploy` job |
| `sign-and-sbom.yml`: `inputs.version` spliced into a `run` block | High | Fixed: passed through `env` |
| `release.yml`: `secrets: inherit` into the reusable workflow | Medium | Fixed: passes the two registry secrets it declares |
| `release.yml`: cache poisoning in `build-plugins` | High (low confidence) | Fixed: cache removed |
| `template-injection` on tag-derived values | Informational ×29 | **Not fixed** — see below |
| `self-repository`, `superfluous-actions`, `use-trusted-publishing` | Low/Info ×3 | Not fixed |

**Credentials.** No workflow runs `git push`, `git commit` or `git tag`, and the only `GITHUB_TOKEN` uses are `password:` inputs to `docker/login-action`, so nothing needs the token left in `.git/config` where any dependency build script or test can read it. The repo is **public** and CI's token is `contents: read`, so this matters most in `release.yml` (`packages: write`, and `contents: write` on `create-release`) and `docs.yml` (`pages: write`, `id-token: write`). CodeRabbit flagged the least important instance; the ones that matter are in the workflows it didn't look at.

**The release cache.** `build-plugins` restored `~/.cargo/registry` and `~/.cargo/git` while producing signed release artifacts. Since this repo does keyless cosign signing and SBOM attestation, artifact inputs should be the checked-out sources and lockfiles alone, not a cache another workflow can write to. I removed the cache rather than suppressing the finding: zizmor's suggested `lookup-only: true` would defeat the cache's purpose, and a line-number ignore breaks silently when the file shifts. A release runs on a `v*` tag, so the rebuild cost is rare. **This is a behaviour change to the release path** and the one item here worth a second opinion.

## What I deliberately left

The 29 informational `template-injection` findings are `${{ github.repository_owner }}` and tag-derived values (`steps.tag.outputs.version` and friends) spliced into `run` blocks in `release.yml`. They are informational because creating a `v*` tag requires write access, so the values are maintainer-controlled today. Worth noting though: `validate-version` only strips the `refs/tags/v` prefix and compares against `Cargo.toml`, it does not validate the tag's *format*, and the comparison itself is a `${{ }}` splice into a shell condition. That becomes a real vulnerability the moment tag creation is delegated to a bot or a wider group. It is a mechanical sweep across `release.yml` and it did not belong in this PR.

## Also here

Documents that `x-barbacane-waf`'s `thresholds.outbound` cannot take effect: the rule that compares against it is a phase 4 rule, and response phases are not evaluated. It is folded into `artifact_hash`, so changing it changes the artifact without changing how any request is handled. Same class as the `barbacane_waf_blocked_total` bug in #143 — a knob that reads as functional and isn't.

## Verification

zizmor run locally against the final state: **no findings at medium and above** (32 ignored by the pinning policy, 62 suppressed). All five workflow files and the config parse as valid YAML. The `persist-credentials` change was verified programmatically to be purely additive: every one of the 25 checkout steps has it, and no line was removed from any workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved GitHub Actions credential handling and permission scoping.
  - Added automated workflow security checks and stricter validation of action references.
  - Limited release signing workflows to explicitly provided credentials.

- **Documentation**
  - Clarified that the WAF’s `thresholds.outbound` setting currently has no effect because response-phase rules are not evaluated.
  - Documented that the value remains included in artifact hashing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->