### PR TITLE
WAF: enable @detectSQLi/@detectXSS via parapet libinjection integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,6 +2377,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libinjectionrs"
+version = "0.1.1"
+source = "git+https://github.com/barbacane-dev/libinjectionrs?rev=7f35f8097e9dd06005334a0c8f50661ce544a8df#7f35f8097e9dd06005334a0c8f50661ce544a8df"
+dependencies = [
+ "bitflags 2.11.0",
+ "serde_json",
+ "smallvec",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,9 +2896,10 @@ dependencies = [
 [[package]]
 name = "parapet"
 version = "0.0.0"
-source = "git+https://github.com/barbacane-dev/parapet?rev=a9218569f57219b897c87416c7a9240f228aca01#a9218569f57219b897c87416c7a9240f228aca01"
+source = "git+https://github.com/barbacane-dev/parapet?rev=695ee8b46bd73eaa0daffdbdd73df0e45b26c6d3#695ee8b46bd73eaa0daffdbdd73df0e45b26c6d3"
 dependencies = [
  "aho-corasick",
+ "libinjectionrs",
  "quick-xml",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +887,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1164,7 +1184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1427,7 +1447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1745,11 +1765,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1759,10 +1777,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2235,7 +2256,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3208,7 +3229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3277,14 +3298,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3353,6 +3375,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3388,6 +3421,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3758,7 +3806,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4038,7 +4086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4049,7 +4097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4439,7 +4487,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ jsonschema = "0.26"
 # WASM runtime
 # SecLang/CRS engine. Pinned by revision while its API settles; moves to a
 # crates.io version when it stabilises (ADR-0031).
-parapet = { git = "https://github.com/barbacane-dev/parapet", rev = "a9218569f57219b897c87416c7a9240f228aca01", features = ["serde"] }
+parapet = { git = "https://github.com/barbacane-dev/parapet", rev = "695ee8b46bd73eaa0daffdbdd73df0e45b26c6d3", features = ["serde"] }
 wasmtime = { version = "47", features = ["cranelift", "pooling-allocator"] }
 wasmtime-wasi = { version = "47" }
 

--- a/adr/0031-waf-integration.md
+++ b/adr/0031-waf-integration.md
@@ -1,7 +1,7 @@
 # ADR-0031: WAF Integration (ModSecurity / OWASP CRS Compatible)
 
-**Status:** Proposed
-**Date:** 2026-09-07
+**Status:** Accepted
+**Date:** 2026-09-07 (accepted 2026-09-11)
 
 ## Context
 
@@ -105,7 +105,7 @@ This is the option that fits the architecture rather than working around it.
 
 - **CRS is already RE2-shaped, and this is now measured, not assumed.** Coraza evaluates `@rx` with Go's `regexp` (RE2), so CRS maintains RE2 compatibility as a hard constraint. 268 of 273 unique CRS `@rx` patterns compile unmodified under the Rust `regex` crate, and all 273 do after a lexical repair pass. See the feasibility probe below. The `regex` crate also gives the same linear-time guarantee, so there is no ReDoS surface from operator-supplied rules.
 - **`@pm` / `@pmFromFile` is Aho-Corasick**, and `aho-corasick` is a first-class Rust crate.
-- **`@detectSQLi` / `@detectXSS` is libinjection**, available as a pure-Rust port ([`libinjectionrs`](https://github.com/saarw/libinjectionrs), BSD-3-Clause), so no C dependency. Audited 2026-09-08 against the C original: 1,631 of 162,963 inputs tokenise differently, four divergence classes characterised including one false positive, and differential fuzzing finds a new class every few minutes once its NUL blind spot is removed. Verdict: **do not adopt yet**. See `docs/audit-libinjectionrs.md` in the Parapet repository.
+- **`@detectSQLi` / `@detectXSS` is libinjection**, adopted as a pure-Rust port ([`barbacane-dev/libinjectionrs`](https://github.com/barbacane-dev/libinjectionrs), BSD-3-Clause), so no C dependency. The 2026-09-08 audit found it diverged from the C original on 1,631 of 162,963 inputs with an open false-positive surface, verdict "do not adopt yet". The fork closed that: it is differential-tested against the C library through an FFI harness over the same corpus and now matches on every input, both verdicts and fingerprints (0 of 162,963 each), with any divergence failing CI. Six char-semantics classes were fixed following the C control flow, and a long differential-fuzzing campaign hardens the surface beyond the corpus.
 - **`@ipMatch` is `ipnet`.** Multipart parsing is `multer`. JSON body parsing is `serde_json`, already a dependency.
 - **A conformance suite exists for free.** The CRS regression corpus is 322 YAML files (roughly 5,000 cases) driven by [`go-ftw`](https://github.com/coreruleset/go-ftw). We do not have to invent a definition of "CRS compatible"; we have to pass someone else's.
 - **Prior art to read, not to depend on:** `zentinel-modsec`, per the survey above. A useful existence proof and a source of design decisions, not a dependency we would take on for a security-critical path at that maturity.
@@ -219,7 +219,7 @@ would trade the ADR's central property for a latency saving.
 
 Release gates for Stage 2 GA:
 
-- **`@detectSQLi` and `@detectXSS` implemented.** These are a GA prerequisite, not an optional extra. Without them the CRS rules 941100, 941101, 942100 and 942101 cannot be enforced, and those are the libinjection classifiers, not peripheral rules. The audit of `libinjectionrs` (see below) concluded it is not adoptable in its current state, so this gate is currently unmet and the route to meeting it is open.
+- **`@detectSQLi` and `@detectXSS` implemented.** These are a GA prerequisite, not an optional extra. Without them the CRS rules 941100, 941101, 942100 and 942101 cannot be enforced, and those are the libinjection classifiers, not peripheral rules. Met: both operators are implemented in Parapet over `libinjectionrs`, whose corpus differential against the C library is at zero.
 - **100% of the CRS regression suite** for the enabled paranoia level, in blocking mode, via `go-ftw`, **with an empty exclusion list**. An earlier draft of this ADR asked for 100% while two operators were refused, which is unreachable: those four rules account for 30 stages of the suite. Rather than define a reduced suite, GA requires the exclusion list to be empty, so the gate cannot be met by shrinking the target.
 - Until GA, the shortfall is reported rather than hidden: the compiler refuses a rule set it cannot fully enforce unless the operator opts in with `unsupported_rules: skip`, and the artifact then records the skipped rule ids in the manifest, where `artifact_hash` and the signature cover them. An operator can prove which rules a running gateway is not enforcing.
 - Unknown directive, operator, transformation, action or target is a hard compile error. No silent skips, ever.
@@ -329,7 +329,7 @@ The Rust-native gateways that ship a WAF do so with their own rule format, which
 - Is `waf-coraza` (Stage 1) worth publishing at all if Stage 2 is committed, given the deprecation cost?
 - ~~Does the engine repository sit in the `barbacane-dev` org or under a neutral name?~~ Resolved: `barbacane-dev/parapet`, with a deliberately Barbacane-agnostic README.
 - Barbacane's own dual-licensing exposure under DCO is broader than the WAF: does the project want a CLA for in-tree contributions generally, or to keep DCO and accept that contributed code is AGPL-only? Out of scope here, but this ADR is the second time it has come up.
-- ~~Which libinjection route: adopt `libinjectionrs`, or port the fingerprint tables?~~ Resolved for now: neither. The audit's verdict is that `libinjectionrs` is not adoptable until its divergence surface is bounded, because differential fuzzing keeps finding new classes and one of them is a false positive. Parapet keeps refusing `@detectSQLi` and `@detectXSS`, which costs 30 regression stages and fails loudly. The missing test infrastructure and the three tooling fixes that were hiding the evidence are contributed upstream in [saarw/libinjectionrs#1](https://github.com/saarw/libinjectionrs/pull/1). Revisit when fuzzing runs clean for hours rather than minutes.
+- ~~Which libinjection route: adopt `libinjectionrs`, or port the fingerprint tables?~~ Resolved: adopt the [`barbacane-dev/libinjectionrs`](https://github.com/barbacane-dev/libinjectionrs) fork. The divergence surface the audit flagged is now bounded: the corpus differential against the C library is at zero on both verdicts and fingerprints, gated in CI, and a long differential-fuzzing campaign drives the surface beyond the corpus. Parapet implements `@detectSQLi` and `@detectXSS` over it, so the 30 regression stages those four rules cover are enforced rather than refused.
 
 ## Related ADRs
 

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -4434,7 +4434,10 @@ SecMarker DONE
                     serde_json::from_slice(&sealed.rules_json).unwrap();
                 let (_, errors) =
                     parapet::RuleSet::compile_all(&directives, &parapet::NoDataLoader);
-                assert!(errors.is_empty(), "sealed rule set still has unenforceable rules");
+                assert!(
+                    errors.is_empty(),
+                    "sealed rule set still has unenforceable rules"
+                );
             }
             Err(e) => assert!(e.to_string().contains("could not be determined"), "{e}"),
         }

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -2012,7 +2012,12 @@ fn rule_id_of(error: &parapet::CompileError) -> Option<u32> {
     let text = error.to_string();
     let rest = text.strip_prefix("rule ")?;
     let id: String = rest.chars().take_while(char::is_ascii_digit).collect();
-    id.parse().ok()
+    // Parapet reports a rule with no id of its own (a chain link) as "rule 0".
+    // Rule ids are positive, so treat 0 as unattributable rather than a real id.
+    match id.parse().ok()? {
+        0 => None,
+        id => Some(id),
+    }
 }
 
 /// Extract root-level `x-barbacane-mcp` config from the first spec that defines it.
@@ -4417,13 +4422,20 @@ SecMarker DONE
         );
         let result = seal_waf_ruleset(&rules, UnsupportedRules::Skip);
         match result {
-            // Either the id is attributed to the chain starter and recorded,
-            // or the build refuses. Silently dropping it is the only
-            // unacceptable outcome.
-            Ok(sealed) => assert!(
-                !sealed.skipped_rules.is_empty(),
-                "a refused rule was neither recorded nor refused"
-            ),
+            // Either the id is attributed and recorded, or the build refuses.
+            // Silently dropping it is the only unacceptable outcome, and a
+            // sealed set must contain only rules the gateway can enforce.
+            Ok(sealed) => {
+                assert!(
+                    !sealed.skipped_rules.is_empty(),
+                    "a refused rule was neither recorded nor refused"
+                );
+                let directives: Vec<parapet::Directive> =
+                    serde_json::from_slice(&sealed.rules_json).unwrap();
+                let (_, errors) =
+                    parapet::RuleSet::compile_all(&directives, &parapet::NoDataLoader);
+                assert!(errors.is_empty(), "sealed rule set still has unenforceable rules");
+            }
             Err(e) => assert!(e.to_string().contains("could not be determined"), "{e}"),
         }
     }

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -3976,14 +3976,11 @@ mod waf_tests {
 
     #[test]
     fn an_unenforceable_rule_refuses_the_artifact_by_default() {
-        // @detectSQLi has no implementation, so the rule cannot be enforced.
+        // An invalid regex cannot be compiled, so the rule cannot be enforced.
         // The default policy refuses rather than shipping a rule set that
         // looks complete.
         let dir = tempdir("unsupported-fail");
-        let rules = ruleset(
-            &dir,
-            "SecRule ARGS \"@detectSQLi\" \"id:942100,phase:2,deny\"\n",
-        );
+        let rules = ruleset(&dir, "SecRule ARGS \"@rx (\" \"id:942100,phase:2,deny\"\n");
         let err = seal_waf_ruleset(&rules, UnsupportedRules::Fail).unwrap_err();
         let text = err.to_string();
         assert!(text.contains("cannot be enforced"), "{text}");
@@ -3996,7 +3993,7 @@ mod waf_tests {
         let rules = ruleset(
             &dir,
             "SecRule ARGS \"@rx attack\" \"id:1,phase:2,deny\"\n\
-             SecRule ARGS \"@detectSQLi\" \"id:942100,phase:2,deny\"\n",
+             SecRule ARGS \"@rx (\" \"id:942100,phase:2,deny\"\n",
         );
         let sealed = seal_waf_ruleset(&rules, UnsupportedRules::Skip).expect("must seal");
         assert_eq!(sealed.skipped_rules, vec![942100]);
@@ -4330,7 +4327,7 @@ SecMarker DONE
         let dir = project(
             "unenforceable",
             SPEC,
-            Some("SecRule ARGS \"@detectSQLi\" \"id:942100,phase:2,deny\"\n"),
+            Some("SecRule ARGS \"@rx (\" \"id:942100,phase:2,deny\"\n"),
         );
         let err = compile(
             &[&dir.join("api.yaml")],
@@ -4416,7 +4413,7 @@ SecMarker DONE
         // the chained link has no id of its own to record.
         let rules = ruleset(
             &dir,
-            "SecRule ARGS \"@rx x\" \"id:5000,phase:2,deny,chain\"\n    SecRule ARGS \"@detectXSS\"\n",
+            "SecRule ARGS \"@rx x\" \"id:5000,phase:2,deny,chain\"\n    SecRule ARGS \"@rx (\"\n",
         );
         let result = seal_waf_ruleset(&rules, UnsupportedRules::Skip);
         match result {

--- a/deny.toml
+++ b/deny.toml
@@ -52,7 +52,11 @@ wildcards = "warn"
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# Parapet, the SecLang/CRS engine (ADR-0031). Pinned by revision in
-# Cargo.toml, and moves to crates.io once its API settles, at which point this
-# entry comes back out.
-allow-git = ["https://github.com/barbacane-dev/parapet"]
+# Parapet, the SecLang/CRS engine (ADR-0031), and libinjectionrs, the
+# libinjection port it uses for @detectSQLi/@detectXSS. Both pinned by revision
+# in Cargo.toml, and move to crates.io once their APIs settle, at which point
+# these entries come back out.
+allow-git = [
+    "https://github.com/barbacane-dev/parapet",
+    "https://github.com/barbacane-dev/libinjectionrs",
+]

--- a/docs/guide/waf.md
+++ b/docs/guide/waf.md
@@ -60,11 +60,13 @@ into `artifact_hash`, so a signed artifact cannot be switched from blocking to
 detection-only, or have its paranoia level lowered, without invalidating the
 signature.
 
-A rule the build cannot enforce fails the build:
+A rule the build cannot enforce fails the build. Stock CRS v4.9.0 compiles in
+full; a rule fails only when its operator cannot be built, for example an
+invalid regex in a custom rule:
 
 ```text
-error[E1080]: x-barbacane-waf: 4 rule(s) in the rule set cannot be enforced by
-this build: rule 942100 (line 46): operator @detectSQLi is not implemented yet
+error[E1080]: x-barbacane-waf: 1 rule(s) in the rule set cannot be enforced by
+this build: rule 900500 (line 12): @rx (: unclosed group
 ...
 Set `unsupported_rules: skip` to build without them. The artifact then records
 their ids and the gateway will not enforce them.
@@ -79,13 +81,6 @@ them at WARN on every boot.
 ## Current limitations
 
 Read these before enabling it in production.
-
-**`@detectSQLi` and `@detectXSS` are not implemented.** Four CRS rules use
-them (941100, 941101, 942100, 942101) and they are the libinjection
-classifiers, not peripheral rules. With `unsupported_rules: skip` the rest of
-CRS runs without them. Regex-based SQLi and XSS rules still fire, so a
-`UNION SELECT` or a `<script>` tag is still caught; a tautology such as
-`1' OR '1'='1` may not be.
 
 **Response-phase rules are not evaluated.** A CRS artifact carries around 152
 rules in phases 3 to 5, mostly outbound data-leakage detection, and they are

--- a/docs/guide/waf.md
+++ b/docs/guide/waf.md
@@ -61,8 +61,10 @@ detection-only, or have its paranoia level lowered, without invalidating the
 signature.
 
 A rule the build cannot enforce fails the build. Stock CRS v4.9.0 compiles in
-full; a rule fails only when its operator cannot be built, for example an
-invalid regex in a custom rule:
+full; a failure comes from a custom rule, for example an unknown directive, a
+missing `@pmFromFile` data file, or an invalid regex. `unsupported_rules: skip`
+covers only rules whose operator will not compile; a parse error or a missing
+data file always fails the build:
 
 ```text
 error[E1080]: x-barbacane-waf: 1 rule(s) in the rule set cannot be enforced by


### PR DESCRIPTION
Bumps the pinned `parapet` rev to the commit that implements the `@detectSQLi`
and `@detectXSS` operators over the [`libinjectionrs`](https://github.com/barbacane-dev/libinjectionrs)
port (differential-tested to zero divergence from the C library over its
~163k-input corpus). CRS rules 941100/941101/942100/942101 are now enforced
rather than skipped.

## Changes

- `Cargo.toml`/`Cargo.lock`: parapet rev `a921856` -> `695ee8b` (pulls
  libinjectionrs transitively).
- **ADR-0031**: marked Accepted; the libinjection note updated from the
  2026-09-08 "do not adopt yet" verdict to the current zero-divergence,
  CI-gated state.
- **WAF guide**: the "@detectSQLi/@detectXSS are not implemented" limitation
  is removed; the E1080 example now uses an invalid custom regex, since stock
  CRS v4.9.0 compiles in full.
- **Compiler tests**: the four that used `@detectSQLi` as a stand-in for an
  unenforceable rule now use an invalid regex, the remaining genuine case for
  the skip/fail mechanism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `@detectSQLi` and `@detectXSS` WAF operators.
  - Stock CRS v4.9.0 rules can now compile successfully in full.

- **Bug Fixes**
  - Improved handling of unsupported or invalid rule operators: compilation now fails clearly when a rule cannot be built.
  - Updated WAF test coverage to reflect current operator support and compilation behavior.

- **Documentation**
  - Updated WAF guidance and examples to describe successful CRS compilation and invalid-regex failures.
  - Removed outdated limitations for SQL injection and cross-site scripting detection operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->