### PR TITLE
Release: skip crates.io publish for parapet-dependent crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,14 +452,17 @@ jobs:
             sleep 60
           }
 
-          # Publish in dependency order
+          # Publish in dependency order (leaves first).
           publish_crate "barbacane-plugin-macros"
           publish_crate "barbacane-plugin-sdk"
           publish_crate "barbacane-telemetry"
           publish_crate "barbacane-wasm"
-          publish_crate "barbacane-compiler"
-          publish_crate "barbacane"
-          publish_crate "barbacane-control"
+
+          # barbacane-compiler, barbacane and barbacane-control depend on
+          # parapet, which is a git dependency (ADR-0031). crates.io rejects git
+          # dependencies, so these cannot be published there yet. They are
+          # distributed as release binaries and container images instead, and
+          # return to this list when parapet moves to a crates.io release.
 
           # Summary
           echo ""


### PR DESCRIPTION
The `Publish Crates` job failed on `barbacane-compiler`, `barbacane` and
`barbacane-control` during the v0.9.0 release: they depend on `parapet`, a git
dependency (ADR-0031), and crates.io rejects git dependencies. The four library
crates that do not depend on parapet published fine, and the binaries and
container images built and published fine, but the failure turned the release
run red.

Drop the three from the crates.io publish list, with a comment. They are
distributed as release binaries and container images, and return to the list
when parapet moves to a crates.io release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Distribution**
  - The compiler, core, and control packages are no longer published to crates.io.
  - These packages continue to be distributed through release binaries and container images.
  - Plugin macros, plugin SDK, telemetry, and WASM packages remain available through crates.io.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->