### PR TITLE
Depend on the WAF engine from crates.io, not a git pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -457,12 +457,9 @@ jobs:
           publish_crate "barbacane-plugin-sdk"
           publish_crate "barbacane-telemetry"
           publish_crate "barbacane-wasm"
-
-          # barbacane-compiler, barbacane and barbacane-control depend on
-          # parapet, which is a git dependency (ADR-0031). crates.io rejects git
-          # dependencies, so these cannot be published there yet. They are
-          # distributed as release binaries and container images instead, and
-          # return to this list when parapet moves to a crates.io release.
+          publish_crate "barbacane-compiler"
+          publish_crate "barbacane"
+          publish_crate "barbacane-control"
 
           # Summary
           echo ""

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -337,6 +337,7 @@ dependencies = [
  "arc-swap",
  "barbacane-compiler",
  "barbacane-telemetry",
+ "barbacane-waf",
  "barbacane-wasm",
  "bytes",
  "clap",
@@ -348,7 +349,6 @@ dependencies = [
  "hyper-util",
  "jsonschema",
  "notify",
- "parapet",
  "parking_lot",
  "reqwest 0.12.28",
  "rustls",
@@ -370,12 +370,12 @@ dependencies = [
 name = "barbacane-compiler"
 version = "0.9.0"
 dependencies = [
+ "barbacane-waf",
  "chrono",
  "criterion",
  "flate2",
  "hex",
  "home",
- "parapet",
  "reqwest 0.12.28",
  "ring",
  "serde",
@@ -420,6 +420,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "barbacane-libinjection"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836db2b79f5f4133d5e64aa99254833016ea0e8b74b306bee79db3c9716c8fba"
+dependencies = [
+ "bitflags 2.11.0",
+ "serde_json",
+ "smallvec",
 ]
 
 [[package]]
@@ -487,6 +498,22 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "wiremock",
+]
+
+[[package]]
+name = "barbacane-waf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fdc4f8d76d6ba9dda6ec2e1c88febc74793f4542475212110f4d90f48f143d"
+dependencies = [
+ "aho-corasick",
+ "barbacane-libinjection",
+ "quick-xml",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1447,7 +1474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2256,7 +2283,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2396,16 +2423,6 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "libinjectionrs"
-version = "0.1.1"
-source = "git+https://github.com/barbacane-dev/libinjectionrs?rev=7f35f8097e9dd06005334a0c8f50661ce544a8df#7f35f8097e9dd06005334a0c8f50661ce544a8df"
-dependencies = [
- "bitflags 2.11.0",
- "serde_json",
- "smallvec",
-]
 
 [[package]]
 name = "libloading"
@@ -2659,7 +2676,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2912,21 +2929,6 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
-]
-
-[[package]]
-name = "parapet"
-version = "0.0.0"
-source = "git+https://github.com/barbacane-dev/parapet?rev=695ee8b46bd73eaa0daffdbdd73df0e45b26c6d3#695ee8b46bd73eaa0daffdbdd73df0e45b26c6d3"
-dependencies = [
- "aho-corasick",
- "libinjectionrs",
- "quick-xml",
- "regex",
- "serde",
- "serde_json",
- "sha1",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3806,7 +3808,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4182,7 +4184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4487,7 +4489,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5709,7 +5711,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ jsonschema = "0.26"
 # WASM runtime
 # SecLang/CRS engine. Pinned by revision while its API settles; moves to a
 # crates.io version when it stabilises (ADR-0031).
-parapet = { git = "https://github.com/barbacane-dev/parapet", rev = "695ee8b46bd73eaa0daffdbdd73df0e45b26c6d3", features = ["serde"] }
+parapet = { package = "barbacane-waf", version = "0.1.0", features = ["serde"] }
 wasmtime = { version = "47", features = ["cranelift", "pooling-allocator"] }
 wasmtime-wasi = { version = "47" }
 

--- a/deny.toml
+++ b/deny.toml
@@ -52,11 +52,6 @@ wildcards = "warn"
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# Parapet, the SecLang/CRS engine (ADR-0031), and libinjectionrs, the
-# libinjection port it uses for @detectSQLi/@detectXSS. Both pinned by revision
-# in Cargo.toml, and move to crates.io once their APIs settle, at which point
-# these entries come back out.
-allow-git = [
-    "https://github.com/barbacane-dev/parapet",
-    "https://github.com/barbacane-dev/libinjectionrs",
-]
+# The WAF engine and its libinjection port are consumed from crates.io
+# (barbacane-waf, barbacane-libinjection), so no git sources are allowed.
+allow-git = []


### PR DESCRIPTION
Now that `barbacane-waf 0.1.0` and `barbacane-libinjection 0.1.1` are on
crates.io, barbacane consumes them from there instead of git revisions.

- `parapet` dependency moves from the git pin to `{ package = "barbacane-waf",
  version = "0.1.0" }`; it keeps the key `parapet`, so no code changes.
  libinjection comes in transitively from crates.io.
- `deny.toml`: `allow-git` is emptied (no git sources remain); `cargo deny
  check` passes on all of advisories/bans/licenses/sources.
- `release.yml`: `barbacane-compiler`, `barbacane` and `barbacane-control`
  return to the crates.io publish list (reverting the earlier exclusion) —
  with no git deps they are publishable, so a release now publishes the whole
  workspace.

Verified locally: builds against the crates.io engine, the 21 WAF compiler
tests pass, `cargo deny check` and `cargo fmt --check` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The compiler, command-line tools, and control components are now published as installable packages through the standard Rust package registry.

- **Improvements**
  - Package distribution now uses registry-hosted components, providing a more consistent installation and upgrade experience.
  - Release publishing has been streamlined for these components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->