### PR TITLE
CI: speed up the pipeline (split coverage + shard integration tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,10 +341,22 @@ jobs:
 
   # Integration tests (slower, requires gateway binary and plugins)
   integration-tests:
-    name: Integration Tests
+    name: Integration Tests (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: [changes, unit-tests]
     if: needs.changes.outputs.code == 'true'
+    # The suite drives the gateway as a child process on OS-assigned ports, so
+    # within a job concurrency stays at 2 to keep the find-then-bind port race
+    # rare. Wall-clock is cut by sharding the test binaries across parallel jobs
+    # instead of raising concurrency. fail-fast off so one shard's failure does
+    # not cancel the others.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    env:
+      SHARD_INDEX: ${{ matrix.shard }}
+      SHARD_TOTAL: 4
     steps:
       - uses: actions/checkout@v6
         with:
@@ -379,20 +391,26 @@ jobs:
         run: chmod +x target/debug/barbacane
 
       - name: Run integration tests
-        # Run the full barbacane-test suite: the lib tests plus every
-        # integration binary in tests/*.rs. The `security` target is excluded
-        # here because it needs PostgreSQL and the control-plane binary — it has
-        # its own `security-suite` job below. Targets are discovered rather than
-        # hard-coded so new suites are picked up automatically.
+        # Every integration binary in tests/*.rs, discovered rather than
+        # hard-coded so new suites are picked up automatically. `security` is
+        # excluded here (it needs PostgreSQL and the control-plane binary and
+        # has its own security-suite job). This shard takes a round-robin slice
+        # of the binaries; the lib tests run only on shard 0 to avoid repeating
+        # them across shards.
         run: |
-          targets=$(ls crates/barbacane-test/tests/*.rs \
+          all=$(ls crates/barbacane-test/tests/*.rs \
             | xargs -n1 basename | sed 's/\.rs$//' \
-            | grep -vx security \
+            | grep -vx security | sort)
+          targets=$(echo "$all" \
+            | awk "NR % $SHARD_TOTAL == $SHARD_INDEX" \
             | sed 's/^/--test /' | tr '\n' ' ')
-          echo "Running integration targets: $targets"
-          # --no-fail-fast so a failure in one binary doesn't hide failures in
-          # the binaries that would run after it; we want the full picture.
-          cargo test -p barbacane-test --lib $targets --no-fail-fast -- --test-threads=2
+          lib=""; [ "$SHARD_INDEX" = "0" ] && lib="--lib"
+          if [ -z "$targets" ] && [ -z "$lib" ]; then
+            echo "No targets for shard $SHARD_INDEX"; exit 0
+          fi
+          echo "Shard $SHARD_INDEX/$SHARD_TOTAL targets: $lib $targets"
+          # --no-fail-fast so one binary's failure doesn't hide later ones.
+          cargo test -p barbacane-test $lib $targets --no-fail-fast -- --test-threads=2
 
   # Line coverage over the unit tests plus the integration suite. The
   # integration suite drives the gateway as a child process, and the harness

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,7 @@ jobs:
       # Raise the floor when the real number rises. Never lower it to turn a
       # red build green.
       - name: Measure coverage
-        run: ./scripts/coverage.sh --lcov lcov.info --summary coverage.txt --floor 60
+        run: ./scripts/coverage.sh --lcov lcov.info --summary coverage.txt --floor 63
 
       - name: Publish summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,24 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, unit-tests]
     if: needs.changes.outputs.code == 'true'
+    # PostgreSQL so the control-plane tests, which drive the axum router
+    # in-process against a real database and otherwise skip, are measured.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: barbacane
+          POSTGRES_PASSWORD: barbacane
+          POSTGRES_DB: barbacane
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgres://barbacane:barbacane@localhost:5432/barbacane
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,24 +403,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, unit-tests]
     if: needs.changes.outputs.code == 'true'
-    # PostgreSQL so the control-plane tests, which drive the axum router
-    # in-process against a real database and otherwise skip, are measured.
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: barbacane
-          POSTGRES_PASSWORD: barbacane
-          POSTGRES_DB: barbacane
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-    env:
-      DATABASE_URL: postgres://barbacane:barbacane@localhost:5432/barbacane
+    # Fast, unit-only coverage for a per-pull-request signal. The full
+    # instrumented run (integration + control-plane over PostgreSQL, with the
+    # enforced floor) is heavy, so it lives in coverage-full.yml on main and a
+    # nightly schedule rather than on the pull-request critical path.
     steps:
       - uses: actions/checkout@v6
         with:
@@ -444,31 +430,17 @@ jobs:
             ${{ runner.os }}-cargo-coverage-
             ${{ runner.os }}-cargo-
 
-      - name: Cache WASM plugins
-        uses: actions/cache@v5
-        id: plugin-cache
-        with:
-          path: |
-            plugins/*/*.wasm
-            plugins/*/target
-          key: ${{ runner.os }}-plugins-${{ hashFiles('plugins/**/Cargo.toml', 'plugins/**/Cargo.lock', 'plugins/**/*.rs', 'crates/barbacane-plugin-sdk/**') }}
-
-      - name: Build WASM plugins
-        if: steps.plugin-cache.outputs.cache-hit != 'true'
-        run: make plugins
-
       - name: Install cargo-llvm-cov
         # Third-party actions are pinned to a commit, as elsewhere in this repo.
         uses: taiki-e/install-action@d438492cf8a250514fa2d34b30bc3c0dc37c65ff # v2
         with:
           tool: cargo-llvm-cov
 
-      # The floor is enforced here rather than in a step of its own: the report
-      # needs the environment `show-env` sets up inside the script.
-      # Raise the floor when the real number rises. Never lower it to turn a
-      # red build green.
-      - name: Measure coverage
-        run: ./scripts/coverage.sh --lcov lcov.info --summary coverage.txt --floor 63
+      # Unit-only, report-only: a quick per-PR number without the integration
+      # suite or a database. The floor is enforced by the full run in
+      # coverage-full.yml.
+      - name: Measure coverage (unit)
+        run: ./scripts/coverage.sh --unit --lcov lcov.info --summary coverage.txt
 
       - name: Publish summary
         if: always()

--- a/.github/workflows/coverage-full.yml
+++ b/.github/workflows/coverage-full.yml
@@ -1,0 +1,99 @@
+name: Coverage (full)
+
+# The full instrumented coverage run: unit + integration (the gateway driven as
+# an instrumented child process) + the control-plane tests over a real
+# PostgreSQL. It is heavy (~35 min), so it runs on main, nightly, and on demand
+# rather than on every pull request. The enforced floor lives here; the
+# per-pull-request CI job runs a fast unit-only report instead.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'plugins/**'
+      - 'scripts/coverage.sh'
+      - '.github/workflows/coverage-full.yml'
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage-full:
+    name: Coverage (full)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: barbacane
+          POSTGRES_PASSWORD: barbacane
+          POSTGRES_DB: barbacane
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgres://barbacane:barbacane@localhost:5432/barbacane
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: llvm-tools-preview
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-coverage-
+            ${{ runner.os }}-cargo-
+
+      - name: Build WASM plugins
+        run: make plugins
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@d438492cf8a250514fa2d34b30bc3c0dc37c65ff # v2
+        with:
+          tool: cargo-llvm-cov
+
+      # Raise the floor when the real number rises. Never lower it to turn a
+      # red build green.
+      - name: Measure coverage
+        run: ./scripts/coverage.sh --lcov lcov.info --summary coverage.txt --floor 63
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo '### Coverage (full)'
+            echo
+            echo '```'
+            cat coverage.txt || echo '(no summary produced)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload lcov
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-lcov
+          path: lcov.info
+          if-no-files-found: ignore


### PR DESCRIPTION
End-to-end CI was ~50 min, dominated by **Coverage (36m)** and **Integration
Tests (28m)**. Two changes:

## 1. Split coverage (the ~36m job off the PR critical path)
- **Per-PR `Coverage`**: `coverage.sh --unit` — unit-only, report-only, no DB,
  no integration (~5–8m signal).
- **`coverage-full.yml`**: full instrumented run (integration + control-plane
  over `postgres:16`) with the **floor 63**, on `push: main` + nightly +
  `workflow_dispatch`. Folds in Stage A (control-plane now measured, 61%→63%).

## 2. Shard Integration Tests (4 parallel jobs)
The suite is execution-bound (~24m of the 28m was tests at `--test-threads=2`);
the gateway runs as a child process on OS-assigned ports (find-then-bind race),
so raising in-job concurrency would add flakiness. Instead the test binaries are
sharded round-robin across 4 parallel jobs, each keeping the proven 2-thread
concurrency. ~28m → ~10m wall-clock.

**Expected PR CI: ~50m → ~15m.** Follow-up (#3): better target caching
(Swatinem/rust-cache or sccache) to cut the repeated compiles.

Note: the required check name changes to `Integration Tests (shard N)` — branch
protection may need the matrix names if it pins the old one.