### PR TITLE
feat(waf): per-transaction audit logging

### DIFF
--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -167,6 +167,21 @@ pub enum UnsupportedRules {
     Skip,
 }
 
+/// When the WAF writes a per-transaction audit record.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuditEngine {
+    /// Never write an audit record.
+    Off,
+    /// Write a record only for a transaction that matched at least one logged
+    /// rule or was blocked. Near-zero volume on clean traffic, and the CRS
+    /// crs-setup default.
+    #[default]
+    RelevantOnly,
+    /// Write a record for every inspected transaction.
+    On,
+}
+
 /// Default largest response body phase-4 rules inspect, in bytes (1 MiB).
 pub const fn default_max_response_body() -> u64 {
     1_048_576
@@ -198,6 +213,9 @@ pub struct WafConfig {
     /// with the skip counted.
     #[serde(default = "default_max_response_body")]
     pub max_response_body: u64,
+    /// When to write a per-transaction audit record.
+    #[serde(default)]
+    pub audit: AuditEngine,
     /// Policy for rules the engine cannot compile.
     #[serde(default)]
     pub unsupported_rules: UnsupportedRules,
@@ -224,6 +242,7 @@ impl Default for WafConfig {
             inbound_threshold: 0,
             outbound_threshold: 0,
             max_response_body: default_max_response_body(),
+            audit: AuditEngine::default(),
             unsupported_rules: UnsupportedRules::default(),
             rules_path: None,
             skipped_rules: Vec::new(),
@@ -1167,13 +1186,14 @@ fn compute_artifact_hash(
     // them must change the hash.
     hasher.update(
         format!(
-            "waf:enabled={}\tparanoia={}\tmode={:?}\tinbound={}\toutbound={}\tmax_response_body={}\tunsupported={:?}\tskipped={}\n",
+            "waf:enabled={}\tparanoia={}\tmode={:?}\tinbound={}\toutbound={}\tmax_response_body={}\taudit={:?}\tunsupported={:?}\tskipped={}\n",
             waf.enabled,
             waf.paranoia_level,
             waf.mode,
             waf.inbound_threshold,
             waf.outbound_threshold,
             waf.max_response_body,
+            waf.audit,
             waf.unsupported_rules,
             waf.skipped_rules
                 .iter()
@@ -1816,6 +1836,11 @@ fn extract_root_waf_config(specs: &[(ApiSpec, String, String)]) -> WafConfig {
                 .get("max_response_body")
                 .and_then(|v| v.as_u64())
                 .unwrap_or_else(default_max_response_body),
+            audit: match value.get("audit").and_then(|v| v.as_str()) {
+                Some("off") => AuditEngine::Off,
+                Some("on") => AuditEngine::On,
+                _ => AuditEngine::RelevantOnly,
+            },
             unsupported_rules: match value.get("unsupported_rules").and_then(|v| v.as_str()) {
                 Some("skip") => UnsupportedRules::Skip,
                 _ => UnsupportedRules::Fail,
@@ -4192,6 +4217,10 @@ mod waf_tests {
         cap.max_response_body = 42;
         assert_ne!(baseline, hash_of(&cap), "max_response_body is not bound");
 
+        let mut audit = base.clone();
+        audit.audit = AuditEngine::On;
+        assert_ne!(baseline, hash_of(&audit), "audit engine is not bound");
+
         let mut off = base.clone();
         off.enabled = false;
         assert_ne!(baseline, hash_of(&off), "enabled is not bound");
@@ -4208,6 +4237,7 @@ mod waf_tests {
         assert_eq!(cfg.inbound_threshold, 5);
         assert_eq!(cfg.outbound_threshold, 4);
         assert_eq!(cfg.max_response_body, 1_048_576);
+        assert_eq!(cfg.audit, AuditEngine::RelevantOnly);
         assert_eq!(cfg.unsupported_rules, UnsupportedRules::Fail);
     }
 

--- a/crates/barbacane-telemetry/src/metrics.rs
+++ b/crates/barbacane-telemetry/src/metrics.rs
@@ -163,6 +163,9 @@ pub struct MetricsRegistry {
     /// was streamed or its body exceeded `max_response_body`. Response headers
     /// (phase 3) were still inspected; the body was not.
     pub waf_response_body_skipped_total: Family<WafInspectionLabels, Counter>,
+    /// Per-transaction audit records written, by method and path. Governed by
+    /// the audit engine policy, so it counts records actually emitted.
+    pub waf_audit_total: Family<WafInspectionLabels, Counter>,
 
     // Middleware metrics
     pub middleware_duration_seconds: Family<MiddlewareLabels, Histogram>,
@@ -294,6 +297,13 @@ impl MetricsRegistry {
             waf_response_body_skipped_total.clone(),
         );
 
+        let waf_audit_total = Family::<WafInspectionLabels, Counter>::default();
+        registry.register(
+            "barbacane_waf_audit_total",
+            "Per-transaction WAF audit records written",
+            waf_audit_total.clone(),
+        );
+
         let validation_failures_total = Family::<ValidationLabels, Counter>::default();
         registry.register(
             "barbacane_validation_failures_total",
@@ -402,6 +412,7 @@ impl MetricsRegistry {
             waf_allowed_total,
             waf_duration_seconds,
             waf_response_body_skipped_total,
+            waf_audit_total,
             middleware_duration_seconds,
             middleware_short_circuits_total,
             dispatch_duration_seconds,
@@ -503,6 +514,16 @@ impl MetricsRegistry {
     /// Record a response whose body phase-4 rules did not inspect.
     pub fn record_waf_response_body_skipped(&self, method: &str, path: &str) {
         self.waf_response_body_skipped_total
+            .get_or_create(&WafInspectionLabels {
+                method: method.to_string(),
+                path: path.to_string(),
+            })
+            .inc();
+    }
+
+    /// Record a per-transaction audit record being written.
+    pub fn record_waf_audit(&self, method: &str, path: &str) {
+        self.waf_audit_total
             .get_or_create(&WafInspectionLabels {
                 method: method.to_string(),
                 path: path.to_string(),

--- a/crates/barbacane-test/tests/waf.rs
+++ b/crates/barbacane-test/tests/waf.rs
@@ -277,6 +277,68 @@ async fn response_headers_are_inspected_even_when_the_body_is_skipped() {
 }
 
 // ---------------------------------------------------------------------------
+// Audit logging
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_blocked_request_writes_an_audit_record() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway
+        .get("/waf/search?q=1'%20or%20'1'%3D'1")
+        .await
+        .unwrap();
+    assert_eq!(assert_blocked(resp, 403).await, ANOMALY_RULE);
+
+    let body = metrics(&gateway).await;
+    assert_eq!(
+        sample(
+            &body,
+            "barbacane_waf_audit_total",
+            &["path=\"/waf/search\""]
+        ),
+        Some(1.0),
+        "a blocked transaction is relevant and must be audited"
+    );
+}
+
+#[tokio::test]
+async fn a_clean_request_writes_no_audit_record_by_default() {
+    let gateway = blocking_gateway().await;
+    let resp = gateway.get("/waf/search?q=hello%20world").await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = metrics(&gateway).await;
+    assert!(
+        sample(&body, "barbacane_waf_audit_total", &["path="]).is_none(),
+        "relevant-only must not audit a transaction that matched nothing"
+    );
+}
+
+/// A match that only scored, without blocking, is still relevant and audited.
+#[tokio::test]
+async fn a_detected_but_not_blocked_request_is_audited() {
+    let gateway = TestGateway::from_spec(&fixture("waf-detection-only.yaml"))
+        .await
+        .expect("failed to start gateway");
+    let resp = gateway
+        .get("/waf/search?q=1'%20or%20'1'%3D'1")
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = metrics(&gateway).await;
+    assert_eq!(
+        sample(
+            &body,
+            "barbacane_waf_audit_total",
+            &["path=\"/waf/search\""]
+        ),
+        Some(1.0),
+        "a matched-but-not-blocked transaction is relevant and must be audited"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Header collection
 // ---------------------------------------------------------------------------
 

--- a/crates/barbacane/src/main.rs
+++ b/crates/barbacane/src/main.rs
@@ -1404,6 +1404,15 @@ impl Gateway {
                             &route_path,
                             "waf_blocked",
                         );
+                        self.emit_waf_audit(
+                            &inspection,
+                            &method_str,
+                            &route_path,
+                            &request_id,
+                            client_addr.map(|a| a.ip().to_string()).as_deref(),
+                            status,
+                            Some(rule_id),
+                        );
                         let response = self.waf_blocked_response(status, rule_id, &message);
                         self.record_request_metrics(
                             &method_str,
@@ -1479,6 +1488,8 @@ impl Gateway {
                         &method_str,
                         &route_path,
                         &request_matched,
+                        &request_id,
+                        client_addr.map(|a| a.ip().to_string()).as_deref(),
                     )
                     .await
                 } else {
@@ -3006,6 +3017,7 @@ impl Gateway {
     /// by the time a phase-4 rule could block. A WebSocket upgrade has no
     /// response phases. Returns the response to send: the upstream response
     /// (rebuilt when its body was collected), or a block response.
+    #[allow(clippy::too_many_arguments)]
     async fn inspect_response_waf(
         &self,
         mut inspection: waf::WafInspection<'_>,
@@ -3013,8 +3025,12 @@ impl Gateway {
         method: &str,
         path: &str,
         request_matched: &[u32],
+        request_id: &str,
+        client_ip: Option<&str>,
     ) -> Response<AnyBody> {
         if response.status() == StatusCode::SWITCHING_PROTOCOLS {
+            // No response phases; audit the request-phase result.
+            self.emit_waf_audit(&inspection, method, path, request_id, client_ip, 101, None);
             return response;
         }
 
@@ -3063,6 +3079,22 @@ impl Gateway {
             }
         }
 
+        let (audit_status, blocked_rule_id) = match &decision {
+            waf::WafDecision::Block {
+                status, rule_id, ..
+            } => (*status, Some(*rule_id)),
+            waf::WafDecision::Allow => (status, None),
+        };
+        self.emit_waf_audit(
+            &inspection,
+            method,
+            path,
+            request_id,
+            client_ip,
+            audit_status,
+            blocked_rule_id,
+        );
+
         if let waf::WafDecision::Block {
             status,
             rule_id,
@@ -3084,6 +3116,47 @@ impl Gateway {
         }
 
         response
+    }
+
+    /// Write a per-transaction WAF audit record, governed by the audit engine
+    /// policy. The record is a structured line on the `waf.audit` tracing
+    /// target so it can be routed to its own sink.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_waf_audit(
+        &self,
+        inspection: &waf::WafInspection,
+        method: &str,
+        path: &str,
+        request_id: &str,
+        client_ip: Option<&str>,
+        response_status: u16,
+        blocked_rule_id: Option<u32>,
+    ) {
+        let Some(stage) = &self.waf else {
+            return;
+        };
+        let matches = inspection.audit_matches();
+        if !waf::should_audit(
+            stage.audit_engine(),
+            blocked_rule_id.is_some(),
+            !matches.is_empty(),
+        ) {
+            return;
+        }
+        self.metrics.record_waf_audit(method, path);
+        let record = serde_json::json!({
+            "request_id": request_id,
+            "client_ip": client_ip,
+            "method": method,
+            "path": path,
+            "response_status": response_status,
+            "blocked": blocked_rule_id.is_some(),
+            "blocking_rule_id": blocked_rule_id,
+            "inbound_score": inspection.inbound_score(),
+            "outbound_score": inspection.outbound_score(),
+            "matches": matches,
+        });
+        tracing::info!(target: "waf.audit", audit = %record, "WAF audit record");
     }
 
     /// Build a 413 Payload Too Large response (RFC 9457). Used when the request

--- a/crates/barbacane/src/waf.rs
+++ b/crates/barbacane/src/waf.rs
@@ -12,9 +12,10 @@
 
 use std::path::Path;
 
-use barbacane_compiler::artifact::{Manifest, WafMode};
+use barbacane_compiler::artifact::{AuditEngine, Manifest, WafMode};
 use parapet::transaction::EngineMode;
 use parapet::{RuleSet, Transaction, Verdict};
+use serde::Serialize;
 
 /// A compiled rule set plus the policy that decides what it does.
 pub struct WafStage {
@@ -27,6 +28,34 @@ pub struct WafStage {
     outbound_threshold: i64,
     /// Largest response body, in bytes, that phase-4 rules inspect.
     max_response_body: usize,
+    /// When to write a per-transaction audit record.
+    audit: AuditEngine,
+}
+
+/// One rule that matched, for an audit record. Only rules that would appear in
+/// the audit log (not `nolog`) are included.
+#[derive(Debug, Clone, Serialize)]
+pub struct WafAuditMatch {
+    /// The rule's id.
+    pub rule_id: u32,
+    /// The rule's expanded `msg:`.
+    pub message: String,
+    /// The rule's expanded `logdata:`, empty if it had none.
+    pub data: String,
+    /// The rule's tags.
+    pub tags: Vec<String>,
+    /// The variable that matched, as `MATCHED_VAR_NAME` reports it.
+    pub matched_var: String,
+}
+
+/// Whether a transaction should be audited under `engine`. `RelevantOnly` logs
+/// a transaction that was blocked or matched at least one logged rule.
+pub fn should_audit(engine: AuditEngine, blocked: bool, matched: bool) -> bool {
+    match engine {
+        AuditEngine::Off => false,
+        AuditEngine::On => true,
+        AuditEngine::RelevantOnly => blocked || matched,
+    }
 }
 
 /// An inspection in progress, held between the request and response phases.
@@ -108,6 +137,7 @@ impl WafStage {
             // that would silently stop inspecting bodies it should.
             max_response_body: usize::try_from(manifest.waf.max_response_body)
                 .unwrap_or(usize::MAX),
+            audit: manifest.waf.audit,
         }))
     }
 
@@ -116,6 +146,11 @@ impl WafStage {
     /// streamed one has its body skipped.
     pub fn response_body_cap(&self) -> usize {
         self.max_response_body
+    }
+
+    /// When the stage writes a per-transaction audit record.
+    pub fn audit_engine(&self) -> AuditEngine {
+        self.audit
     }
 
     /// How many rules the stage carries.
@@ -269,6 +304,28 @@ impl WafInspection<'_> {
         self.tx.matched_ids()
     }
 
+    /// The rules that matched and would appear in the audit log, in match
+    /// order. Excludes `nolog` rules, which matched and scored but do not log.
+    pub fn audit_matches(&self) -> Vec<WafAuditMatch> {
+        self.tx
+            .matches()
+            .iter()
+            .filter(|m| m.logged)
+            .map(|m| WafAuditMatch {
+                rule_id: m.id.unwrap_or(0),
+                message: m.message.clone(),
+                data: m.data.clone(),
+                tags: m.tags.clone(),
+                matched_var: m.matched_name.clone(),
+            })
+            .collect()
+    }
+
+    /// The outbound anomaly score the response accumulated, for logging.
+    pub fn outbound_score(&self) -> i64 {
+        self.tx.anomaly_score("blocking_outbound_anomaly_score")
+    }
+
     /// The inbound anomaly score the request accumulated, for logging.
     pub fn inbound_score(&self) -> i64 {
         self.tx.anomaly_score("blocking_inbound_anomaly_score")
@@ -312,6 +369,7 @@ SecRule REMOTE_ADDR "@rx ." "id:5,phase:5,pass,nolog,msg:'phase 5 ran'"
             inbound_threshold: 5,
             outbound_threshold: 4,
             max_response_body: 1_048_576,
+            audit: AuditEngine::RelevantOnly,
         }
     }
 
@@ -406,6 +464,7 @@ SecRule REMOTE_ADDR "@rx ." "id:5,phase:5,pass,nolog,msg:'phase 5 ran'"
             inbound_threshold: 5,
             outbound_threshold: 4,
             max_response_body: 1_048_576,
+            audit: AuditEngine::RelevantOnly,
         }
     }
 
@@ -529,6 +588,62 @@ SecRule REMOTE_ADDR "@rx ." "id:5,phase:5,pass,nolog,msg:'phase 5 ran'"
         assert!(
             inspection.matched_rule_ids().contains(&5),
             "phase 5 must run when the response was not blocked"
+        );
+    }
+
+    #[test]
+    fn should_audit_follows_the_engine_policy() {
+        use AuditEngine::*;
+        // Off never logs.
+        assert!(!should_audit(Off, true, true));
+        assert!(!should_audit(Off, false, false));
+        // On always logs.
+        assert!(should_audit(On, false, false));
+        assert!(should_audit(On, true, true));
+        // RelevantOnly logs a block or a match, nothing else.
+        assert!(should_audit(RelevantOnly, true, false));
+        assert!(should_audit(RelevantOnly, false, true));
+        assert!(!should_audit(RelevantOnly, false, false));
+    }
+
+    #[test]
+    fn audit_matches_report_the_rule_that_matched() {
+        let stage = stage(EngineMode::Blocking);
+        let (_, mut inspection) = inspect(&stage, "/?q=fine");
+        let _ = inspection.inspect_response(200, &[], Some(b"this leaks a secret"));
+        let matches = inspection.audit_matches();
+        let outbound = matches.iter().find(|m| m.rule_id == 2);
+        let outbound = outbound.expect("the phase-4 rule should be in the audit matches");
+        assert_eq!(outbound.message, "outbound leak");
+    }
+
+    #[test]
+    fn audit_matches_exclude_nolog_rules() {
+        let source = r#"
+SecRule ARGS "@rx attack" "id:10,phase:2,pass,msg:'logged'"
+SecRule ARGS "@rx attack" "id:11,phase:2,pass,nolog,msg:'silent'"
+"#;
+        let directives = parapet::parse(source, "test.conf").expect("must parse");
+        let rules = RuleSet::compile(&directives, &parapet::NoDataLoader).expect("must compile");
+        let stage = WafStage {
+            rules,
+            mode: EngineMode::Blocking,
+            paranoia_level: 1,
+            inbound_threshold: 5,
+            outbound_threshold: 4,
+            max_response_body: 1_048_576,
+            audit: AuditEngine::RelevantOnly,
+        };
+        let (_, inspection) = inspect(&stage, "/?q=attack");
+        let ids: Vec<u32> = inspection
+            .audit_matches()
+            .iter()
+            .map(|m| m.rule_id)
+            .collect();
+        assert!(ids.contains(&10), "a logged rule must appear in the audit");
+        assert!(
+            !ids.contains(&11),
+            "a nolog rule must not appear in the audit"
         );
     }
 

--- a/docs/guide/waf.md
+++ b/docs/guide/waf.md
@@ -25,6 +25,7 @@ x-barbacane-waf:
     inbound: 5
     outbound: 4
   max_response_body: 1048576   # bytes; phase-4 body inspection cap (default 1 MiB)
+  audit: relevant-only         # off | relevant-only (default) | on
   unsupported_rules: fail      # fail (default) | skip
 ```
 
@@ -32,8 +33,9 @@ x-barbacane-waf:
 crosses it; `thresholds.outbound` does the same for the response, scored by
 phase 3 and 4 rules. `max_response_body` bounds phase-4 body inspection: a
 buffered response body at or under it is inspected, a larger or streamed one is
-not (see [Response-phase inspection](#response-phase-inspection)). All three are
-covered by `artifact_hash`.
+not (see [Response-phase inspection](#response-phase-inspection)). `audit`
+controls per-transaction audit logging (see [Audit logging](#audit-logging)).
+All of these are covered by `artifact_hash`.
 
 `ruleset` is resolved relative to the spec. Point it at a directory containing
 the `.conf` files and, for CRS, the setup file:
@@ -98,6 +100,29 @@ time a phase-4 rule could act on it. Each skip is counted in
 rule set that promises outbound body inspection can be checked against what the
 gateway actually inspects. A WebSocket upgrade has no response phases.
 
+## Audit logging
+
+The WAF writes one structured record per transaction on the `waf.audit` tracing
+target, carrying the request id, client address, method, path, the rules that
+matched (id, message, logdata, tags, matched variable), the inbound and outbound
+anomaly scores, the verdict, and the response status. Route that target to its
+own sink to feed a SIEM.
+
+`audit` controls when a record is written:
+
+| Value | Behaviour |
+|---|---|
+| `off` | Never. |
+| `relevant-only` (default) | Only when the transaction was blocked or matched at least one rule that logs. Near-zero volume on clean traffic; the CRS crs-setup default. |
+| `on` | Every inspected transaction. |
+
+A rule's `nolog` action keeps it out of the record, matching how it keeps a rule
+out of the ModSecurity audit log; the rule still matched and still scored. The
+number of records written is exported as `barbacane_waf_audit_total`.
+
+A transaction the WAF allowed but a later gateway check rejects (schema
+validation, payload size) before dispatch is not audited in this version.
+
 ## Current limitations
 
 Read these before enabling it in production.
@@ -126,7 +151,7 @@ thing, and it is the single most common reason a WAF gets turned off again.
 
 ## Observing it
 
-Five metrics on the admin endpoint:
+Six metrics on the admin endpoint:
 
 | Metric | Meaning |
 |---|---|
@@ -135,6 +160,7 @@ Five metrics on the admin endpoint:
 | `barbacane_waf_allowed_total{method,path}` | Requests inspected and allowed. With the above, the block rate. |
 | `barbacane_waf_duration_seconds{method,path}` | Time spent inspecting, so the WAF's share of latency is visible rather than inferred. |
 | `barbacane_waf_response_body_skipped_total{method,path}` | Responses whose body phase-4 rules did not inspect, because it was streamed or over `max_response_body`. Response headers were still inspected. |
+| `barbacane_waf_audit_total{method,path}` | Per-transaction audit records written, governed by the `audit` policy. |
 
 `barbacane_waf_matched_total` counts every rule that matched, including the
 control-flow rules CRS uses to gate paranoia levels. Those are `pass,nolog`


### PR DESCRIPTION
Implements Option A of #158. Reopens #159 as a fresh PR: #159 was auto-closed when its base branch (`feat/waf-response-phase`, #157) was deleted on merge. This branch is now rebased onto `main` with only the audit commit; the response-phase work is already merged (#157).

## What

Emits one structured record per inspected transaction on the `waf.audit` tracing target: request id, client address, method, path, the rules that matched (id, message, logdata, tags, matched variable), inbound + outbound anomaly scores, verdict, and response status. Route that target to its own sink to feed a SIEM.

## Config

`x-barbacane-waf.audit`, covered by `artifact_hash`:

| Value | Behaviour |
|---|---|
| `off` | never |
| `relevant-only` (default) | only when the transaction was blocked or matched a logged rule (near-zero volume on clean traffic; the CRS crs-setup default) |
| `on` | every inspected transaction |

`nolog` rules are excluded from the record, matching the ModSecurity audit log.

## Design

- Reads the matches parapet already captures; `WafInspection` now exposes `audit_matches()` and `outbound_score()`.
- Records are emitted at the request-phase block site and from `inspect_response_waf` (allow, response-block, and WebSocket upgrade).
- New `barbacane_waf_audit_total` metric counts records written, which is how the behaviour is asserted end to end.
- Does not implement the legacy ModSecurity multipart audit format.

## Not covered (documented)

A transaction the WAF allowed but a later gateway check rejects (schema validation, 413) before dispatch is not audited in this version.

## Relation to parapet#9

Independent. parapet#9 (phase 5 after a block) would add CRS 980xxx correlation output to blocked-transaction records once wired; natural follow-up.

## Tests

- Unit: `should_audit` policy matrix; `audit_matches` reports fields and excludes `nolog`.
- Integration: a blocked request is audited; a clean request is not (under `relevant-only`); a detected-but-not-blocked request is audited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable WAF audit logging with `off`, `relevant-only` (default), and `on` modes.
  * Added structured per-transaction audit records, including matched rules, request details, and response status.
  * Added the `barbacane_waf_audit_total` metric for tracking audit records by request method and path.
* **Documentation**
  * Documented audit configuration, structured logging output, and the new metric.
  * Clarified that audit settings are included in artifact integrity checks.
* **Tests**
  * Added coverage for blocked, clean, and relevant-but-allowed transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->