### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-09-12
+
+Headline: the WAF now inspects responses (CRS phases 3 to 5) and writes a per-transaction audit log, and request transformers can read cookies.
+
+> **Upgrade note (breaking):** **all pre-0.10 `.bca` artifacts must be recompiled.** The manifest now binds two new WAF policy fields (`max_response_body`, `audit`) into `artifact_hash`, and the data plane recomputes and verifies `artifact_hash` on load unconditionally, so an artifact built before 0.10 fails with `artifact integrity check failed`. Recompile every artifact with 0.10 (`barbacane compile`); re-sign signed artifacts (`BARBACANE_SIGNING_KEY`). The artifact format version is now **5**.
+
+### Added
+
+- **WAF**: response-phase inspection (CRS phases 3, 4 and 5). Phase 3 (response headers) runs on every path including streaming; phase 4 (response body) runs on a buffered body at or under a configurable `max_response_body` cap (default 1 MiB), while a streamed or oversized body has its headers inspected and its body skipped and counted in `barbacane_waf_response_body_skipped_total`; phase 5 (logging and correlation) runs on every transaction, including a blocked one. `thresholds.outbound` is now live (it scored nothing before, because response phases were not evaluated). A WebSocket upgrade has no response phases.
+- **WAF**: per-transaction audit logging. One structured record per inspected transaction on the `waf.audit` tracing target, carrying the request id, client address, method, path, the rules that matched (id, message, logdata, tags, matched variable), the inbound and outbound anomaly scores, the verdict, and the response status. Controlled by `x-barbacane-waf.audit`: `off`, `relevant-only` (default; only blocked or rule-matching transactions, the CRS crs-setup default), or `on`. `nolog` rules are excluded, as in the ModSecurity audit log. Records written are counted by `barbacane_waf_audit_total`.
+- **plugins/request-transformer**: variables can read request cookies with `$cookie.<name>` (RFC 6265, case-sensitive names, quoted values unwrapped), and `$`-variables now interpolate when embedded in a larger string rather than only as a whole value.
+
+### Changed
+
+- **WAF**: the engine ([`barbacane-waf`](https://crates.io/crates/barbacane-waf)) is now a crates.io dependency (0.1.1) rather than a git pin.
+- **CI**: the pipeline is faster: coverage moved off the per-PR path (full coverage runs on `main` and nightly), and integration tests are sharded. Unit-test coverage was also raised (validator ~96%, `waf.rs` ~88.5%).
+
+### Fixed
+
+- **WAF**: the HTTP/2 `:authority` pseudo-header is exposed as a `Host` header, so CRS Host rules (for example 920280, missing Host) evaluate correctly on HTTP/2 requests instead of always seeing an absent Host.
+
 ## [0.9.0] - 2026-09-11
 
 Headline: the WAF's libinjection classifiers are live, so OWASP CRS SQL injection and XSS rules are enforced end to end.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "arc-swap",
  "barbacane-compiler",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-compiler"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "barbacane-waf",
  "chrono",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-control"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-macros"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-plugin-sdk"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "barbacane-plugin-macros",
  "base64",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-sigv4"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "hex",
  "hmac",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-telemetry"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-test"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "barbacane-compiler",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "barbacane-wasm"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,10 +100,10 @@ parking_lot = "0.12"
 # JSON Schema validation
 jsonschema = "0.26"
 
-# WASM runtime
-# SecLang/CRS engine. Pinned by revision while its API settles; moves to a
-# crates.io version when it stabilises (ADR-0031).
+# SecLang/CRS engine (ADR-0031), published as `barbacane-waf`.
 parapet = { package = "barbacane-waf", version = "0.1.1", features = ["serde"] }
+
+# WASM runtime
 wasmtime = { version = "47", features = ["cranelift", "pooling-allocator"] }
 wasmtime-wasi = { version = "47" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 # Minimum supported Rust version, set by the dependency floor: wasmtime 47
 # requires rustc 1.94. Enforced by the `msrv` CI job.
@@ -158,15 +158,15 @@ assert_cmd = "2"
 predicates = "3"
 
 # Workspace crates (version required for crates.io publishing)
-barbacane-sigv4 = { path = "crates/barbacane-sigv4", version = "0.9.0" }
-barbacane-compiler = { path = "crates/barbacane-compiler", version = "0.9.0" }
-barbacane-plugin-sdk = { path = "crates/barbacane-plugin-sdk", version = "0.9.0" }
-barbacane-plugin-macros = { path = "crates/barbacane-plugin-macros", version = "0.9.0" }
-barbacane-wasm = { path = "crates/barbacane-wasm", version = "0.9.0" }
-barbacane-telemetry = { path = "crates/barbacane-telemetry", version = "0.9.0" }
-barbacane-test = { path = "crates/barbacane-test", version = "0.9.0" }
-barbacane = { path = "crates/barbacane", version = "0.9.0" }
-barbacane-control = { path = "crates/barbacane-control", version = "0.9.0" }
+barbacane-sigv4 = { path = "crates/barbacane-sigv4", version = "0.10.0" }
+barbacane-compiler = { path = "crates/barbacane-compiler", version = "0.10.0" }
+barbacane-plugin-sdk = { path = "crates/barbacane-plugin-sdk", version = "0.10.0" }
+barbacane-plugin-macros = { path = "crates/barbacane-plugin-macros", version = "0.10.0" }
+barbacane-wasm = { path = "crates/barbacane-wasm", version = "0.10.0" }
+barbacane-telemetry = { path = "crates/barbacane-telemetry", version = "0.10.0" }
+barbacane-test = { path = "crates/barbacane-test", version = "0.10.0" }
+barbacane = { path = "crates/barbacane", version = "0.10.0" }
+barbacane-control = { path = "crates/barbacane-control", version = "0.10.0" }
 
 [profile.dev]
 opt-level = 0

--- a/crates/barbacane-compiler/src/artifact.rs
+++ b/crates/barbacane-compiler/src/artifact.rs
@@ -21,11 +21,14 @@ use crate::manifest::ProjectManifest;
 
 /// Current artifact format version.
 ///
-/// v4 adds Ed25519 signing fields and records each plugin's declared capability
-/// `host_functions` in the manifest. Whether those capabilities are enforced on
-/// load is gated by the manifest `capabilities_enforced` flag (WA-1), not by the
-/// version, so older artifacts and capability-less builds load without rejection.
-pub const ARTIFACT_VERSION: u32 = 4;
+/// v5 binds two WAF policy fields into the manifest and `artifact_hash`:
+/// `max_response_body` (the phase-4 body inspection cap) and `audit` (the audit
+/// engine policy). Because the data plane recomputes and verifies `artifact_hash`
+/// on load, a pre-v5 artifact fails the integrity check and must be recompiled.
+///
+/// v4 added Ed25519 signing fields and recorded each plugin's declared
+/// capability `host_functions` in the manifest.
+pub const ARTIFACT_VERSION: u32 = 5;
 
 /// Options for compilation.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Release 0.10.0.

## Version + format
- Workspace version 0.9.0 → 0.10.0 (workspace.package + internal dep pins).
- Artifact format version 4 → 5: the manifest now binds `max_response_body` and `audit` into `artifact_hash`.

## Breaking upgrade note
All pre-0.10 `.bca` artifacts must be recompiled. The data plane recomputes and verifies `artifact_hash` on load, so an artifact built before 0.10 fails with `artifact integrity check failed`. Recompile with `barbacane compile`; re-sign signed artifacts.

## Changelog (0.10.0)
- **Added**: WAF response-phase inspection (CRS phases 3-5, configurable `max_response_body` cap, skip metric, live `thresholds.outbound`); WAF per-transaction audit logging (`audit: off|relevant-only|on`, `waf.audit` target, `nolog`-aware, `barbacane_waf_audit_total`); request-transformer `$cookie.<name>` + embedded interpolation.
- **Changed**: WAF engine now a crates.io dep (`barbacane-waf` 0.1.1); faster/sharded CI and higher unit-test coverage.
- **Fixed**: HTTP/2 `:authority` exposed as `Host` so CRS Host rules evaluate on h2.

## After merge
Tag `v0.10.0` → the release workflow validates the tag/version/changelog match, builds binaries, publishes the crates (parapet is now a crates.io dep, so the gateway crates publish cleanly), and cuts the GitHub release.

Also fixes the stale "pinned by revision" comment on the parapet dependency.